### PR TITLE
quest improvements

### DIFF
--- a/database/realm/RealmDatabaseManager.py
+++ b/database/realm/RealmDatabaseManager.py
@@ -357,3 +357,11 @@ class RealmDatabaseManager(object):
             realm_db_session.close()
             return 0
         return -1
+
+    @staticmethod
+    def character_update_quest(quest_id):
+        if quest_id:
+            realm_db_session = SessionHolder()
+            realm_db_session.merge(quest_id)
+            realm_db_session.flush()
+            realm_db_session.close()

--- a/game/world/managers/objects/player/QuestManager.py
+++ b/game/world/managers/objects/player/QuestManager.py
@@ -10,6 +10,7 @@ from game.world.managers.objects.item.ItemManager import ItemManager
 from network.packet.PacketWriter import PacketWriter, OpCode
 from utils.constants.ObjectCodes import QuestGiverStatus, QuestState, QuestFailedReasons, ObjectTypes
 from utils.constants.UpdateFields import PlayerFields
+from utils import Formulas
 
 # Terminology:
 # - quest or quest template refer to the quest template (the db record)
@@ -23,6 +24,7 @@ class QuestManager(object):
     def __init__(self, player_mgr):
         self.player_mgr = player_mgr
         self.active_quests = {}
+        self.done_quests = {}
 
     def load_quests(self):
         db_quests = RealmDatabaseManager.character_get_quests(self.player_mgr.guid)
@@ -30,6 +32,8 @@ class QuestManager(object):
         for db_quest in db_quests:
             if db_quest.status == QuestState.QUEST_ACCEPTED or db_quest.status == QuestState.QUEST_REWARD:
                 self.active_quests[db_quest.quest] = ActiveQuest(db_quest.quest, db_quest.status)
+            elif db_quest.status == QuestState.QUEST_DONE:
+                self.done_quests[db_quest.quest] = True
             else:
                 Logger.error(f"Quest database (guid={db_quest.guid}, quest_id={db_quest.quest}) has state {db_quest.status}. No handling.")
 
@@ -65,6 +69,8 @@ class QuestManager(object):
 
             if quest_entry in self.active_quests:
                 continue
+            if quest_entry in self.done_quests:
+                continue
 
             if quest.Method == 0:
                 new_dialog_status = QuestGiverStatus.QUEST_GIVER_REWARD
@@ -80,7 +86,7 @@ class QuestManager(object):
 
         return dialog_status
 
-    def prepare_quest_giver_gossip_menu(self, quest_giver, guid):
+    def prepare_quest_giver_gossip_menu(self, quest_giver, quest_giver_guid):
         quest_menu = QuestMenu()
         # Type is unit, but not player
         if quest_giver.get_type() == ObjectTypes.TYPE_UNIT and quest_giver.get_type() != ObjectTypes.TYPE_PLAYER:
@@ -116,6 +122,8 @@ class QuestManager(object):
             quest = WorldDatabaseManager.QuestTemplateHolder.quest_get_by_entry(quest_entry)
             if not quest or not self.check_quest_requirements(quest) or not self.check_quest_level(quest, False):
                 continue
+            if quest_entry in self.done_quests:
+                continue
             quest_state = QuestState.QUEST_OFFER
             if quest_entry in self.active_quests:
                 quest_state = self.active_quests[quest_entry].state
@@ -126,16 +134,16 @@ class QuestManager(object):
         if len(quest_menu.items) == 1:
             quest_menu_item = list(quest_menu.items.values())[0]
             if quest_menu_item.status == QuestState.QUEST_REWARD:
-                # TODO: Handle completed quest
+                self.send_quest_giver_offer_reward(self.active_quests[quest_menu_item.quest.entry], quest_giver_guid, True)
                 return 0
             elif quest_menu_item.status == QuestState.QUEST_ACCEPTED:
                 # TODO: Handle in progress quests
                 return 0
             else:
