### PR TITLE
Guild persistence and other changes.

### DIFF
--- a/database/realm/RealmDatabaseManager.py
+++ b/database/realm/RealmDatabaseManager.py
@@ -289,6 +289,16 @@ class RealmDatabaseManager(object):
             realm_db_session.flush()
             realm_db_session.close()
 
+    @staticmethod
+    def character_get_guild(character):
+        realm_db_session = SessionHolder()
+        guild_member = realm_db_session.query(GuildMember).filter_by(guid=character.guid & ~HighGuid.HIGHGUID_PLAYER).first()
+        guild = None
+        if guild_member:
+            guild = guild_member.guild
+        realm_db_session.close()
+        return guild
+
     # Ticket stuff
 
     @staticmethod
@@ -377,16 +387,6 @@ class RealmDatabaseManager(object):
         realm_db_session.refresh(guild_member)
         realm_db_session.close()
         return guild_member
-
-    @staticmethod
-    def character_get_guild(character):
-        realm_db_session = SessionHolder()
-        guild_member = realm_db_session.query(GuildMember).filter_by(guid=character.guid & ~HighGuid.HIGHGUID_PLAYER).first()
-        guild = None
-        if guild_member:
-            guild = guild_member.guild
-        realm_db_session.close()
-        return guild
 
     @staticmethod
     def guild_get_members(guild):

--- a/database/realm/RealmDatabaseManager.py
+++ b/database/realm/RealmDatabaseManager.py
@@ -357,3 +357,85 @@ class RealmDatabaseManager(object):
             realm_db_session.close()
             return 0
         return -1
+
+    # Guild
+
+    @staticmethod
+    def guild_create(guild):
+        realm_db_session = SessionHolder()
+        realm_db_session.add(guild)
+        realm_db_session.flush()
+        realm_db_session.refresh(guild)
+        realm_db_session.close()
+        return guild
+
+    @staticmethod
+    def guild_create_player(guild_member):
+        realm_db_session = SessionHolder()
+        realm_db_session.add(guild_member)
+        realm_db_session.flush()
+        realm_db_session.refresh(guild_member)
+        realm_db_session.close()
+        return guild_member
+
+    @staticmethod
+    def character_get_guild(character):
+        realm_db_session = SessionHolder()
+        guild_member = realm_db_session.query(GuildMember).filter_by(guid=character.guid & ~HighGuid.HIGHGUID_PLAYER).first()
+        guild = None
+        if guild_member:
+            guild = guild_member.guild
+        realm_db_session.close()
+        return guild
+
+    @staticmethod
+    def guild_get_members(guild):
+        realm_db_session = SessionHolder()
+        guild_members = realm_db_session.query(GuildMember).filter_by(guild_id=guild.guild_id).all()
+        realm_db_session.close()
+        return guild_members
+
+    @staticmethod
+    def guild_get_all():
+        realm_db_session = SessionHolder()
+        guilds = realm_db_session.query(Guild).all()
+        realm_db_session.close()
+        return guilds
+
+    @staticmethod
+    def guild_get_accounts(guild_id):
+        realm_db_session = SessionHolder()
+        guild_members = realm_db_session.query(GuildMember).filter_by(guild_id=guild_id).all()
+        accounts = []
+        if guild_members:
+            accounts = list(set([member.character.account_id for member in guild_members])) # Distinct
+        realm_db_session.close()
+        return accounts
+
+    @staticmethod
+    def guild_update(guild):
+        realm_db_session = SessionHolder()
+        realm_db_session.merge(guild)
+        realm_db_session.flush()
+        realm_db_session.close()
+
+    @staticmethod
+    def guild_update_player(guild_member):
+        realm_db_session = SessionHolder()
+        realm_db_session.merge(guild_member)
+        realm_db_session.flush()
+        realm_db_session.close()
+
+    @staticmethod
+    def guild_destroy(guild):
+        realm_db_session = SessionHolder()
+        realm_db_session.delete(guild)
+        realm_db_session.flush()
+        realm_db_session.close()
+
+    @staticmethod
+    def guild_remove_player(guid_member):
+        realm_db_session = SessionHolder()
+        realm_db_session.delete(guid_member)
+        realm_db_session.flush()
+        realm_db_session.close()

--- a/database/realm/RealmModels.py
+++ b/database/realm/RealmModels.py
@@ -4,7 +4,6 @@ from sqlalchemy.dialects.mysql import BIGINT, INTEGER, LONGTEXT, MEDIUMINT, SMAL
 from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
 
-
 Base = declarative_base()
 metadata = Base.metadata
 
@@ -189,7 +188,6 @@ class Guild(Base):
 
     guild_id = Column(INTEGER(11), autoincrement=True, primary_key=True, server_default=text("0"))
     name = Column(String(255), nullable=False, server_default=text("''"))
-    leader_guid = Column(ForeignKey('characters.guid', ondelete='CASCADE', onupdate='CASCADE'), nullable=False, index=True, server_default=text("0"))
     motd = Column(String(255), nullable=False, server_default=text("''"))
     creation_date = Column(TIMESTAMP, nullable=False, server_default=text("current_timestamp()"))
     emblem_style = Column(INTEGER(5), nullable=False, server_default=text("-1"))
@@ -198,15 +196,15 @@ class Guild(Base):
     border_color = Column(INTEGER(5), nullable=False, server_default=text("-1"))
     background_color = Column(INTEGER(5), nullable=False, server_default=text("-1"))
 
-    leader = relationship('Character')
-
+    guild_master = relationship('GuildMember', lazy='subquery', uselist=False, primaryjoin='and_(Guild.guild_id==GuildMember.guild_id, GuildMember.rank==0)', viewonly=True)
 
 class GuildMember(Base):
     __tablename__ = 'guild_member'
 
     guild_id = Column(ForeignKey('guild.guild_id', ondelete='CASCADE', onupdate='CASCADE'), primary_key=True, nullable=False, server_default=text("0"))
-    guid = Column(ForeignKey('characters.guid', ondelete='CASCADE', onupdate='CASCADE'), primary_key=True, nullable=False, index=True, server_default=text("0"))
+    guid = Column(ForeignKey('characters.guid',  ondelete='CASCADE', onupdate='CASCADE'), primary_key=True, nullable=False, index=True, server_default=text("0"))
     rank = Column(TINYINT(2), nullable=False, server_default=text("0"))
 
-    character = relationship('Character')
-    guild = relationship('Guild')
+    # Need subquery attribute, else we get '<GuildMember> is not bound to a Session' exceptions when accessing ref.
+    character = relationship('Character', lazy='subquery')
+    guild = relationship('Guild', lazy='subquery')

--- a/database/realm/RealmModels.py
+++ b/database/realm/RealmModels.py
@@ -196,7 +196,6 @@ class Guild(Base):
     border_color = Column(INTEGER(5), nullable=False, server_default=text("-1"))
     background_color = Column(INTEGER(5), nullable=False, server_default=text("-1"))
 
-    guild_master = relationship('GuildMember', lazy='subquery', uselist=False, primaryjoin='and_(Guild.guild_id==GuildMember.guild_id, GuildMember.rank==0)', viewonly=True)
 
 class GuildMember(Base):
     __tablename__ = 'guild_member'
@@ -205,6 +204,5 @@ class GuildMember(Base):
     guid = Column(ForeignKey('characters.guid', ondelete='CASCADE', onupdate='CASCADE'), primary_key=True, nullable=False, index=True, server_default=text("0"))
     rank = Column(TINYINT(2), nullable=False, server_default=text("0"))
 
-    # Need subquery attribute, else we get '<GuildMember> is not bound to a Session' exceptions when accessing ref.
-    character = relationship('Character', lazy='subquery')
-    guild = relationship('Guild', lazy='subquery')
+    character = relationship('Character', lazy='joined')
+    guild = relationship('Guild', lazy='joined')

--- a/database/realm/RealmModels.py
+++ b/database/realm/RealmModels.py
@@ -202,7 +202,7 @@ class GuildMember(Base):
     __tablename__ = 'guild_member'
 
     guild_id = Column(ForeignKey('guild.guild_id', ondelete='CASCADE', onupdate='CASCADE'), primary_key=True, nullable=False, server_default=text("0"))
-    guid = Column(ForeignKey('characters.guid',  ondelete='CASCADE', onupdate='CASCADE'), primary_key=True, nullable=False, index=True, server_default=text("0"))
+    guid = Column(ForeignKey('characters.guid', ondelete='CASCADE', onupdate='CASCADE'), primary_key=True, nullable=False, index=True, server_default=text("0"))
     rank = Column(TINYINT(2), nullable=False, server_default=text("0"))
 
     # Need subquery attribute, else we get '<GuildMember> is not bound to a Session' exceptions when accessing ref.

--- a/etc/databases/realm/updates/updates.sql
+++ b/etc/databases/realm/updates/updates.sql
@@ -107,5 +107,13 @@ begin not atomic
 
         insert into applied_updates values ('270420211');
     end if;
