### PR TITLE
fixed docker db init script path

### DIFF
--- a/etc/docker/build_sql_patches.sh
+++ b/etc/docker/build_sql_patches.sh
@@ -3,8 +3,8 @@
 function init_database() {
     SQL_DUMP='CREATE DATABASE `alpha_'${1}'` /*!40100 COLLATE utf8mb4_general_ci */;'$'\n'
     SQL_DUMP=${SQL_DUMP}'USE `alpha_'${1}'`;'$'\n'
-    SQL_DUMP=${SQL_DUMP}$(cat ../databases/${1}/${1}.sql)$'\n'
-    SQL_DUMP=${SQL_DUMP}$(cat ../databases/${1}/updates/*.sql)
+    SQL_DUMP=${SQL_DUMP}$(cat /etc/databases/${1}/${1}.sql)$'\n'
+    SQL_DUMP=${SQL_DUMP}$(cat /etc/databases/${1}/updates/*.sql)
 
     echo "${SQL_DUMP}" | docker_process_sql
 }


### PR DESCRIPTION
the script that initializes the docker sql DB doesn't work anymore. This path fix repairs it.