-                self.send_quest_giver_quest_details(quest_menu_item.quest, guid, True)
+                self.send_quest_giver_quest_details(quest_menu_item.quest, quest_giver_guid, True)
         else:
             # TODO: Send the proper greeting message
-            self.send_quest_giver_quest_list("Greetings, $N.", guid, quest_menu.items)
+            self.send_quest_giver_quest_list("Greetings, $N.", quest_giver_guid, quest_menu.items)
         self.update_surrounding_quest_status()
 
     def check_quest_requirements(self, quest):
@@ -156,11 +164,11 @@ class QuestManager(object):
             return False
 
         # Has the character already started the next quest in the chain
-        if quest.NextQuestInChain > 0 and quest.NextQuestInChain in self.active_quests:
+        if quest.NextQuestInChain > 0 and quest.NextQuestInChain in self.done_quests:
             return False
 
         # Does the character have the previous quest
-        if quest.PrevQuestId > 0 and quest.PrevQuestId not in self.active_quests:
+        if quest.PrevQuestId > 0 and quest.PrevQuestId not in self.done_quests:
             return False
 
         # TODO: Does the character have the required skill
@@ -413,7 +421,47 @@ class QuestManager(object):
 
         self.player_mgr.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_QUEST_QUERY_RESPONSE, data))
 
-    def add_quest(self, quest_id, quest_giver_guid):
+    def send_quest_giver_offer_reward(self, active_quest, quest_giver_guid, enablenext=False):
+        # CGPlayer_C::OnQuestGiverChooseReward
+        quest = active_quest.quest
+        quest_title = PacketWriter.string_to_bytes(quest.Title)
+        quest_offer_reward_text = PacketWriter.string_to_bytes(quest.OfferRewardText)
+        data = pack(
+            f'<QI{len(quest_title)}s{len(quest_offer_reward_text)}sI',
+            quest_giver_guid,
+            quest.entry,
+            quest_title,
+            quest_offer_reward_text,
+            0,  # enablenext
+        )
+
+        # Emote count
+        data += pack('<I', 0)
+        #for i in range(4):
+        #    data += pack('<2I', 0, 0)
+
+        # Reward choices
+        rew_choice_item_list = list(filter((0).__ne__, self.generate_rew_choice_item_list(quest)))
+        rew_choice_count_list = list(filter((0).__ne__, self.generate_rew_choice_count_list(quest)))
+        data += pack('<I', len(rew_choice_item_list))
+        for index, item in enumerate(rew_choice_item_list):
+            data += _gen_item_struct(item, rew_choice_count_list[index])
+
+        # Required items
+        req_item_list = list(filter((0).__ne__, self.generate_req_item_list(quest)))
+        req_count_list = list(filter((0).__ne__, self.generate_req_item_count_list(quest)))
+        data += pack('<I', len(req_item_list))
+        for index, item in enumerate(req_item_list):
+            data += _gen_item_struct(item, req_count_list[index], include_display_id=False)
+
+        # Reward
+        data += pack('<I', quest.RewOrReqMoney if quest.RewOrReqMoney >= 0 else -quest.RewOrReqMoney)
+        data += pack('<I', quest.RewSpell)
+        data += pack('<I', quest.RewSpellCast)
+
+        self.player_mgr.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_QUESTGIVER_OFFER_REWARD, data))
+
+    def handle_add_quest(self, quest_id, quest_giver_guid):
         active_quest = ActiveQuest(quest_id)
         self.active_quests[quest_id] = active_quest
         self.send_quest_query_response(active_quest)
@@ -426,21 +474,67 @@ class QuestManager(object):
         self.build_update()
         self.player_mgr.send_update_self()
 
-        db_quest = CharacterQuestStatus()
-        db_quest.guid = self.player_mgr.guid
-        db_quest.quest = quest_id
-        db_quest.status = int(active_quest.state)
-        RealmDatabaseManager.character_add_quest(db_quest)
+        RealmDatabaseManager.character_add_quest(self.make_db_quest(active_quest))
 