+	
+	-- 30/04/2021 1
+	if (select count(*) from applied_updates where id='300420211') = 0 then
+		ALTER TABLE guild DROP FOREIGN KEY leader_guid_fk;
+		ALTER TABLE guild DROP COLUMN leader_guid;
+		insert into applied_updates values ('300420211');
+	end if;
+	
 end $
 delimiter ;

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -1,7 +1,9 @@
 from database.dbc.DbcDatabaseManager import DbcDatabaseManager
+from database.realm.RealmDatabaseManager import RealmDatabaseManager
 from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.managers.objects.creature.CreatureManager import CreatureManager
 from game.world.managers.objects.GameObjectManager import GameObjectManager
+from game.world.managers.objects.player.guild.GuildManager import GuildManager
 from utils.ConfigManager import config
 from utils.Logger import Logger
 
@@ -30,6 +32,7 @@ class WorldLoader:
         WorldLoader.load_skill_line_abilities()
         WorldLoader.load_taxi_nodes()
         WorldLoader.load_taxi_path_nodes()
+        WorldLoader.load_guilds()
 
     @staticmethod
     def load_gameobjects():
@@ -109,6 +112,19 @@ class WorldLoader:
             Logger.progress('Loading quest templates...', count, length)
 
         return length
+
+    @staticmethod
+    def load_guilds():
+        guilds = RealmDatabaseManager.guild_get_all()
+        length = len(guilds)
+        count = 0
+
+        for guild in guilds:
+            if guild.name not in GuildManager.GUILDS:
+                GuildManager.GUILDS[guild.name] = GuildManager(guild)
+                GuildManager.GUILDS[guild.name].load_guild_members()
+                count += 1
+                Logger.progress('Loading guilds...', count, length)
 
     @staticmethod
     def load_spells():

--- a/game/world/managers/objects/player/ChatManager.py
+++ b/game/world/managers/objects/player/ChatManager.py
@@ -63,7 +63,7 @@ class ChatManager(object):
             if chat_type == ChatMsgs.CHAT_MSG_GUILD:
                 sender.guild_manager.send_message_to_guild(sender_packet, GuildChatMessageTypes.G_MSGTYPE_ALL, source=sender)
             else:
-                if sender.guild_manager.get_guild_rank(sender) > GuildRank.GUILDRANK_OFFICER:
+                if sender.guild_manager.get_rank(sender.guid) > GuildRank.GUILDRANK_OFFICER:
                     GuildManager.send_guild_command_result(sender, GuildTypeCommand.GUILD_CREATE_S, '',
                                                            GuildCommandResults.GUILD_PERMISSIONS)
                 else:

--- a/game/world/managers/objects/player/GroupManager.py
+++ b/game/world/managers/objects/player/GroupManager.py
@@ -158,7 +158,7 @@ class GroupManager(object):
         name_bytes = PacketWriter.string_to_bytes(target_player_mgr.player.name)
         data = pack(
             f'<{len(name_bytes)}s',
-            name_bytes,
+            name_bytes
         )
 
         packet = PacketWriter.get_packet(OpCode.SMSG_GROUP_SET_LEADER, data)
@@ -290,7 +290,7 @@ class GroupManager(object):
         name_bytes = PacketWriter.string_to_bytes(player_name)
         data = pack(
             f'<{len(name_bytes)}s',
-            name_bytes,
+            name_bytes
         )
 
         packet = PacketWriter.get_packet(OpCode.SMSG_GROUP_DECLINE, data)
@@ -352,7 +352,7 @@ class GroupManager(object):
         name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
         data = pack(
             f'<{len(name_bytes)}s',
-            name_bytes,
+            name_bytes
         )
 
         packet = PacketWriter.get_packet(OpCode.SMSG_GROUP_INVITE, data)
@@ -367,7 +367,7 @@ class GroupManager(object):
             f'<I{len(name_bytes)}sI',
             group_operation,
             name_bytes,
-            result,
+            result
         )
 
         packet = PacketWriter.get_packet(OpCode.SMSG_PARTY_COMMAND_RESULT, data)

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -1,6 +1,7 @@
 import time
 from struct import unpack
 
+from game.world.WorldSessionStateHandler import WorldSessionStateHandler
 from game.world.managers.GridManager import GridManager
 from game.world.managers.abstractions.Vector import Vector
 from game.world.managers.objects.UnitManager import UnitManager
@@ -223,13 +224,6 @@ class PlayerManager(UnitManager):
         if self.group_manager:
             self.group_manager.leave_party(self, force_disband=self.group_manager.party_leader == self)
 
-        # TODO: Temp hackfix until guilds are saved in db
-        if self.guild_manager:
-            if self.guild_manager.guild_master == self:
-                self.guild_manager.disband()
-            else:
-                self.guild_manager.leave(self)
-
         if self.duel_manager:
             self.duel_manager.force_duel_end(self)
 
@@ -242,6 +236,7 @@ class PlayerManager(UnitManager):
         GridManager.remove_object(self)
         self.session.player_mgr = None
         self.session = None
