### PR TITLE
Added vscode and venv folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 **.pyc
+
+# IDE configuration files
 .idea
+.vscode/
+
 etc/config/config.yml
+
+# virtualenv folder
+venv/


### PR DESCRIPTION
These folders are required to be in **gitignore** file for developers that are using VS Code as IDE and Virtualenv.