-    def remove_quest(self, slot):
+    def handle_remove_quest(self, slot):
         quest_id = self.player_mgr.get_uint32(PlayerFields.PLAYER_QUEST_LOG_1_1 + (slot * 6))
         if quest_id in self.active_quests:
-            del self.active_quests[quest_id]
-            self.update_surrounding_quest_status()
-            self.set_questlog_entry(len(self.active_quests), 0)
-            self.build_update()
-            self.player_mgr.send_update_self()
+            self.remove_from_questlog(quest_id)
             RealmDatabaseManager.character_delete_quest(self.player_mgr.guid, quest_id)
+
+    def make_db_quest(self, active_quest):
+        db_quest = CharacterQuestStatus()
+        db_quest.guid = self.player_mgr.guid
+        db_quest.quest = active_quest.quest_id
+        db_quest.status = int(active_quest.state)
+        return db_quest
+
+    def handle_complete_quest(self, quest_id, quest_giver_guid):
+        if quest_id not in self.active_quests:
+            return
+        active_quest = self.active_quests[quest_id]
+        if not self.is_quest_complete(active_quest, quest_giver_guid):
+            return
+        self.send_quest_giver_offer_reward(active_quest, quest_giver_guid, True)
+
+    def handle_choose_reward(self, quest_giver_guid, quest_id, item_choice):
+        if quest_id not in self.active_quests:
+            return
+        active_quest = self.active_quests[quest_id]
+        if not self.is_quest_complete(active_quest, quest_giver_guid):
+            return
+
+        self.reward_xp(active_quest)
+        self.reward_gold(active_quest)
+        #self.reward_item(active_quest, item_choice)
+
+        self.remove_from_questlog(quest_id)
+        self.done_quests[quest_id] = True
+
+        active_quest.state = QuestState.QUEST_DONE
+        RealmDatabaseManager.character_update_quest(self.make_db_quest(active_quest))
+
+        if active_quest.quest.NextQuestInChain > 0:
+            next_quest_id = active_quest.quest.NextQuestInChain
+            if next_quest_id not in self.active_quests and next_quest_id not in self.done_quests:
+                next_quest = WorldDatabaseManager.QuestTemplateHolder.quest_get_by_entry(next_quest_id)
+                self.send_quest_giver_quest_details(next_quest, quest_giver_guid, True)
+
+        # TODO: If no next quest, how to get the dialog to close? (maybe CGUnit_C::NPCFlagChanged)
+
+    def remove_from_questlog(self, quest_id):
+        del self.active_quests[quest_id]
+        self.update_surrounding_quest_status()
+        self.set_questlog_entry(len(self.active_quests), 0)
+        self.build_update()
+        self.player_mgr.send_update_self()
+
+    def reward_xp(self, active_quest):
+        self.player_mgr.give_xp([Formulas.PlayerFormulas.quest_xp_reward(active_quest.quest.QuestLevel, self.player_mgr.level, active_quest.quest.RewXP)])
+
+    def reward_gold(self, active_quest):
+        if active_quest.quest.RewOrReqMoney != 0:
+            self.player_mgr.mod_money(active_quest.quest.RewOrReqMoney)
 
     def build_update(self):
         for slot, quest_id in enumerate(self.active_quests.keys()):
@@ -484,6 +578,11 @@ class QuestManager(object):
     def complete_quest(self, active_quest):
         active_quest.state = QuestState.QUEST_REWARD
 
+    def is_quest_complete(self, active_quest, quest_giver_guid):
+        if active_quest.state != QuestState.QUEST_REWARD:
+            return False
+        # TODO: check that quest_giver_guid is turn-in for quest_id
+        return True
 
 class QuestMenu:
     class QuestMenuItem(NamedTuple):