+        WorldSessionStateHandler.pop_active_player(self)
 
     def get_tutorial_packet(self):
         return PacketWriter.get_packet(OpCode.SMSG_TUTORIAL_FLAGS, pack('<18I', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -218,6 +218,8 @@ class PlayerManager(UnitManager):
         GridManager.update_object(self)
         ChannelManager.join_default_channels(self)  # Once in-world
         self.friends_manager.send_online_notification()  # Notify our friends
+        if self.guild_manager:
+            self.guild_manager.send_online_notification(self)
 
     def logout(self):
         # TODO: Temp hackfix until groups are saved in db
@@ -232,6 +234,8 @@ class PlayerManager(UnitManager):
 
         self.online = False
         self.friends_manager.send_offline_notification()
+        if self.guild_manager:
+            self.guild_manager.send_offline_notification(self)
         self.session.save_character()
         GridManager.remove_object(self)
         self.session.player_mgr = None

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -219,7 +219,7 @@ class PlayerManager(UnitManager):
         ChannelManager.join_default_channels(self)  # Once in-world
         self.friends_manager.send_online_notification()  # Notify our friends
         if self.guild_manager:
-            self.guild_manager.send_online_notification(self)
+            self.guild_manager.send_motd(player_mgr=self)
 
     def logout(self):
         # TODO: Temp hackfix until groups are saved in db
@@ -234,8 +234,6 @@ class PlayerManager(UnitManager):
 
         self.online = False
         self.friends_manager.send_offline_notification()
-        if self.guild_manager:
-            self.guild_manager.send_offline_notification(self)
         self.session.save_character()
         GridManager.remove_object(self)
         self.session.player_mgr = None

--- a/game/world/managers/objects/player/guild/GuildManager.py
+++ b/game/world/managers/objects/player/guild/GuildManager.py
@@ -38,13 +38,13 @@ class GuildManager(object):
             name_bytes = PacketWriter.string_to_bytes(previous_gm.character.name)
             data += pack(
                 f'<{len(name_bytes)}s',
-                name_bytes,
+                name_bytes
             )
 
             name_bytes = PacketWriter.string_to_bytes(member.character.name)
             data += pack(
                 f'<{len(name_bytes)}s',
-                name_bytes,
+                name_bytes
             )
 
             packet = PacketWriter.get_packet(OpCode.SMSG_GUILD_EVENT, data)
@@ -101,7 +101,7 @@ class GuildManager(object):
         name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
         data += pack(
             f'<{len(name_bytes)}s',
-            name_bytes,
+            name_bytes
         )
 
         self.build_update(player_mgr)
@@ -118,13 +118,13 @@ class GuildManager(object):
         target_name_bytes = PacketWriter.string_to_bytes(member.character.name)
         data += pack(
             f'<{len(target_name_bytes)}s',
-            target_name_bytes,
+            target_name_bytes
         )
 
         remover_name_bytes = PacketWriter.string_to_bytes(guild_master.character.name)
         data += pack(
             f'<{len(remover_name_bytes)}s',
-            remover_name_bytes,
+            remover_name_bytes
         )
 
         packet = PacketWriter.get_packet(OpCode.SMSG_GUILD_EVENT, data)
@@ -146,7 +146,7 @@ class GuildManager(object):
         leaver_name_bytes = PacketWriter.string_to_bytes(member.character.name)
         data += pack(
             f'<{len(leaver_name_bytes)}s',
-            leaver_name_bytes,
+            leaver_name_bytes
         )
 
         packet = PacketWriter.get_packet(OpCode.SMSG_GUILD_EVENT, data)
@@ -166,7 +166,7 @@ class GuildManager(object):
         leaver_name_bytes = PacketWriter.string_to_bytes(guild_master.character.name)
         data += pack(
             f'<{len(leaver_name_bytes)}s',
-            leaver_name_bytes,
+            leaver_name_bytes
         )
 
         packet = PacketWriter.get_packet(OpCode.SMSG_GUILD_EVENT, data)
@@ -219,14 +219,14 @@ class GuildManager(object):
         target_name_bytes = PacketWriter.string_to_bytes(member.character.name)
         data += pack(
             f'<{len(target_name_bytes)}s',
-            target_name_bytes,
+            target_name_bytes
         )
 
         rank_name = GuildRank(member.rank).name.split('_')[1].capitalize()
         rank_name_bytes = PacketWriter.string_to_bytes(rank_name)
         data += pack(
             f'<{len(rank_name_bytes)}s',
-            rank_name_bytes,
+            rank_name_bytes
         )
 
         packet = PacketWriter.get_packet(OpCode.SMSG_GUILD_EVENT, data)
@@ -254,14 +254,14 @@ class GuildManager(object):
         target_name_bytes = PacketWriter.string_to_bytes(member.character.name)
         data += pack(
             f'<{len(target_name_bytes)}s',
-            target_name_bytes,
+            target_name_bytes
         )
 
         rank_name = GuildRank(member.rank).name.split('_')[1].capitalize()
         rank_name_bytes = PacketWriter.string_to_bytes(rank_name)
         data += pack(
             f'<{len(rank_name_bytes)}s',
-            rank_name_bytes,
+            rank_name_bytes
         )
 
         packet = PacketWriter.get_packet(OpCode.SMSG_GUILD_EVENT, data)

--- a/game/world/managers/objects/player/guild/GuildManager.py
+++ b/game/world/managers/objects/player/guild/GuildManager.py
@@ -1,42 +1,47 @@
 from struct import pack
+from datetime import datetime
+
+from database.realm.RealmDatabaseManager import RealmDatabaseManager, Guild, GuildMember
+from game.world.WorldSessionStateHandler import WorldSessionStateHandler
 from network.packet.PacketWriter import PacketWriter, OpCode
-from utils.constants.ObjectCodes import GuildRank, GuildCommandResults, GuildTypeCommand, GuildEvents, GuildChatMessageTypes
+from utils.constants.ObjectCodes import GuildRank, GuildCommandResults, GuildTypeCommand, GuildEvents, \
+    GuildChatMessageTypes
 from game.world.managers.objects.player.guild.GuildPendingInvite import GuildPendingInvite
 from utils.TextUtils import TextChecker
 from utils.constants.UpdateFields import PlayerFields
 
 
 class GuildManager(object):
-    GUILD_COUNT = 0  # TODO, generate/recycle guild IDs when we have db persistence
-    GUILDS = {}
+    GUILDS = {}  # Check for name duplicity upon creation.
     PENDING_INVITES = {}
 
-    def __init__(self, guild_name):
-        GuildManager.GUILD_COUNT += 1
-        self.guild_id = GuildManager.GUILD_COUNT  # int32
-        self.guild_name = guild_name
+    def __init__(self, guild):
+        self.guild = guild
         self.members = {}
-        self.ranks = {}
-        self.guild_master = None
-        self.created_at = 0  # Date
-        self.motd = ''
-        GuildManager.GUILDS[self.guild_id] = self
+        GuildManager.GUILDS[self.guild.name] = self
 
-    def set_guild_master(self, player_mgr):
-        previous_gm = self.guild_master
-        self.guild_master = player_mgr
-        self.ranks[player_mgr.guid] = GuildRank.GUILDRANK_GUILD_MASTER
+    def load_guild_members(self):
+        members = RealmDatabaseManager.guild_get_members(self.guild)
+
+        for member in members:
+            self.members[member.guid] = member
+
+    def set_guild_master(self, player_guid):
+        member = self.members[player_guid].character
+        previous_gm = self.guild.guild_master
+
+        member.rank = int(GuildRank.GUILDRANK_GUILD_MASTER)
+        previous_gm.rank = int(GuildRank.GUILDRANK_OFFICER)
 
         if previous_gm:
-            self.ranks[previous_gm.guid] = GuildRank.GUILDRANK_OFFICER
             data = pack('<2B', GuildEvents.GUILD_EVENT_LEADER_CHANGED, 2)
-            name_bytes = PacketWriter.string_to_bytes(previous_gm.player.name)
+            name_bytes = PacketWriter.string_to_bytes(previous_gm.character.name)
             data += pack(
                 f'<{len(name_bytes)}s',
                 name_bytes,
             )
 
-            name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
+            name_bytes = PacketWriter.string_to_bytes(member.character.name)
             data += pack(
                 f'<{len(name_bytes)}s',
                 name_bytes,
@@ -45,16 +50,30 @@ class GuildManager(object):
             packet = PacketWriter.get_packet(OpCode.SMSG_GUILD_EVENT, data)
             self.send_message_to_guild(packet, GuildChatMessageTypes.G_MSGTYPE_ALL)
 
-        player_mgr.set_uint32(PlayerFields.PLAYER_GUILDRANK, self.get_guild_rank(player_mgr))
-        player_mgr.set_dirty()
+        self.update_db_guild_members(member_only=member)
+        player_mgr = WorldSessionStateHandler.find_player_by_guid(player_guid)
+        if player_mgr:
+            player_mgr.set_uint32(PlayerFields.PLAYER_GUILDRANK, member.rank)
+            player_mgr.set_dirty()
+
+    def update_db_guild_members(self, member_only=None):
+        if member_only:
+            RealmDatabaseManager.guild_update_player(member_only)
+        else:
+            for member in self.members.values():
+                RealmDatabaseManager.guild_update_player(member)
+
+    def update_db_guild(self):
+        RealmDatabaseManager.guild_update(self.guild)
 
     def set_motd(self, motd):
-        self.motd = motd
+        self.guild.motd = motd;
+        self.update_db_guild()
         self.send_motd()
 
     def send_motd(self):
         data = pack('<2B', GuildEvents.GUILD_EVENT_MOTD, 1)
-        motd_bytes = PacketWriter.string_to_bytes(self.motd)
+        motd_bytes = PacketWriter.string_to_bytes(self.guild.motd)
         data += pack(
             f'<{len(motd_bytes)}s',
             motd_bytes,
@@ -63,16 +82,20 @@ class GuildManager(object):
         packet = PacketWriter.get_packet(OpCode.SMSG_GUILD_EVENT, data)
         self.send_message_to_guild(packet, GuildChatMessageTypes.G_MSGTYPE_ALL)
 
-    def is_member(self, player_mgr):
-        return player_mgr.guid in self.members
+    def _create_new_member(self, player_guid, rank):
+        member = GuildMember()
+        member.guild_id = self.guild.guild_id
+        member.rank = int(rank)
+        member.guid = player_guid
+        RealmDatabaseManager.guild_create_player(member)
+        return member
 
     def add_new_member(self, player_mgr, is_guild_master=False):
-        self.members[player_mgr.guid] = player_mgr
+        rank = GuildRank.GUILDRANK_GUILD_MASTER if is_guild_master else GuildRank.GUILDRANK_INITIATE
+        guild_member = self._create_new_member(player_mgr.guid, rank)
+
         player_mgr.guild_manager = self
-        if is_guild_master:
-            self.set_guild_master(player_mgr)
-        else:
-            self.ranks[player_mgr.guid] = GuildRank.GUILDRANK_INITIATE
+        self.members[player_mgr.guid] = guild_member
 
         data = pack('<2B', GuildEvents.GUILD_EVENT_JOINED, 1)
         name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
@@ -81,21 +104,24 @@ class GuildManager(object):
             name_bytes,
         )
 
-        packet = PacketWriter.get_packet(OpCode.SMSG_GUILD_EVENT, data)
-        self.send_message_to_guild(packet, GuildChatMessageTypes.G_MSGTYPE_ALL)
-
         self.build_update(player_mgr)
         player_mgr.set_dirty()
 
-    def remove_member(self, player_mgr):
+        packet = PacketWriter.get_packet(OpCode.SMSG_GUILD_EVENT, data)
+        self.send_message_to_guild(packet, GuildChatMessageTypes.G_MSGTYPE_ALL)
+
+    def remove_member(self, player_guid):
+        member = self.members[player_guid]
+        guild_master = self.guild.guild_master
+
         data = pack('<2B', GuildEvents.GUILD_EVENT_REMOVED, 2)
-        target_name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
+        target_name_bytes = PacketWriter.string_to_bytes(member.character.name)
         data += pack(
             f'<{len(target_name_bytes)}s',
             target_name_bytes,
         )
 
-        remover_name_bytes = PacketWriter.string_to_bytes(self.guild_master.player.name)
+        remover_name_bytes = PacketWriter.string_to_bytes(guild_master.character.name)
         data += pack(
             f'<{len(remover_name_bytes)}s',
             remover_name_bytes,
@@ -105,17 +131,19 @@ class GuildManager(object):
         self.send_message_to_guild(packet, GuildChatMessageTypes.G_MSGTYPE_ALL)
 
         # Pop it at the end, so he gets the above message.
-        self.members.pop(player_mgr.guid)
-        self.ranks.pop(player_mgr.guid)
-        self.build_update(player_mgr, unset=True)
+        RealmDatabaseManager.guild_remove_player(member)
+        player_mgr = WorldSessionStateHandler.find_player_by_guid(player_guid)
 
-        player_mgr.guild_manager = None
-        player_mgr.set_dirty()
+        if player_mgr:
+            self.build_update(player_mgr, unset=True)
+            player_mgr.guild_manager = None
+            player_mgr.set_dirty()
 
-    def leave(self, player_mgr):
+    def leave(self, player_guid):
+        member = self.members[player_guid]
+
         data = pack('<2B', GuildEvents.GUILD_EVENT_LEFT, 1)
-
-        leaver_name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
+        leaver_name_bytes = PacketWriter.string_to_bytes(member.character.name)
         data += pack(
             f'<{len(leaver_name_bytes)}s',
             leaver_name_bytes,
@@ -124,17 +152,18 @@ class GuildManager(object):
         packet = PacketWriter.get_packet(OpCode.SMSG_GUILD_EVENT, data)
         self.send_message_to_guild(packet, GuildChatMessageTypes.G_MSGTYPE_ALL)
 
-        self.members.pop(player_mgr.guid)
-        self.ranks.pop(player_mgr.guid)
-        self.build_update(player_mgr, unset=True)
-
-        player_mgr.guild_manager = None
-        player_mgr.set_dirty()
+        RealmDatabaseManager.guild_remove_player(member)
+        player_mgr = WorldSessionStateHandler.find_player_by_guid(player_guid)
+        if player_mgr:
+            self.build_update(player_mgr, unset=True)
+            player_mgr.guild_manager = None
+            player_mgr.set_dirty()
 
     def disband(self):
-        data = pack('<2B', GuildEvents.GUILD_EVENT_DISBANDED, 1)
+        guild_master = self.guild.guild_master
 
-        leaver_name_bytes = PacketWriter.string_to_bytes(self.guild_master.player.name)
+        data = pack('<2B', GuildEvents.GUILD_EVENT_DISBANDED, 1)
+        leaver_name_bytes = PacketWriter.string_to_bytes(guild_master.character.name)
         data += pack(
             f'<{len(leaver_name_bytes)}s',
             leaver_name_bytes,
@@ -144,24 +173,29 @@ class GuildManager(object):
         self.send_message_to_guild(packet, GuildChatMessageTypes.G_MSGTYPE_ALL)
 
         for member in self.members.values():
-            self.build_update(member, unset=True)
-            member.guild_manager = None
-            member.set_dirty()
+            RealmDatabaseManager.guild_remove_player(member)
+            player_mgr = WorldSessionStateHandler.find_player_by_guid(member.guid)
+            if player_mgr:
+                self.build_update(player_mgr, unset=True)
+                player_mgr.guild_manager = None
+                player_mgr.set_dirty()
 
-        GuildManager.GUILDS.pop(self.guild_id)
+        GuildManager.GUILDS.pop(self.guild.name)
         self.members.clear()
-        self.ranks.clear()
+        RealmDatabaseManager.guild_destroy(self.guild)
 
     def send_message_to_guild(self, packet, msg_type=None, source=None):
         for member in self.members.values():
             if msg_type and msg_type == GuildChatMessageTypes.G_MSGTYPE_OFFICERCHAT \
-                    and self.get_guild_rank(member) > GuildRank.GUILDRANK_OFFICER:
+                    and member.rank > GuildRank.GUILDRANK_OFFICER:
                 continue
 
-            if source and member.friends_manager.has_ignore(source.guid):
-                continue
+            member_session = WorldSessionStateHandler.get_session_by_character_guid(member.guid)
+            if member_session and member_session.player_mgr:
+                if source and member_session.player_mgr.friends_manager.has_ignore(source.guid):
+                    continue
 
-            member.session.enqueue_packet(packet)
+                member_session.enqueue_packet(packet)
 
     def invite_member(self, player_mgr, invited_player):
         if invited_player.guid not in GuildManager.PENDING_INVITES:
@@ -169,28 +203,26 @@ class GuildManager(object):
             return True
         return False
 
-    def get_guild_rank(self, player_mgr):
-        return self.ranks[player_mgr.guid]
+    def promote_rank(self, player_guid):
+        member = self.members[player_guid]
 
-    def promote_rank(self, player_mgr):
-        if player_mgr == self.guild_master:
+        if member.rank == int(GuildRank.GUILDRANK_GUILD_MASTER):
             return False
 
-        current_rank = int(self.ranks[player_mgr.guid])
-        if current_rank == int(GuildRank.GUILDRANK_OFFICER):
+        if member.rank == int(GuildRank.GUILDRANK_OFFICER):
             return False
         else:
-            self.ranks[player_mgr.guid] = GuildRank((current_rank - 1))
+            member.rank -= 1
 
         data = pack('<2B', GuildEvents.GUILD_EVENT_PROMOTION, 2)
 
-        target_name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
+        target_name_bytes = PacketWriter.string_to_bytes(member.character.name)
         data += pack(
             f'<{len(target_name_bytes)}s',
             target_name_bytes,
         )
 
-        rank_name = GuildRank(self.ranks[player_mgr.guid]).name.split('_')[1].capitalize()
+        rank_name = GuildRank(member.rank).name.split('_')[1].capitalize()
         rank_name_bytes = PacketWriter.string_to_bytes(rank_name)
         data += pack(
             f'<{len(rank_name_bytes)}s',
@@ -200,29 +232,32 @@ class GuildManager(object):
         packet = PacketWriter.get_packet(OpCode.SMSG_GUILD_EVENT, data)
         self.send_message_to_guild(packet, GuildChatMessageTypes.G_MSGTYPE_ALL)
 
-        player_mgr.set_uint32(PlayerFields.PLAYER_GUILDRANK, self.get_guild_rank(player_mgr))
-        player_mgr.set_dirty()
+        player_mgr = WorldSessionStateHandler.find_player_by_guid(member.guid)
+        if player_mgr:
+            player_mgr.set_uint32(PlayerFields.PLAYER_GUILDRANK, member.rank)
+            player_mgr.set_dirty()
 
+        self.update_db_guild_members()
         return True
 
-    def demote_rank(self, player_mgr):
-        if player_mgr == self.guild_master:
+    def demote_rank(self, player_guid):
+        member = self.members[player_guid]
+        if member.rank == GuildRank.GUILDRANK_GUILD_MASTER:
             return False
 
-        current_rank = int(self.ranks[player_mgr.guid])
-        if current_rank == int(GuildRank.GUILDRANK_INITIATE):  # Use initiate as lowest for now
+        if member.rank == GuildRank.GUILDRANK_INITIATE:  # Use initiate as lowest for now
             return False
         else:
-            self.ranks[player_mgr.guid] = GuildRank((current_rank + 1))
+            member.rank += 1
 
         data = pack('<2B', GuildEvents.GUILD_EVENT_DEMOTION, 2)
-        target_name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
+        target_name_bytes = PacketWriter.string_to_bytes(member.character.name)
         data += pack(
             f'<{len(target_name_bytes)}s',
             target_name_bytes,
         )
 
-        rank_name = GuildRank(self.ranks[player_mgr.guid]).name.split('_')[1].capitalize()
+        rank_name = GuildRank(member.rank).name.split('_')[1].capitalize()
         rank_name_bytes = PacketWriter.string_to_bytes(rank_name)
         data += pack(
             f'<{len(rank_name_bytes)}s',
@@ -232,10 +267,19 @@ class GuildManager(object):
         packet = PacketWriter.get_packet(OpCode.SMSG_GUILD_EVENT, data)
         self.send_message_to_guild(packet, GuildChatMessageTypes.G_MSGTYPE_ALL)
 
-        player_mgr.set_uint32(PlayerFields.PLAYER_GUILDRANK, self.get_guild_rank(player_mgr))
-        player_mgr.set_dirty()
+        player_mgr = WorldSessionStateHandler.find_player_by_guid(member.guid)
+        if player_mgr:
+            player_mgr.set_uint32(PlayerFields.PLAYER_GUILDRANK, member.rank)
+            player_mgr.set_dirty()
 
+        self.update_db_guild_members()
         return True
+
+    def has_member(self, player_guid):
+        return player_guid in self.members
+
+    def get_rank(self, player_guid):
+        return self.members[player_guid].rank
 
     def build_update(self, player_mgr, unset=False):
         if unset:
@@ -243,9 +287,9 @@ class GuildManager(object):
             player_mgr.set_uint32(PlayerFields.PLAYER_GUILDRANK, 0)
             player_mgr.set_uint32(PlayerFields.PLAYER_GUILD_TIMESTAMP, 0)
         else:
-            player_mgr.set_uint32(PlayerFields.PLAYER_GUILDID, self.guild_id)
-            player_mgr.set_uint32(PlayerFields.PLAYER_GUILDRANK, self.get_guild_rank(player_mgr))
-            player_mgr.set_uint32(PlayerFields.PLAYER_GUILD_TIMESTAMP, self.created_at)
+            player_mgr.set_uint32(PlayerFields.PLAYER_GUILDID, self.guild.guild_id)
+            player_mgr.set_uint32(PlayerFields.PLAYER_GUILDRANK, self.members[player_mgr.guid].rank)
+            player_mgr.set_uint32(PlayerFields.PLAYER_GUILD_TIMESTAMP, 0)  # Format creation_data
 
     @staticmethod
     def create_guild(player_mgr, guild_name):
@@ -253,18 +297,48 @@ class GuildManager(object):
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_CREATE_S, '',
                                                    GuildCommandResults.GUILD_NAME_INVALID)
             return
-        for guild in GuildManager.GUILDS.values():
-            if guild.guild_name == guild_name:
-                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_CREATE_S, guild_name,
-                                                       GuildCommandResults.GUILD_NAME_EXISTS)
-                return
+        if guild_name in GuildManager.GUILDS:
+            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_CREATE_S, guild_name,
+                                                   GuildCommandResults.GUILD_NAME_EXISTS)
+            return
         if player_mgr.guild_manager:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_CREATE_S, '',
                                                    GuildCommandResults.GUILD_ALREADY_IN_GUILD)
             return
 
-        player_mgr.guild_manager = GuildManager(guild_name)
+        guild = GuildManager._create_guild("", guild_name, 0, 0, 0, 0, 0, player_mgr.guid)
+        player_mgr.guild_manager = GuildManager(guild)
         player_mgr.guild_manager.add_new_member(player_mgr, is_guild_master=True)
+
+    @staticmethod
+    def load_guilds():
+        guilds = RealmDatabaseManager.guild_get_all()
+
+        for guild in guilds:
+            if guild.name not in GuildManager.GUILDS:
+                GuildManager.GUILDS[guild.name] = GuildManager(guild)
+                GuildManager.GUILDS[guild.name].load_guild_members()
+
+    @staticmethod
+    def set_character_guild(player_mgr):
+        guild = RealmDatabaseManager.character_get_guild(player_mgr.player)
+        if guild and guild.name in GuildManager.GUILDS:
+            player_mgr.guild_manager = GuildManager.GUILDS[guild.name]
+
+    @staticmethod
+    def _create_guild(motd, name, bg_color, b_color, b_style, e_color, e_style, leader_guid):
+        guild = Guild()
+        guild.motd = motd
+        guild.name = name
+        guild.background_color = bg_color
+        guild.border_color = b_color
+        guild.border_style = b_style
+        guild.emblem_color = e_color
+        guild.emblem_style = e_style
+        guild.leader_guid = leader_guid
+        guild.creation_date = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        RealmDatabaseManager.guild_create(guild)
+        return guild
 
     @staticmethod
     def send_guild_command_result(player_mgr, command_type, message, command):

--- a/game/world/opcode_handling/handlers/guild/GuildCreateHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildCreateHandler.py
@@ -6,8 +6,9 @@ class GuildCreateHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        guild_name = PacketReader.read_string(reader.data, 0).strip()
-        player_mgr = world_session.player_mgr
-        GuildManager.create_guild(player_mgr, guild_name)
+        if reader.data:  # Handle null data.
+            guild_name = PacketReader.read_string(reader.data, 0).strip()
+            player_mgr = world_session.player_mgr
+            GuildManager.create_guild(player_mgr, guild_name)
 
         return 0

--- a/game/world/opcode_handling/handlers/guild/GuildDemoteHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildDemoteHandler.py
@@ -1,7 +1,7 @@
+from database.realm.RealmDatabaseManager import RealmDatabaseManager
 from network.packet.PacketReader import *
 from game.world.managers.objects.player.guild.GuildManager import GuildManager
-from utils.constants.ObjectCodes import GuildCommandResults, GuildTypeCommand
-from game.world.WorldSessionStateHandler import WorldSessionStateHandler
+from utils.constants.ObjectCodes import GuildCommandResults, GuildTypeCommand, GuildRank
 
 
 class GuildDemoteHandler(object):
@@ -9,23 +9,19 @@ class GuildDemoteHandler(object):
     @staticmethod
     def handle(world_session, socket, reader):
         target_name = PacketReader.read_string(reader.data, 0).strip()
-        target_player_mgr = WorldSessionStateHandler.find_player_by_name(target_name)
+        target_player_mgr = RealmDatabaseManager.character_get_by_name(target_name)
         player_mgr = world_session.player_mgr
 
         if not player_mgr.guild_manager:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        # TODO: Check if player is officer or greater, not only GM
-        elif player_mgr != player_mgr.guild_manager.guild_master:
+        elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_PERMISSIONS)
-        elif not target_player_mgr:
+        elif not target_player_mgr or not player_mgr.guild_manager.has_member(target_player_mgr.guid):
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
                                                    GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
-        elif not player_mgr.guild_manager.is_member(target_player_mgr):
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif not player_mgr.guild_manager.demote_rank(target_player_mgr):
+        elif not player_mgr.guild_manager.demote_rank(target_player_mgr.guid):
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_INTERNAL)
 

--- a/game/world/opcode_handling/handlers/guild/GuildDemoteHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildDemoteHandler.py
@@ -1,4 +1,5 @@
 from database.realm.RealmDatabaseManager import RealmDatabaseManager
+from game.world.managers.objects.player.ChatManager import ChatManager
 from network.packet.PacketReader import *
 from game.world.managers.objects.player.guild.GuildManager import GuildManager
 from utils.constants.ObjectCodes import GuildCommandResults, GuildTypeCommand, GuildRank
@@ -23,7 +24,7 @@ class GuildDemoteHandler(object):
                                                    GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
         elif not player_mgr.guild_manager.has_member(target_player_mgr.guid):
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
+                                                   GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
         elif not player_mgr.guild_manager.demote_rank(target_player_mgr.guid):
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_INTERNAL)

--- a/game/world/opcode_handling/handlers/guild/GuildDemoteHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildDemoteHandler.py
@@ -9,24 +9,25 @@ class GuildDemoteHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        target_name = PacketReader.read_string(reader.data, 0).strip()
-        target_player_mgr = RealmDatabaseManager.character_get_by_name(target_name)
-        player_mgr = world_session.player_mgr
+        if reader.data:  # Handle null data.
+            target_name = PacketReader.read_string(reader.data, 0).strip()
+            target_player_mgr = RealmDatabaseManager.character_get_by_name(target_name)
+            player_mgr = world_session.player_mgr
 
-        if not player_mgr.guild_manager:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
-                                                   GuildCommandResults.GUILD_PERMISSIONS)
-        elif not target_player_mgr:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
-        elif not player_mgr.guild_manager.has_member(target_player_mgr.guid):
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif not player_mgr.guild_manager.demote_rank(target_player_mgr.guid):
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
-                                                   GuildCommandResults.GUILD_INTERNAL)
+            if not player_mgr.guild_manager:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
+            elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
+                                                       GuildCommandResults.GUILD_PERMISSIONS)
+            elif not target_player_mgr:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
+            elif not player_mgr.guild_manager.has_member(target_player_mgr.guid):
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
+            elif not player_mgr.guild_manager.demote_rank(target_player_mgr.guid):
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
+                                                       GuildCommandResults.GUILD_INTERNAL)
 
         return 0

