### PR TITLE
Error AuthCodes should now properly display on the client.

### DIFF
--- a/game/world/WorldManager.py
+++ b/game/world/WorldManager.py
@@ -14,7 +14,7 @@ from network.packet.PacketWriter import *
 from network.packet.PacketReader import *
 from database.world.WorldDatabaseManager import *
 from utils.Logger import Logger
-
+from utils.constants.AuthCodes import AuthCode
 
 STARTUP_TIME = time()
 WORLD_ON = True
@@ -45,8 +45,6 @@ class WorldServerSessionHandler(object):
             self.account_mgr = None
             self.keep_alive = True
 
-            self.auth_challenge(self.request)
-
             incoming_thread = threading.Thread(target=self.process_incoming)
             incoming_thread.daemon = True
             incoming_thread.start()
@@ -55,8 +53,9 @@ class WorldServerSessionHandler(object):
             outgoing_thread.daemon = True
             outgoing_thread.start()
 
-            while self.receive(self.request) != -1 and self.keep_alive:
-                continue
+            if self.auth_challenge(self.request):
+                while self.receive(self.request) != -1 and self.keep_alive:
+                    continue
 
         finally:
             self.disconnect()
@@ -97,13 +96,17 @@ class WorldServerSessionHandler(object):
                 self.disconnect()
 
     def disconnect(self):
+        # Avoid multiple calls.
+        if not self.keep_alive:
+            return
+        self.keep_alive = False
+
         try:
             if self.player_mgr:
                 self.player_mgr.logout()
         except AttributeError:
             pass
 
-        self.keep_alive = False
         self.incoming_pending.empty()
         self.outgoing_pending.empty()
         WorldSessionStateHandler.remove(self)
@@ -114,18 +117,40 @@ class WorldServerSessionHandler(object):
         except OSError:
             pass
 
+    #  We handle auth_challenge before launching queue threads and anything else.
     def auth_challenge(self, sck):
         data = pack('<6B', 0, 0, 0, 0, 0, 0)
-        sck.sendall(PacketWriter.get_packet(OpCode.SMSG_AUTH_CHALLENGE, data))
+        try:
+            sck.settimeout(3)  #  Set a 3 second timeout.
+            sck.sendall(PacketWriter.get_packet(OpCode.SMSG_AUTH_CHALLENGE, data))  # Request challenge
+            reader = self.receive_client_message(sck)
+            if reader and reader.opcode == OpCode.CMSG_AUTH_SESSION:
+                handler, found = Definitions.get_handler_from_packet(self, reader.opcode)
+                if handler:
+                    res = handler(self, sck, reader)
+                    if res == 0:
+                        return True
+            return False
+        except socket.timeout: #  Cant check this inside Auth handler.
+            data = pack('<B', AuthCode.AUTH_SESSION_EXPIRED)
+            sck.request.sendall(PacketWriter.get_packet(OpCode.SMSG_AUTH_RESPONSE, data))
+            return False
+        finally:
+            sck.settimeout(None)
 
     def receive(self, sck):
         try:
+            sck.settimeout(120)  # Need to make sure we don't hang in here forever.
             reader = self.receive_client_message(sck)
+            sck.settimeout(None)
             if reader:
                 self.incoming_pending.put(reader)
             else:
                 return -1
             return 0
+        except socket.timeout:
+            self.disconnect()
+            return -1
         except OSError:
             self.disconnect()
             return -1

--- a/game/world/WorldManager.py
+++ b/game/world/WorldManager.py
@@ -45,15 +45,15 @@ class WorldServerSessionHandler(object):
             self.account_mgr = None
             self.keep_alive = True
 
-            incoming_thread = threading.Thread(target=self.process_incoming)
-            incoming_thread.daemon = True
-            incoming_thread.start()
+            if self.auth_challenge(self.request)
+                incoming_thread = threading.Thread(target=self.process_incoming)
+                incoming_thread.daemon = True
+                incoming_thread.start()
 
-            outgoing_thread = threading.Thread(target=self.process_outgoing)
-            outgoing_thread.daemon = True
-            outgoing_thread.start()
+                outgoing_thread = threading.Thread(target=self.process_outgoing)
+                outgoing_thread.daemon = True
+                outgoing_thread.start()
 
-            if self.auth_challenge(self.request):
                 while self.receive(self.request) != -1 and self.keep_alive:
                     continue
 

--- a/game/world/WorldManager.py
+++ b/game/world/WorldManager.py
@@ -45,7 +45,7 @@ class WorldServerSessionHandler(object):
             self.account_mgr = None
             self.keep_alive = True
 
-            if self.auth_challenge(self.request)
+            if self.auth_challenge(self.request):
                 incoming_thread = threading.Thread(target=self.process_incoming)
                 incoming_thread.daemon = True
                 incoming_thread.start()

--- a/game/world/opcode_handling/handlers/interface/AuthSessionHandler.py
+++ b/game/world/opcode_handling/handlers/interface/AuthSessionHandler.py
@@ -49,6 +49,7 @@ class AuthSessionHandler(object):
         WorldSessionStateHandler.add(world_session)
 
         data = pack('<B', auth_code)
-        world_session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_AUTH_RESPONSE, data))
+        # We directly send this through the socket, skipping queue model.
+        world_session.request.sendall(PacketWriter.get_packet(OpCode.SMSG_AUTH_RESPONSE, data))
 
         return 0 if auth_code == AuthCode.AUTH_OK else -1


### PR DESCRIPTION
/ Handle Auth challenge before launching any threads or queues.
/ Set a 120 second timeout to world socket,.
/ Avoid multiple calls over socket.shutdown() and socket.close()