--- a/game/world/opcode_handling/Definitions.py
+++ b/game/world/opcode_handling/Definitions.py
@@ -68,6 +68,8 @@ from game.world.opcode_handling.handlers.quest.QuestGiverStatusHandler import Qu
 from game.world.opcode_handling.handlers.quest.QuestGiverHelloHandler import QuestGiverHelloHandler
 from game.world.opcode_handling.handlers.quest.QuestGiverQueryQuestHandler import QuestGiverQueryQuestHandler
 from game.world.opcode_handling.handlers.quest.QuestGiverAcceptQuestHandler import QuestGiverAcceptQuestHandler
+from game.world.opcode_handling.handlers.quest.QuestGiverCompleteQuestHandler import QuestGiverCompleteQuestHandler
+from game.world.opcode_handling.handlers.quest.QuestGiverChooseRewardHandler import QuestGiverChooseRewardHandler
 from game.world.opcode_handling.handlers.quest.QuestGiverRemoveQuestHandler import QuestGiverRemoveQuestHandler
 from game.world.opcode_handling.handlers.group.GroupInviteHandler import GroupInviteHandler
 from game.world.opcode_handling.handlers.group.GroupInviteAcceptHandler import GroupInviteAcceptHandler
@@ -199,6 +201,8 @@ HANDLER_DEFINITIONS = {
     OpCode.CMSG_QUESTGIVER_HELLO: QuestGiverHelloHandler.handle,
     OpCode.CMSG_QUESTGIVER_QUERY_QUEST: QuestGiverQueryQuestHandler.handle,
     OpCode.CMSG_QUESTGIVER_ACCEPT_QUEST: QuestGiverAcceptQuestHandler.handle,
+    OpCode.CMSG_QUESTGIVER_COMPLETE_QUEST: QuestGiverCompleteQuestHandler.handle,
+    OpCode.CMSG_QUESTGIVER_CHOOSE_REWARD: QuestGiverChooseRewardHandler.handle,
     OpCode.CMSG_QUESTLOG_REMOVE_QUEST: QuestGiverRemoveQuestHandler.handle,
     OpCode.CMSG_GROUP_INVITE: GroupInviteHandler.handle,
     OpCode.CMSG_GROUP_ACCEPT: GroupInviteAcceptHandler.handle,

--- a/game/world/opcode_handling/handlers/quest/QuestGiverChooseRewardHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverChooseRewardHandler.py
@@ -1,0 +1,22 @@
+from struct import unpack
+
+from game.world.managers.GridManager import GridManager
+from utils.Logger import Logger
+
+
+class QuestGiverChooseRewardHandler(object):
+
+    @staticmethod
+    def handle(world_session, socket, reader):
+        # CGPlayer_C::GetQuestReward
+        if len(reader.data) >= 16:  # Avoid handling empty packet
+            quest_giver_guid, quest_id, item_choice = unpack ('<Q2I', reader.data[:16])
+            quest_giver = GridManager.get_surrounding_unit_by_guid(world_session.player_mgr, quest_giver_guid)
+            if not quest_giver:
+                Logger.error(f'Error in CMSG_QUESTGIVER_COMPLETE_QUEST, could not find quest giver with guid of: {quest_giver_guid}')
+                return 0
+            if world_session.player_mgr.is_enemy_to(quest_giver):
+                return 0
+
+            world_session.player_mgr.quest_manager.handle_choose_reward(quest_giver_guid, quest_id, item_choice)
+        return 0

--- a/game/world/opcode_handling/handlers/quest/QuestGiverCompleteQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverCompleteQuestHandler.py
@@ -4,7 +4,7 @@ from game.world.managers.GridManager import GridManager
 from utils.Logger import Logger
 
 
-class QuestGiverAcceptQuestHandler(object):
+class QuestGiverCompleteQuestHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
@@ -12,10 +12,10 @@ class QuestGiverAcceptQuestHandler(object):
             quest_giver_guid, quest_id = unpack ('<QI', reader.data[:12])
             quest_giver = GridManager.get_surrounding_unit_by_guid(world_session.player_mgr, quest_giver_guid)
             if not quest_giver:
-                Logger.error(f'Error in CMSG_QUESTGIVER_ACCEPT_QUEST, could not find quest giver with guid of: {quest_giver_guid}')
+                Logger.error(f'Error in CMSG_QUESTGIVER_COMPLETE_QUEST, could not find quest giver with guid of: {quest_giver_guid}')
                 return 0
             if world_session.player_mgr.is_enemy_to(quest_giver):
                 return 0
 
-            world_session.player_mgr.quest_manager.handle_add_quest(quest_id, quest_giver_guid)
+            world_session.player_mgr.quest_manager.handle_complete_quest(quest_id, quest_giver_guid)
         return 0

--- a/game/world/opcode_handling/handlers/quest/QuestGiverRemoveQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverRemoveQuestHandler.py
@@ -7,5 +7,5 @@ class QuestGiverRemoveQuestHandler(object):
     def handle(world_session, socket, reader):
         if len(reader.data) >= 1:  # Avoid handling empty quest giver remove quest packet
             slot = unpack('<B', reader.data[:1])[0]
-            world_session.player_mgr.quest_manager.remove_quest(slot)
+            world_session.player_mgr.quest_manager.handle_remove_quest(slot)
         return 0

--- a/utils/Formulas.py
+++ b/utils/Formulas.py
@@ -123,3 +123,18 @@ class PlayerFormulas(object):
 
         # Always round to the nearest hundred
         return int(round(((8 * level) + diff) * PlayerFormulas.base_xp_per_mob(level) + 1, -2))
+
+    @staticmethod
+    def quest_xp_reward(quest_level, player_level, rew_xp):
+        if player_level <= quest_level + 5:
+            return rew_xp
+        elif player_level == quest_level + 6:
+            return math.ceil(rew_xp * 0.8)
+        elif player_level == quest_level + 7:
+            return math.ceil(rew_xp * 0.6)
+        elif player_level == quest_level + 8:
+            return math.ceil(rew_xp * 0.4)
+        elif player_level == quest_level + 9:
+            return math.ceil(rew_xp * 0.2)
+        else:
+            return math.ceil(rew_xp * 0.1)

--- a/utils/constants/ObjectCodes.py
+++ b/utils/constants/ObjectCodes.py
@@ -269,7 +269,8 @@ class QuestState(IntEnum):
     QUEST_OFFER = 1
     QUEST_ACCEPTED = 2
     QUEST_REWARD = 3
-    QUEST_STATE_NUM_TYPES = 4
+    QUEST_DONE = 4
+    QUEST_STATE_NUM_TYPES = 5
 
 
 class QuestFailedReasons(IntEnum):


### PR DESCRIPTION
- add character_update_quest to RealmDatabaseManager
  - used to set quest to DONE
- add done_quests dict to QuestManager
- populate done quests when the player enters the world
- don't let done quests affect the quest giver status
- name consistency
  - quest_giver_guid
  - methods called from handlers start with handle_
    - handle_add_quest
    - handle_choose_reward
    - handle_complete_quest
    - handle_remove_quest
    - the quest menu stuff not done yet
- omit done quests from the quest giver menu
- go right to the rewards menu if the quest giver menu has a single quest, and its REWARD status
- check quest requirements checks that a quest is done rather than just accepted
- handle quest complete
  - send_quest_giver_offer_reward()
  - handle_complete_quest()
  - is_quest_complete()
  - only instant complete quests are supported at the moment
- handle quest rewards
  - handle_choose_reward()
  - reward_xp()
  - reward_gold()
  - quest_xp_reward() - scale xp by level
  - add pseudo quest status QUEST_DONE
- refactor: add method to make a db_quest struct, make_db_quest()
  - used when adding a quest
  - used when completing a quest
- refactor: add remove_from_questlog()
  - used when abandoning a quest
  - used when completing a quest