--- a/game/world/opcode_handling/handlers/guild/GuildDemoteHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildDemoteHandler.py
@@ -18,7 +18,10 @@ class GuildDemoteHandler(object):
         elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_PERMISSIONS)
-        elif not target_player_mgr or not player_mgr.guild_manager.has_member(target_player_mgr.guid):
+        elif not target_player_mgr:
+            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
+                                                   GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
+        elif not player_mgr.guild_manager.has_member(target_player_mgr.guid):
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
                                                    GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
         elif not player_mgr.guild_manager.demote_rank(target_player_mgr.guid):

--- a/game/world/opcode_handling/handlers/guild/GuildDisbandHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildDisbandHandler.py
@@ -1,5 +1,5 @@
 from game.world.managers.objects.player.guild.GuildManager import GuildManager
-from utils.constants.ObjectCodes import GuildCommandResults, GuildTypeCommand
+from utils.constants.ObjectCodes import GuildCommandResults, GuildTypeCommand, GuildRank
 
 
 class GuildDisbandHandler(object):
@@ -11,7 +11,7 @@ class GuildDisbandHandler(object):
         if not player_mgr.guild_manager:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_CREATE_S, '',
                                                    GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif player_mgr != player_mgr.guild_manager.guild_master:
+        elif player_mgr.guild_manager.get_rank(player_mgr.guid) != GuildRank.GUILDRANK_GUILD_MASTER:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_FOUNDER_S, '',
                                                    GuildCommandResults.GUILD_PERMISSIONS)
         else:

--- a/game/world/opcode_handling/handlers/guild/GuildInfoHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildInfoHandler.py
@@ -1,3 +1,4 @@
+from database.realm.RealmDatabaseManager import RealmDatabaseManager
 from network.packet.PacketWriter import *
 from game.world.managers.objects.player.guild.GuildManager import GuildManager
 from utils.constants.ObjectCodes import GuildCommandResults, GuildTypeCommand
@@ -14,15 +15,16 @@ class GuildInfoHandler(object):
                                                    GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
         else:
             # Guild name
-            name_bytes = PacketWriter.string_to_bytes(player.guild_manager.guild_name)
+            name_bytes = PacketWriter.string_to_bytes(player.guild_manager.guild.name)
             data = pack(
                 f'<{len(name_bytes)}s',
                 name_bytes
             )
 
-            # TODO: Handle proper data and nº of accounts
+            accounts = RealmDatabaseManager.guild_get_accounts(guild_id=player.guild_manager.guild.guild_id)
+            # TODO: Parse DB DT.
             # Day, Month, Years, Players, Nº Accounts
-            data += pack('<5I', 0, 0, 0, len(player.guild_manager.members), 0)
+            data += pack('<5I', 0, 0, 0, len(player.guild_manager.members), len(accounts))
             player.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_GUILD_INFO, data))
 
         return 0

--- a/game/world/opcode_handling/handlers/guild/GuildInviteAcceptHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildInviteAcceptHandler.py
@@ -11,7 +11,8 @@ class GuildInviteAcceptHandler(object):
         if player_mgr.guid in GuildManager.PENDING_INVITES:
             inviter = GuildManager.PENDING_INVITES[player_mgr.guid].inviter
             GuildManager.PENDING_INVITES.pop(player_mgr.guid)
-            inviter.guild_manager.add_new_member(player_mgr)
+            if inviter and inviter.guild_manager: # Invited could have left right after sending the invite.
+                inviter.guild_manager.add_new_member(player_mgr)
         else:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_INTERNAL)

--- a/game/world/opcode_handling/handlers/guild/GuildInviteDeclineHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildInviteDeclineHandler.py
@@ -16,7 +16,7 @@ class GuildInviteDeclineHandler(object):
             inviter_name_bytes = PacketWriter.string_to_bytes(inviter.player.name)
             data = pack(
                 f'<{len(inviter_name_bytes)}s',
-                inviter_name_bytes,
+                inviter_name_bytes
             )
 
             inviter.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_GUILD_DECLINE, data))

--- a/game/world/opcode_handling/handlers/guild/GuildInviteHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildInviteHandler.py
@@ -36,13 +36,13 @@ class GuildInviteHandler(object):
                 name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
                 data = pack(
                     f'<{len(name_bytes)}s',
-                    name_bytes,
+                    name_bytes
                 )
 
                 guild_name_bytes = PacketWriter.string_to_bytes(player_mgr.guild_manager.guild.name)
                 data += pack(
                     f'<{len(guild_name_bytes)}s',
-                    guild_name_bytes,
+                    guild_name_bytes
                 )
 
                 target_player_mgr.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_GUILD_INVITE, data))

--- a/game/world/opcode_handling/handlers/guild/GuildInviteHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildInviteHandler.py
@@ -9,42 +9,43 @@ class GuildInviteHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        target_name = PacketReader.read_string(reader.data, 0).strip()
-        target_player_mgr = WorldSessionStateHandler.find_player_by_name(target_name)
-        player_mgr = world_session.player_mgr
+        if reader.data:  # Handle null data.
+            target_name = PacketReader.read_string(reader.data, 0).strip()
+            target_player_mgr = WorldSessionStateHandler.find_player_by_name(target_name)
+            player_mgr = world_session.player_mgr
 
-        if not player_mgr.guild_manager:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
-                                                   GuildCommandResults.GUILD_PERMISSIONS)
-        elif not target_player_mgr:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
-        elif target_player_mgr.guild_manager:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
-                                                   GuildCommandResults.GUILD_ALREADY_IN_GUILD)
-        elif target_player_mgr.team != player_mgr.team:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
-                                                   GuildCommandResults.GUILD_NOT_ALLIED)
-        else:
-            if player_mgr.guild_manager.invite_member(player_mgr, target_player_mgr):
+            if not player_mgr.guild_manager:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
+            elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
+                                                       GuildCommandResults.GUILD_PERMISSIONS)
+            elif not target_player_mgr:
                 GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
-                                                       GuildCommandResults.GUILD_U_HAVE_INVITED)
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
+            elif target_player_mgr.guild_manager:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
+                                                       GuildCommandResults.GUILD_ALREADY_IN_GUILD)
+            elif target_player_mgr.team != player_mgr.team:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
+                                                       GuildCommandResults.GUILD_NOT_ALLIED)
+            else:
+                if player_mgr.guild_manager.invite_member(player_mgr, target_player_mgr):
+                    GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
+                                                           GuildCommandResults.GUILD_U_HAVE_INVITED)
 
-                name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
-                data = pack(
-                    f'<{len(name_bytes)}s',
-                    name_bytes
-                )
+                    name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
+                    data = pack(
+                        f'<{len(name_bytes)}s',
+                        name_bytes
+                    )
 
-                guild_name_bytes = PacketWriter.string_to_bytes(player_mgr.guild_manager.guild.name)
-                data += pack(
-                    f'<{len(guild_name_bytes)}s',
-                    guild_name_bytes
-                )
+                    guild_name_bytes = PacketWriter.string_to_bytes(player_mgr.guild_manager.guild.name)
+                    data += pack(
+                        f'<{len(guild_name_bytes)}s',
+                        guild_name_bytes
+                    )
 
-                target_player_mgr.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_GUILD_INVITE, data))
+                    target_player_mgr.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_GUILD_INVITE, data))
 
         return 0

--- a/game/world/opcode_handling/handlers/guild/GuildInviteHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildInviteHandler.py
@@ -16,7 +16,7 @@ class GuildInviteHandler(object):
         if not player_mgr.guild_manager:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif player_mgr.guild_manager.get_guild_rank(player_mgr) > GuildRank.GUILDRANK_OFFICER:
+        elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_PERMISSIONS)
         elif not target_player_mgr:
@@ -39,7 +39,7 @@ class GuildInviteHandler(object):
                     name_bytes,
                 )
 
-                guild_name_bytes = PacketWriter.string_to_bytes(player_mgr.guild_manager.guild_name)
+                guild_name_bytes = PacketWriter.string_to_bytes(player_mgr.guild_manager.guild.name)
                 data += pack(
                     f'<{len(guild_name_bytes)}s',
                     guild_name_bytes,

--- a/game/world/opcode_handling/handlers/guild/GuildLeaderHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildLeaderHandler.py
@@ -8,23 +8,27 @@ class GuildLeaderHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        target_name = PacketReader.read_string(reader.data, 0).strip()
-        target_player_mgr = RealmDatabaseManager.character_get_by_name(target_name)
-        player_mgr = world_session.player_mgr
+        if reader.data: #Can just type /gleader
+            target_name = PacketReader.read_string(reader.data, 0).strip()
+            target_player_mgr = RealmDatabaseManager.character_get_by_name(target_name)
+            player_mgr = world_session.player_mgr
 
-        if not player_mgr.guild_manager:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        if not target_player_mgr:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
-        elif not player_mgr.guild_manager.has_member(target_player_mgr.guid):
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif player_mgr.guild_manager.get_rank(player_mgr.guid) != GuildRank.GUILDRANK_GUILD_MASTER:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_FOUNDER_S, '',
-                                                   GuildCommandResults.GUILD_PERMISSIONS)
-        else:
-            player_mgr.guild_manager.set_guild_master(target_player_mgr.guid)
+            if not player_mgr.guild_manager:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
+            elif not target_player_mgr:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
+            elif not player_mgr.guild_manager.has_member(target_player_mgr.guid):
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
+            elif player_mgr.guild_manager.get_rank(player_mgr.guid) != GuildRank.GUILDRANK_GUILD_MASTER:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_FOUNDER_S, '',
+                                                       GuildCommandResults.GUILD_PERMISSIONS)
+            elif player_mgr.guid == target_player_mgr.guid:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_FOUNDER_S, '',
+                                                       GuildCommandResults.GUILD_INTERNAL)
+            else:
+                player_mgr.guild_manager.set_guild_master(target_player_mgr.guid)
 
         return 0

--- a/game/world/opcode_handling/handlers/guild/GuildLeaveHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildLeaveHandler.py
@@ -1,5 +1,5 @@
 from game.world.managers.objects.player.guild.GuildManager import GuildManager
-from utils.constants.ObjectCodes import GuildCommandResults, GuildTypeCommand
+from utils.constants.ObjectCodes import GuildCommandResults, GuildTypeCommand, GuildRank
 
 
 class GuildLeaveHandler(object):
@@ -11,10 +11,10 @@ class GuildLeaveHandler(object):
         if not player.guild_manager:
             GuildManager.send_guild_command_result(player, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif player.guild_manager.guild_master == player:  # GM should use disband.
+        elif player.guild_manager.get_rank(player.guid) == GuildRank.GUILDRANK_GUILD_MASTER:  # GM should use disband.
             GuildManager.send_guild_command_result(player, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_INTERNAL)
         else:
-            player.guild_manager.leave(player)
+            player.guild_manager.leave(player.guid)
 
         return 0

--- a/game/world/opcode_handling/handlers/guild/GuildMOTDHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildMOTDHandler.py
@@ -14,12 +14,12 @@ class GuildMOTDHandler(object):
             if not player_mgr.guild_manager:
                 GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                        GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-            elif not motd:
-                player_mgr.guild_manager.send_motd()
             elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
                 GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                        GuildCommandResults.GUILD_PERMISSIONS)
             else:
                 player_mgr.guild_manager.set_motd(motd)
+        elif world_session.player_mgr.guild_manager:
+            world_session.player_mgr.guild_manager.send_motd()
 
         return 0

--- a/game/world/opcode_handling/handlers/guild/GuildMOTDHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildMOTDHandler.py
@@ -15,7 +15,7 @@ class GuildMOTDHandler(object):
                                                    GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
         elif not motd:
             player_mgr.guild_manager.send_motd()
-        elif player_mgr.guild_manager.get_guild_rank(player_mgr) > GuildRank.GUILDRANK_OFFICER:
+        elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_PERMISSIONS)
         else:

--- a/game/world/opcode_handling/handlers/guild/GuildMOTDHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildMOTDHandler.py
@@ -20,6 +20,6 @@ class GuildMOTDHandler(object):
             else:
                 player_mgr.guild_manager.set_motd(motd)
         elif world_session.player_mgr.guild_manager:
-            world_session.player_mgr.guild_manager.send_motd()
+            world_session.player_mgr.guild_manager.send_motd(world_session.player_mgr)
 
         return 0

--- a/game/world/opcode_handling/handlers/guild/GuildMOTDHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildMOTDHandler.py
@@ -7,18 +7,19 @@ class GuildMOTDHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        motd = PacketReader.read_string(reader.data, 0).strip()
-        player_mgr = world_session.player_mgr
+        if reader.data:  # Handle null data.
+            motd = PacketReader.read_string(reader.data, 0).strip()
+            player_mgr = world_session.player_mgr
 
-        if not player_mgr.guild_manager:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif not motd:
-            player_mgr.guild_manager.send_motd()
-        elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
-                                                   GuildCommandResults.GUILD_PERMISSIONS)
-        else:
-            player_mgr.guild_manager.set_motd(motd)
+            if not player_mgr.guild_manager:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
+            elif not motd:
+                player_mgr.guild_manager.send_motd()
+            elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
+                                                       GuildCommandResults.GUILD_PERMISSIONS)
+            else:
+                player_mgr.guild_manager.set_motd(motd)
 
         return 0

--- a/game/world/opcode_handling/handlers/guild/GuildPromoteHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildPromoteHandler.py
@@ -1,7 +1,7 @@
 from network.packet.PacketReader import *
 from game.world.managers.objects.player.guild.GuildManager import GuildManager
-from utils.constants.ObjectCodes import GuildCommandResults, GuildTypeCommand
-from game.world.WorldSessionStateHandler import WorldSessionStateHandler
+from utils.constants.ObjectCodes import GuildCommandResults, GuildTypeCommand, GuildRank
+from database.realm.RealmDatabaseManager import RealmDatabaseManager
 
 
 class GuildPromoteHandler(object):
@@ -9,23 +9,22 @@ class GuildPromoteHandler(object):
     @staticmethod
     def handle(world_session, socket, reader):
         target_name = PacketReader.read_string(reader.data, 0).strip()
-        target_player_mgr = WorldSessionStateHandler.find_player_by_name(target_name)
+        target_player_mgr = RealmDatabaseManager.character_get_by_name(target_name)
         player_mgr = world_session.player_mgr
 
         if not player_mgr.guild_manager:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        # TODO I guess not only GM should be able to promote?
-        elif player_mgr != player_mgr.guild_manager.guild_master:
+        elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_PERMISSIONS)
         elif not target_player_mgr:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
                                                    GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
-        elif not player_mgr.guild_manager.is_member(target_player_mgr):
+        elif not player_mgr.guild_manager.has_member(target_player_mgr.guid):
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
                                                    GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif not player_mgr.guild_manager.promote_rank(target_player_mgr):
+        elif not player_mgr.guild_manager.promote_rank(target_player_mgr.guid):
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_INTERNAL)
 

--- a/game/world/opcode_handling/handlers/guild/GuildPromoteHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildPromoteHandler.py
@@ -8,24 +8,25 @@ class GuildPromoteHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        target_name = PacketReader.read_string(reader.data, 0).strip()
-        target_player_mgr = RealmDatabaseManager.character_get_by_name(target_name)
-        player_mgr = world_session.player_mgr
+        if reader.data:  # Handle null data.
+            target_name = PacketReader.read_string(reader.data, 0).strip()
+            target_player_mgr = RealmDatabaseManager.character_get_by_name(target_name)
+            player_mgr = world_session.player_mgr
 
-        if not player_mgr.guild_manager:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
-                                                   GuildCommandResults.GUILD_PERMISSIONS)
-        elif not target_player_mgr:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
-        elif not player_mgr.guild_manager.has_member(target_player_mgr.guid):
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif not player_mgr.guild_manager.promote_rank(target_player_mgr.guid):
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
-                                                   GuildCommandResults.GUILD_INTERNAL)
+            if not player_mgr.guild_manager:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
+            elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
+                                                       GuildCommandResults.GUILD_PERMISSIONS)
+            elif not target_player_mgr:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
+            elif not player_mgr.guild_manager.has_member(target_player_mgr.guid):
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
+            elif not player_mgr.guild_manager.promote_rank(target_player_mgr.guid):
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
+                                                       GuildCommandResults.GUILD_INTERNAL)
 
         return 0

--- a/game/world/opcode_handling/handlers/guild/GuildQueryHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildQueryHandler.py
@@ -7,23 +7,24 @@ class GuildQueryHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        # No ranks/permissions on 0.5.3 client.
-        guild_id = unpack('<1I', reader.data[:4])[0]
-        player = world_session.player_mgr
+        if reader.data:  # Handle null data.
+            # No ranks/permissions on 0.5.3 client.
+            guild_id = unpack('<1I', reader.data[:4])[0]
+            player = world_session.player_mgr
 
-        # TODO, Fix this, go back to guid key...
-        for guild_manager in GuildManager.GUILDS.values():
-            if guild_manager.guild.guild_id == guild_id:
-                guild = guild_manager.guild
-                data = pack('<1I', guild_id)
+            # TODO, Fix this, go back to guid key...
+            for guild_manager in GuildManager.GUILDS.values():
+                if guild_manager.guild.guild_id == guild_id:
+                    guild = guild_manager.guild
+                    data = pack('<1I', guild_id)
 
-                name_bytes = PacketWriter.string_to_bytes(guild.name)
-                data += pack(
-                    f'<{len(name_bytes)}s',
-                    name_bytes
-                )
+                    name_bytes = PacketWriter.string_to_bytes(guild.name)
+                    data += pack(
+                        f'<{len(name_bytes)}s',
+                        name_bytes
+                    )
 
-                data += pack('<5i', guild.emblem_style, guild.emblem_color, guild.border_style, guild.border_color, guild.background_color)
-                player.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_GUILD_QUERY_RESPONSE, data))
+                    data += pack('<5i', guild.emblem_style, guild.emblem_color, guild.border_style, guild.border_color, guild.background_color)
+                    player.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_GUILD_QUERY_RESPONSE, data))
 
         return 0

--- a/game/world/opcode_handling/handlers/guild/GuildQueryHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildQueryHandler.py
@@ -11,18 +11,19 @@ class GuildQueryHandler(object):
         guild_id = unpack('<1I', reader.data[:4])[0]
         player = world_session.player_mgr
 
-        if guild_id in GuildManager.GUILDS:
-            guild = GuildManager.GUILDS[guild_id]
-            data = pack('<1I', guild_id)
+        # TODO, Fix this, go back to guid key...
+        for guild_manager in GuildManager.GUILDS.values():
+            if guild_manager.guild.guild_id == guild_id:
+                guild = guild_manager.guild
+                data = pack('<1I', guild_id)
 
-            name_bytes = PacketWriter.string_to_bytes(guild.guild_name)
-            data += pack(
-                f'<{len(name_bytes)}s',
-                name_bytes,
-            )
+                name_bytes = PacketWriter.string_to_bytes(guild.name)
+                data += pack(
+                    f'<{len(name_bytes)}s',
+                    name_bytes,
+                )
 
-            # TODO: EmblemStyle, EmblemColor, BorderStyle, BorderColor, BGColor
-            data += pack('<5i', -1, -1, -1, -1, -1)
-            player.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_GUILD_QUERY_RESPONSE, data))
+                data += pack('<5i', guild.emblem_style, guild.emblem_color, guild.border_style, guild.border_color, guild.background_color)
+                player.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_GUILD_QUERY_RESPONSE, data))
 
         return 0

--- a/game/world/opcode_handling/handlers/guild/GuildQueryHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildQueryHandler.py
@@ -20,7 +20,7 @@ class GuildQueryHandler(object):
                 name_bytes = PacketWriter.string_to_bytes(guild.name)
                 data += pack(
                     f'<{len(name_bytes)}s',
-                    name_bytes,
+                    name_bytes
                 )
 
                 data += pack('<5i', guild.emblem_style, guild.emblem_color, guild.border_style, guild.border_color, guild.background_color)

--- a/game/world/opcode_handling/handlers/guild/GuildRemoveMemberHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildRemoveMemberHandler.py
@@ -8,23 +8,24 @@ class GuildRemoveMemberHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        target_name = PacketReader.read_string(reader.data, 0).strip()
-        target_player_mgr = RealmDatabaseManager.character_get_by_name(target_name)
-        player_mgr = world_session.player_mgr
+        if reader.data:  # Handle null data.
+            target_name = PacketReader.read_string(reader.data, 0).strip()
+            target_player_mgr = RealmDatabaseManager.character_get_by_name(target_name)
+            player_mgr = world_session.player_mgr
 
-        if not player_mgr.guild_manager:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_CREATE_S, '',
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        if not target_player_mgr:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
-        elif not player_mgr.guild_manager.has_member(target_player_mgr.guid):
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
-                                                   GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
-            GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
-                                                   GuildCommandResults.GUILD_PERMISSIONS)
-        else:
-            player_mgr.guild_manager.remove_member(target_player_mgr.guid)
+            if not player_mgr.guild_manager:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_CREATE_S, '',
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
+            if not target_player_mgr:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
+            elif not player_mgr.guild_manager.has_member(target_player_mgr.guid):
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
+                                                       GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
+            elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
+                                                       GuildCommandResults.GUILD_PERMISSIONS)
+            else:
+                player_mgr.guild_manager.remove_member(target_player_mgr.guid)
 
         return 0

--- a/game/world/opcode_handling/handlers/guild/GuildRemoveMemberHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildRemoveMemberHandler.py
@@ -1,6 +1,6 @@
 from game.world.managers.objects.player.guild.GuildManager import GuildManager
 from network.packet.PacketReader import *
-from game.world.WorldSessionStateHandler import WorldSessionStateHandler
+from database.realm.RealmDatabaseManager import RealmDatabaseManager
 from utils.constants.ObjectCodes import GuildCommandResults, GuildTypeCommand, GuildRank
 
 
@@ -9,7 +9,7 @@ class GuildRemoveMemberHandler(object):
     @staticmethod
     def handle(world_session, socket, reader):
         target_name = PacketReader.read_string(reader.data, 0).strip()
-        target_player_mgr = WorldSessionStateHandler.find_player_by_name(target_name)
+        target_player_mgr = RealmDatabaseManager.character_get_by_name(target_name)
         player_mgr = world_session.player_mgr
 
         if not player_mgr.guild_manager:
@@ -18,13 +18,13 @@ class GuildRemoveMemberHandler(object):
         if not target_player_mgr:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
                                                    GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
-        elif not target_player_mgr.guild_manager or not player_mgr.guild_manager.is_member(target_player_mgr):
+        elif not player_mgr.guild_manager.has_member(target_player_mgr.guid):
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
                                                    GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif player_mgr.guild_manager.get_guild_rank(player_mgr) > GuildRank.GUILDRANK_OFFICER:
+        elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
             GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_PERMISSIONS)
         else:
-            player_mgr.guild_manager.remove_member(target_player_mgr)
+            player_mgr.guild_manager.remove_member(target_player_mgr.guid)
 
         return 0

--- a/game/world/opcode_handling/handlers/guild/GuildRosterHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildRosterHandler.py
@@ -1,3 +1,4 @@
+from database.realm.RealmDatabaseManager import RealmDatabaseManager
 from network.packet.PacketWriter import *
 from utils.constants.UnitCodes import Classes, Races
 from database.world.WorldDatabaseManager import WorldDatabaseManager
@@ -24,8 +25,8 @@ class GuildRosterHandler(object):
 
             # Members count
             data += pack('<I', len(player.guild_manager.members))
-            # TODO: Number of accounts
-            data += pack('<I', 0)
+            accounts = RealmDatabaseManager.guild_get_accounts(guild_id=player.guild_manager.guild.guild_id)
+            data += pack('<I', len(accounts))
 
             for member in player.guild_manager.members.values():
                 player_name = PacketWriter.string_to_bytes(member.character.name)

--- a/game/world/opcode_handling/handlers/guild/GuildRosterHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildRosterHandler.py
@@ -1,10 +1,7 @@
 from database.realm.RealmDatabaseManager import RealmDatabaseManager
 from network.packet.PacketWriter import *
-from utils.constants.UnitCodes import Classes, Races
-from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.managers.objects.player.guild.GuildManager import GuildManager
 from utils.constants.ObjectCodes import GuildCommandResults, GuildTypeCommand
-from utils.TextUtils import GameTextFormatter
 
 
 class GuildRosterHandler(object):

--- a/game/world/opcode_handling/handlers/guild/GuildRosterHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildRosterHandler.py
@@ -16,7 +16,7 @@ class GuildRosterHandler(object):
             GuildManager.send_guild_command_result(player, GuildTypeCommand.GUILD_CREATE_S, '',
                                                    GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
         else:
-            guild_name = PacketWriter.string_to_bytes(player.guild_manager.guild_name)
+            guild_name = PacketWriter.string_to_bytes(player.guild_manager.guild.name)
             data = pack(
                 f'<{len(guild_name)}s',
                 guild_name
@@ -28,11 +28,11 @@ class GuildRosterHandler(object):
             data += pack('<I', 0)
 
             for member in player.guild_manager.members.values():
-                player_name = PacketWriter.string_to_bytes(member.player.name)
+                player_name = PacketWriter.string_to_bytes(member.character.name)
                 data += pack(
                     f'<{len(player_name)}sI',
                     player_name,
-                    member.guild_manager.get_guild_rank(member)
+                    member.rank,
                 )
 
             player.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_GUILD_ROSTER, data))

--- a/game/world/opcode_handling/handlers/guild/GuildRosterHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildRosterHandler.py
@@ -32,7 +32,7 @@ class GuildRosterHandler(object):
                 data += pack(
                     f'<{len(player_name)}sI',
                     player_name,
-                    member.rank,
+                    member.rank
                 )
 
             player.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_GUILD_ROSTER, data))

--- a/game/world/opcode_handling/handlers/player/PlayerLoginHandler.py
+++ b/game/world/opcode_handling/handlers/player/PlayerLoginHandler.py
@@ -2,6 +2,8 @@ import time
 
 from struct import unpack
 
+from game.world.WorldSessionStateHandler import WorldSessionStateHandler
+from game.world.managers.objects.player.guild.GuildManager import GuildManager
 from network.packet.PacketWriter import *
 from database.realm.RealmDatabaseManager import *
 from database.dbc.DbcDatabaseManager import *
@@ -28,6 +30,8 @@ class PlayerLoginHandler(object):
         if not world_session.player_mgr.player:
             Logger.anticheat(f'Character with wrong guid ({guid}) tried to login.')
             return -1
+        else:
+            WorldSessionStateHandler.push_active_player_session(world_session)
 
         # Disabled race & class checks (only if not a GM)
         if not world_session.player_mgr.is_gm:
@@ -70,6 +74,7 @@ class PlayerLoginHandler(object):
         world_session.player_mgr.stat_manager.apply_bonuses()
         world_session.player_mgr.skill_manager.load_skills()
         world_session.player_mgr.quest_manager.load_quests()
+        GuildManager.set_character_guild(world_session.player_mgr)
 
         # First login
         if world_session.player_mgr.player.totaltime == 0:

--- a/game/world/opcode_handling/handlers/social/WhoHandler.py
+++ b/game/world/opcode_handling/handlers/social/WhoHandler.py
@@ -54,7 +54,7 @@ class WhoHandler(object):
                         continue
                     if player_name and not player_name.lower() in session.player_mgr.player.name.lower:
                         continue
-                    if session.player_mgr.guild_manager and guild_name and guild_name.lower() not in session.player_mgr.guild_manager.guild_name.lower():
+                    if session.player_mgr.guild_manager and guild_name and guild_name.lower() not in session.player_mgr.guild_manager.guild.name.lower():
                         continue
                     if class_mask != 0xFFFFFFFF and class_mask & session.player_mgr.class_mask != session.player_mgr.class_mask:
                         continue
@@ -81,7 +81,7 @@ class WhoHandler(object):
 
                     player_name_bytes = PacketWriter.string_to_bytes(session.player_mgr.player.name)
 
-                    player_guild_name = session.player_mgr.guild_manager.guild_name if session.player_mgr.guild_manager else ""
+                    player_guild_name = session.player_mgr.guild_manager.guild.name if session.player_mgr.guild_manager else ""
                     guild_name_bytes = PacketWriter.string_to_bytes(player_guild_name)
                     player_data += pack(
                         f'<{len(player_name_bytes)}s{len(guild_name_bytes)}s5I',

--- a/game/world/opcode_handling/handlers/social/WhoHandler.py
+++ b/game/world/opcode_handling/handlers/social/WhoHandler.py
@@ -81,7 +81,7 @@ class WhoHandler(object):
 
                     player_name_bytes = PacketWriter.string_to_bytes(session.player_mgr.player.name)
 
-                    player_guild_name = session.player_mgr.guild_manager.guild.name if session.player_mgr.guild_manager else ""
+                    player_guild_name = session.player_mgr.guild_manager.guild.name if session.player_mgr.guild_manager else ''
                     guild_name_bytes = PacketWriter.string_to_bytes(player_guild_name)
                     player_data += pack(
                         f'<{len(player_name_bytes)}s{len(guild_name_bytes)}s5I',


### PR DESCRIPTION
+ Guild persistance.
- Drop leader_guid column, leader already exist over guild_members table.
* Modify all Guild handlers to not expect an online player for guild related actions. (Can kick offline player, promote, demote, etc)
* Make player_mgr and session O(1) accessible by guid/name over WorldSessionStateHandler.