### PR TITLE
Initial work on FactionManager/Reputations and Proficiencies.

### DIFF
--- a/database/dbc/DbcDatabaseManager.py
+++ b/database/dbc/DbcDatabaseManager.py
@@ -302,6 +302,13 @@ class DbcDatabaseManager(object):
     # Faction
 
     @staticmethod
+    def factions_get_all():
+        dbc_db_session = SessionHolder()
+        factions = dbc_db_session.query(Faction).all()
+        dbc_db_session.close()
+        return factions
+
+    @staticmethod
     def faction_template_get_by_id(faction_id):
         dbc_db_session = SessionHolder()
         res = dbc_db_session.query(FactionTemplate).filter_by(ID=faction_id).first()

--- a/database/dbc/DbcDatabaseManager.py
+++ b/database/dbc/DbcDatabaseManager.py
@@ -27,6 +27,14 @@ class DbcDatabaseManager(object):
         dbc_db_session.close()
         return res
 
+    @staticmethod
+    def char_get_proficiency(race, class_):
+        dbc_db_session = SessionHolder()
+        base_info = dbc_db_session.query(CharBaseInfo).filter_by(RaceID=race, ClassID=class_).first()
+        proficiency = dbc_db_session.query(ChrProficiency).filter_by(ID=base_info.Proficiency).first()
+        dbc_db_session.close()
+        return proficiency
+
     # AreaTrigger
 
     @staticmethod
@@ -307,10 +315,3 @@ class DbcDatabaseManager(object):
         factions = dbc_db_session.query(Faction).all()
         dbc_db_session.close()
         return factions
-
-    @staticmethod
-    def faction_template_get_by_id(faction_id):
-        dbc_db_session = SessionHolder()
-        res = dbc_db_session.query(FactionTemplate).filter_by(ID=faction_id).first()
-        dbc_db_session.close()
-        return res

--- a/database/dbc/DbcModels.py
+++ b/database/dbc/DbcModels.py
@@ -2,6 +2,7 @@
 from sqlalchemy import Column, Float, Text, text
 from sqlalchemy.dialects.mysql import INTEGER, TINYINT
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
 
 Base = declarative_base()
 metadata = Base.metadata
@@ -391,6 +392,14 @@ class Faction(Base):
     Name_zhCN = Column(Text)
     Name_enTW = Column(Text)
     Name_Mask = Column(INTEGER(10), nullable=False, server_default=text("'0'"))
+
+    faction_templates = relationship('FactionTemplate',
+                                     foreign_keys='FactionTemplate.Faction',
+                                     primaryjoin="Faction.ID == FactionTemplate.Faction",
+                                     uselist=True,
+                                     viewonly=True,
+                                     lazy='joined'
+                                     )
 
 
 class FactionGroup(Base):

--- a/database/realm/RealmDatabaseManager.py
+++ b/database/realm/RealmDatabaseManager.py
@@ -350,6 +350,21 @@ class RealmDatabaseManager(object):
             realm_db_session.merge(quest_status)
             realm_db_session.flush()
             realm_db_session.close()
+
+    @staticmethod
+    def charater_get_reputations(character):
+        realm_db_session = SessionHolder()
+        reputations = realm_db_session.query(CharacterReputation).filter_by(character=character.guid & ~HighGuid.HIGHGUID_PLAYER).all()
+        realm_db_session.close()
+        return reputations
+
+    @staticmethod
+    def character_add_reputation(reputation):
+        realm_db_session = SessionHolder()
+        realm_db_session.add(reputation)
+        realm_db_session.flush()
+        realm_db_session.refresh(reputation)
+        realm_db_session.close()
     
     # Ticket stuff
 

--- a/database/realm/RealmModels.py
+++ b/database/realm/RealmModels.py
@@ -183,6 +183,18 @@ class CharacterQuestState(Base):
     character = relationship('Character')
 
 
+class CharacterReputation(Base):
+    __tablename__ = 'character_reputation'
+
+    character = Column(ForeignKey('characters.guid', ondelete='CASCADE', onupdate='CASCADE'), primary_key=True, nullable=False, server_default=text("'0'"))
+    faction = Column(INTEGER(11), primary_key=True, nullable=False, server_default=text("'0'"))
+    standing = Column(INTEGER(11), nullable=False, server_default=text("'0'"))
+    flags = Column(TINYINT(1), nullable=False, server_default=text("'0'"))
+    index = Column(INTEGER(5), nullable=False)
+
+    character1 = relationship('Character')
+
+
 class Guild(Base):
     __tablename__ = 'guild'
 

--- a/etc/databases/realm/updates/updates.sql
+++ b/etc/databases/realm/updates/updates.sql
@@ -1,0 +1,18 @@
+delimiter $
+begin not atomic
+	-- 15/05/2021 1
+	if (select count(*) from applied_updates where id='150520211') = 0 then
+		DROP TABLE IF EXISTS `character_reputation`;
+		CREATE TABLE IF NOT EXISTS `character_reputation` (
+		`character` int(11) unsigned NOT NULL DEFAULT 0,
+		`faction` int(11) unsigned NOT NULL DEFAULT 0,
+		`standing` int(11) NOT NULL DEFAULT 0,
+		`flags` tinyint(1) unsigned NOT NULL DEFAULT 0,
+		`index` int(5) NOT NULL,
+		PRIMARY KEY (`character`,`faction`),
+		CONSTRAINT `fk_character_reputation_character` FOREIGN KEY (`character`) REFERENCES `characters` (`guid`) ON DELETE CASCADE ON UPDATE CASCADE
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8;	
+		insert into applied_updates values ('150520211');
+    end if;
+end $
+delimiter ;

--- a/etc/databases/realm/updates/updates.txt
+++ b/etc/databases/realm/updates/updates.txt
@@ -1,9 +1,0 @@
-CREATE TABLE IF NOT EXISTS `character_reputation` (
-  `character` int(11) unsigned NOT NULL DEFAULT 0,
-  `faction` int(11) unsigned NOT NULL DEFAULT 0,
-  `standing` int(11) NOT NULL DEFAULT 0,
-  `flags` tinyint(1) unsigned NOT NULL DEFAULT 0,
-  `index` int(5) NOT NULL,
-  PRIMARY KEY (`character`,`faction`),
-  CONSTRAINT `fk_character_reputation_character` FOREIGN KEY (`character`) REFERENCES `characters` (`guid`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/etc/databases/realm/updates/updates.txt
+++ b/etc/databases/realm/updates/updates.txt
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS `character_reputation` (
+  `character` int(11) unsigned NOT NULL DEFAULT 0,
+  `faction` int(11) unsigned NOT NULL DEFAULT 0,
+  `standing` int(11) NOT NULL DEFAULT 0,
+  `flags` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `index` int(5) NOT NULL,
+  PRIMARY KEY (`character`,`faction`),
+  CONSTRAINT `fk_character_reputation_character` FOREIGN KEY (`character`) REFERENCES `characters` (`guid`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -19,21 +19,19 @@ class WorldLoader:
         MapManager.initialize_maps()
 
         # Gameobject spawns
-        # if config.Server.Settings.load_gameobjects:
-        #     WorldLoader.load_gameobjects()
-        # else:
-        #     Logger.info('Skipped game object loading.')
-        #
-        # # Creature spawns
-        # if config.Server.Settings.load_creatures:
-        #     WorldLoader.load_creature_loot_templates()
-        #     WorldLoader.load_creatures()
-        #     WorldLoader.load_creature_quests()
-        #     WorldLoader.load_creature_involved_quests()
-        # else:
-        #     Logger.info('Skipped creature loading.')
+        if config.Server.Settings.load_gameobjects:
+            WorldLoader.load_gameobjects()
+        else:
+            Logger.info('Skipped game object loading.')
 
-        WorldLoader.load_factions()
+        # Creature spawns
+        if config.Server.Settings.load_creatures:
+            WorldLoader.load_creature_loot_templates()
+            WorldLoader.load_creatures()
+            WorldLoader.load_creature_quests()
+            WorldLoader.load_creature_involved_quests()
+        else:
+            Logger.info('Skipped creature loading.')
 
         WorldLoader.load_item_templates()
         WorldLoader.load_quests()
@@ -44,6 +42,7 @@ class WorldLoader:
         WorldLoader.load_taxi_path_nodes()
 
         # Character related data
+        WorldLoader.load_factions()
         WorldLoader.load_groups()
         WorldLoader.load_guilds()
 

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -4,6 +4,7 @@ from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.managers.maps.MapManager import MapManager
 from game.world.managers.objects.creature.CreatureManager import CreatureManager
 from game.world.managers.objects.GameObjectManager import GameObjectManager
+from game.world.managers.objects.player.FactionManager import FactionManager
 from game.world.managers.objects.player.GroupManager import GroupManager
 from game.world.managers.objects.player.guild.GuildManager import GuildManager
 from utils.ConfigManager import config
@@ -18,19 +19,21 @@ class WorldLoader:
         MapManager.initialize_maps()
 
         # Gameobject spawns
-        if config.Server.Settings.load_gameobjects:
-            WorldLoader.load_gameobjects()
-        else:
-            Logger.info('Skipped game object loading.')
+        # if config.Server.Settings.load_gameobjects:
+        #     WorldLoader.load_gameobjects()
+        # else:
+        #     Logger.info('Skipped game object loading.')
+        #
+        # # Creature spawns
+        # if config.Server.Settings.load_creatures:
+        #     WorldLoader.load_creature_loot_templates()
+        #     WorldLoader.load_creatures()
+        #     WorldLoader.load_creature_quests()
+        #     WorldLoader.load_creature_involved_quests()
+        # else:
+        #     Logger.info('Skipped creature loading.')
 
-        # Creature spawns
-        if config.Server.Settings.load_creatures:
-            WorldLoader.load_creature_loot_templates()
-            WorldLoader.load_creatures()
-            WorldLoader.load_creature_quests()
-            WorldLoader.load_creature_involved_quests()
-        else:
-            Logger.info('Skipped creature loading.')
+        WorldLoader.load_factions()
 
         WorldLoader.load_item_templates()
         WorldLoader.load_quests()
@@ -108,6 +111,20 @@ class WorldLoader:
 
             count += 1
             Logger.progress('Loading item templates...', count, length)
+
+        return length
+
+    @staticmethod
+    def load_factions():
+        factions = DbcDatabaseManager.factions_get_all()
+        length = len(factions)
+        count = 0
+
+        for faction in factions:
+            FactionManager.load_faction(faction)
+
+            count += 1
+            Logger.progress('Loading factions...', count, length)
 
         return length
 

--- a/game/world/managers/objects/UnitManager.py
+++ b/game/world/managers/objects/UnitManager.py
@@ -7,6 +7,7 @@ from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.managers.maps.MapManager import MapManager
 from game.world.managers.objects.MovementManager import MovementManager
 from game.world.managers.objects.ObjectManager import ObjectManager
+from game.world.managers.objects.player.FactionManager import FactionManager
 from game.world.managers.objects.spell.AuraManager import AuraManager
 from game.world.managers.objects.spell.SpellManager import SpellManager
 from network.packet.PacketWriter import PacketWriter, OpCode
@@ -768,29 +769,8 @@ class UnitManager(ObjectManager):
     def get_type_id(self):
         return ObjectTypeIds.ID_UNIT
 
-    def _allegiance_status_checker(self, target, check_friendly=True):
-        own_faction = DbcDatabaseManager.faction_template_get_by_id(self.faction)
-        target_faction = DbcDatabaseManager.faction_template_get_by_id(target.faction)
-        # Some units currently have a bugged faction, terminate the method if this is encountered
-        if not target_faction:
-            return False
-        own_enemies = [own_faction.Enemies_1, own_faction.Enemies_2, own_faction.Enemies_3, own_faction.Enemies_4]
-        own_friends = [own_faction.Friend_1, own_faction.Friend_2, own_faction.Friend_3, own_faction.Friend_4]
-        if target_faction.Faction > 0:
-            for enemy in own_enemies:
-                if enemy == target_faction.Faction:
-                    return not check_friendly
-            for friend in own_friends:
-                if friend == target_faction.Faction:
-                    return check_friendly
-
-        if check_friendly:
-            return ((own_faction.FriendGroup & target_faction.FactionGroup) or (own_faction.FactionGroup & target_faction.FriendGroup)) != 0
-        else:
-            return ((own_faction.EnemyGroup & target_faction.FactionGroup) or (own_faction.FactionGroup & target_faction.EnemyGroup)) != 0
-
     def is_friendly_to(self, target):
-        return self._allegiance_status_checker(target, True)
+        return FactionManager.allegiance_status_checker(self.faction, target.faction, True)
 
     def is_enemy_to(self, target):
-        return self._allegiance_status_checker(target, False)
+        return FactionManager.allegiance_status_checker(self.faction, target.faction, False)

--- a/game/world/managers/objects/player/FactionManager.py
+++ b/game/world/managers/objects/player/FactionManager.py
@@ -1,29 +1,22 @@
-from database.dbc.DbcDatabaseManager import DbcDatabaseManager
-from utils.constants.ObjectCodes import FactionGroupType
-from utils.constants.UnitCodes import Races
+from utils.Logger import Logger
+
 
 class Faction_(object):
     def __init__(self, faction):
-        self.id = faction.ID
+        self.faction_id = faction.ID
         self.faction = faction
-        self.templates = []
+        self.templates = {}
         self.enemies = []
         self.friends = []
-        self.faction_group = None
-        self.friend_group = None
-        self.enemy_group = None
+        self.our_masks = 0
+        self.friends_masks = 0
+        self.enemies_masks = 0
         self.name = faction.Name_enUS
         self.reputation_index = faction.ReputationIndex
         self.reputation_base_value = faction.ReputationBase_1
 
     def has_template(self, id):
         return id in self.templates
-
-    def is_friendly_to(self, faction):
-        return self.faction_group == faction.faction_group
-
-    def is_enemy_to(self, faction):
-        return self.faction_group != faction.faction_group
 
 class FactionManager(object):
     FACTIONS = {}
@@ -32,16 +25,12 @@ class FactionManager(object):
     def load_faction(faction):
         new_faction = Faction_(faction)
 
-        faction_group = 0
-        friend_group = 0
-        enemy_group = 0
-
         for template in faction.faction_templates:
-            new_faction.templates.append(template.ID)
+            new_faction.templates[template.ID] = template
 
-            faction_group |= FactionManager._get_faction_group(template.FactionGroup)
-            friend_group |= FactionManager._get_faction_group(template.FriendGroup)
-            enemy_group |= FactionManager._get_faction_group(template.EnemyGroup)
+            new_faction.our_masks |= template.FactionGroup
+            new_faction.friends_masks |= template.FriendGroup
+            new_faction.enemies_masks |= template.EnemyGroup
 
             new_faction.friends.append(template.Friend_1)
             new_faction.friends.append(template.Friend_2)
@@ -53,15 +42,36 @@ class FactionManager(object):
             new_faction.enemies.append(template.Enemies_3)
             new_faction.enemies.append(template.Enemies_4)
 
-        new_faction.faction_group = FactionManager._get_faction_group(faction_group)
-        new_faction.friend_group = FactionManager._get_faction_group(friend_group)
-        new_faction.enemy_group = FactionManager._get_faction_group(enemy_group)
-
         new_faction.enemies = list(filter((0).__ne__, new_faction.enemies))
         new_faction.friends = list(filter((0).__ne__, new_faction.friends))
-        new_faction.friends.append(new_faction.id)
 
         FactionManager.FACTIONS[faction.ID] = new_faction
+
+    @staticmethod
+    def allegiance_status_checker(source_faction_id, target_faction_id, check_friendly=True):
+        own_faction = FactionManager.get_by_faction_id(source_faction_id)
+        target_faction = FactionManager.get_by_faction_id(target_faction_id)
+
+        # Force lookup if we were unable to locate a direct faction.
+        if not own_faction:
+            own_faction = FactionManager.get_by_template_id(source_faction_id)
+        if not target_faction:
+            target_faction = FactionManager.get_by_template_id(target_faction_id)
+
+        # Some units currently have a bugged faction, terminate the method if this is encountered
+        if not own_faction or not target_faction:
+            Logger.warning(f'Unable to compare factions. {source_faction_id} vs {target_faction_id}')
+            return False
+
+        if own_faction.faction_id in target_faction.enemies:
+            return not check_friendly
+        elif target_faction.faction_id in own_faction.friends:
+            return check_friendly
+
+        if check_friendly:
+            return ((own_faction.friends_masks & target_faction.our_masks) or (own_faction.our_masks & target_faction.friends_masks)) != 0
+        else:
+            return ((own_faction.enemies_masks & target_faction.our_masks) or (own_faction.our_masks & target_faction.enemies_masks)) != 0
 
     @staticmethod
     def get_by_reputation_index(index):
@@ -71,47 +81,14 @@ class FactionManager(object):
         return None
 
     @staticmethod
-    def get_by_id(id):
+    def get_by_faction_id(id):
         if id in FactionManager.FACTIONS:
             return FactionManager.FACTIONS[id]
         return None
 
     @staticmethod
-    def get_by_template(template_id):
+    def get_by_template_id(template_id):
         for faction in FactionManager.FACTIONS.values():
-            for template in faction.faction_templates:
-                if template.ID == template_id:
-                    return faction
+            if template_id in faction.templates:
+                return faction
         return None
-
-    @staticmethod
-    def get_by_race(race):
-        if race <= Races.RACE_TAUREN:
-            return FactionManager.FACTIONS[int(race)]
-        elif race == Races.RACE_GNOME:
-            return FactionManager.FACTIONS[115]
-        elif race == Races.RACE_TROLL:
-            return FactionManager.FACTIONS[116]
-        else:
-            return None
-
-    @staticmethod
-    def are_friendly(race1, race2):
-        faction1 = FactionManager.get_by_race(race1)
-        faction2 = FactionManager.get_by_race(race2)
-        return faction1.is_friendly_to(faction2)
-
-    @staticmethod
-    def _get_faction_group(value):
-        if value == 0:
-            val = FactionGroupType.Default
-        elif value > FactionGroupType.Alliance and value < FactionGroupType.Horde:
-            val = FactionGroupType.Alliance
-        elif value > FactionGroupType.Horde and value < FactionGroupType.Monster:
-            val = FactionGroupType.Horde
-        elif value > FactionGroupType.Monster:
-            val = FactionGroupType.Monster
-        else:
-            val = FactionGroupType(value)
-
-        return val

--- a/game/world/managers/objects/player/FactionManager.py
+++ b/game/world/managers/objects/player/FactionManager.py
@@ -1,0 +1,117 @@
+from database.dbc.DbcDatabaseManager import DbcDatabaseManager
+from utils.constants.ObjectCodes import FactionGroupType
+from utils.constants.UnitCodes import Races
+
+class Faction_(object):
+    def __init__(self, faction):
+        self.id = faction.ID
+        self.faction = faction
+        self.templates = []
+        self.enemies = []
+        self.friends = []
+        self.faction_group = None
+        self.friend_group = None
+        self.enemy_group = None
+        self.name = faction.Name_enUS
+        self.reputation_index = faction.ReputationIndex
+        self.reputation_base_value = faction.ReputationBase_1
+
+    def has_template(self, id):
+        return id in self.templates
+
+    def is_friendly_to(self, faction):
+        return self.faction_group == faction.faction_group
+
+    def is_enemy_to(self, faction):
+        return self.faction_group != faction.faction_group
+
+class FactionManager(object):
+    FACTIONS = {}
+
+    @staticmethod
+    def load_faction(faction):
+        new_faction = Faction_(faction)
+
+        faction_group = 0
+        friend_group = 0
+        enemy_group = 0
+
+        for template in faction.faction_templates:
+            new_faction.templates.append(template.ID)
+
+            faction_group |= FactionManager._get_faction_group(template.FactionGroup)
+            friend_group |= FactionManager._get_faction_group(template.FriendGroup)
+            enemy_group |= FactionManager._get_faction_group(template.EnemyGroup)
+
+            new_faction.friends.append(template.Friend_1)
+            new_faction.friends.append(template.Friend_2)
+            new_faction.friends.append(template.Friend_3)
+            new_faction.friends.append(template.Friend_4)
+
+            new_faction.enemies.append(template.Enemies_1)
+            new_faction.enemies.append(template.Enemies_2)
+            new_faction.enemies.append(template.Enemies_3)
+            new_faction.enemies.append(template.Enemies_4)
+
+        new_faction.faction_group = FactionManager._get_faction_group(faction_group)
+        new_faction.friend_group = FactionManager._get_faction_group(friend_group)
+        new_faction.enemy_group = FactionManager._get_faction_group(enemy_group)
+
+        new_faction.enemies = list(filter((0).__ne__, new_faction.enemies))
+        new_faction.friends = list(filter((0).__ne__, new_faction.friends))
+        new_faction.friends.append(new_faction.id)
+
+        FactionManager.FACTIONS[faction.ID] = new_faction
+
+    @staticmethod
+    def get_by_reputation_index(index):
+        for faction in FactionManager.FACTIONS.values():
+            if faction.reputation_index == index and index > -1:
+                return faction
+        return None
+
+    @staticmethod
+    def get_by_id(id):
+        if id in FactionManager.FACTIONS:
+            return FactionManager.FACTIONS[id]
+        return None
+
+    @staticmethod
+    def get_by_template(template_id):
+        for faction in FactionManager.FACTIONS.values():
+            for template in faction.faction_templates:
+                if template.ID == template_id:
+                    return faction
+        return None
+
+    @staticmethod
+    def get_by_race(race):
+        if race <= Races.RACE_TAUREN:
+            return FactionManager.FACTIONS[int(race)]
+        elif race == Races.RACE_GNOME:
+            return FactionManager.FACTIONS[115]
+        elif race == Races.RACE_TROLL:
+            return FactionManager.FACTIONS[116]
+        else:
+            return None
+
+    @staticmethod
+    def are_friendly(race1, race2):
+        faction1 = FactionManager.get_by_race(race1)
+        faction2 = FactionManager.get_by_race(race2)
+        return faction1.is_friendly_to(faction2)
+
+    @staticmethod
+    def _get_faction_group(value):
+        if value == 0:
+            val = FactionGroupType.Default
+        elif value > FactionGroupType.Alliance and value < FactionGroupType.Horde:
+            val = FactionGroupType.Alliance
+        elif value > FactionGroupType.Horde and value < FactionGroupType.Monster:
+            val = FactionGroupType.Horde
+        elif value > FactionGroupType.Monster:
+            val = FactionGroupType.Monster
+        else:
+            val = FactionGroupType(value)
+
+        return val

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -415,13 +415,13 @@ class PlayerManager(UnitManager):
         self.map_ = self.teleport_destination_map
         self.location = Vector(self.teleport_destination.x, self.teleport_destination.y, self.teleport_destination.z, self.teleport_destination.o)
 
+        # Get us in a new grid.
+        MapManager.update_object(self)
+
         # Get us in world again.
         self.send_update_self(create=True if not self.is_relocating else False,
                               force_inventory_update=True if not self.is_relocating else False,
                               reset_fields=False)
-
-        # Get us in a new grid.
-        MapManager.update_object(self)
 
         self.send_update_surrounding(self.generate_proper_update_packet(
             create=True if not self.is_relocating else False),

--- a/game/world/managers/objects/player/ReputationManager.py
+++ b/game/world/managers/objects/player/ReputationManager.py
@@ -12,7 +12,7 @@ class ReputationManager(object):
 
     @staticmethod
     def send_player_reputations(player_mgr):
-        # Let the client initialize its internet faction db.
+        # Let the client initialize its internal faction db.
         data = pack('<I', 64)  # Client always except 64 factions.
         for i in range(0, 64):
             data += pack('<Bi', 0, 0)

--- a/game/world/managers/objects/player/ReputationManager.py
+++ b/game/world/managers/objects/player/ReputationManager.py
@@ -1,44 +1,63 @@
 from struct import pack
-
+from utils.constants.UnitCodes import UnitReaction
 from database.realm.RealmDatabaseManager import RealmDatabaseManager
 from network.packet.PacketWriter import PacketWriter
-from utils.constants.ObjectCodes import ReputationReacion
+from utils.constants.ObjectCodes import ReputationFlag
 from utils.constants.OpCodes import OpCode
 
 
+# TODO: In the future, each player should have its own ReputatoinManager, taking care of individual states.
+#  Still, it looks like rep system was practically barebones, we need more information.
 class ReputationManager(object):
 
     @staticmethod
     def send_player_reputations(player_mgr):
         reputations = RealmDatabaseManager.charater_get_reputations(player_mgr.player)
-        rep_dict = {}
-        for reputation in reputations:
-            print(reputation.index)
-            rep_dict[reputation.index] = reputation
+        reputations_dict = {x.index: x for x in reputations}
+        visible_factions = []
 
         data = pack('<I', 64)  # Client always except 64 factions.
-        for rep_index in range(0, 64):
-            if rep_index in rep_dict:
-                data += pack('<Bi', rep_dict[rep_index].flags, rep_dict[rep_index].standing)
+        for i in range(0, 64):
+            if i in reputations_dict:
+                data += pack('<Bi', reputations[i].flags, reputations[i].standing)
+                visible_factions.append(PacketWriter.get_packet(OpCode.SMSG_SET_FACTION_VISIBLE, pack('<I', i)))
             else:
                 data += pack('<Bi', 0, 0)
 
         packet = PacketWriter.get_packet(OpCode.SMSG_INITIALIZE_FACTIONS, data)
         player_mgr.session.enqueue_packet(packet)
 
+        # Force those factions with index > -1 to be shown on the client.
+        for packet in visible_factions:
+            player_mgr.session.enqueue_packet(packet)
+
     @staticmethod
-    def get_reaction(standing):
-        if standing >= 2100:
-            return ReputationReacion.REVERED
-        elif standing >= 900:
-            return ReputationReacion.FRIENDLY
-        elif standing >= 300:
-            return ReputationReacion.AMIABLE
-        elif standing >= 0:
-            return ReputationReacion.NEUTRAL
-        elif standing >= -300:
-            return ReputationReacion.UNFRIENDLY
-        elif standing >- -600:
-            return ReputationReacion.HOSTILE
+    def get_reputation_flag(faction):
+        reaction = ReputationManager.get_reaction(faction)
+        if reaction < UnitReaction.UNIT_REACTION_UNFRIENDLY:
+            return int(ReputationFlag.ATWAR)
         else:
-            return ReputationReacion.HATED
+            return int(ReputationFlag.HIDDEN)
+
+    @staticmethod
+    def get_stainding(faction):
+        return faction.reputation_base_value
+
+    @staticmethod
+    def get_reaction(faction):
+        standing = ReputationManager.get_stainding(faction)
+
+        if standing >= 2100:
+            return UnitReaction.UNIT_REACTION_REVERED
+        elif standing >= 900:
+            return UnitReaction.UNIT_REACTION_FRIENDLY
+        elif standing >= 300:
+            return UnitReaction.UNIT_REACTION_AMIABLE
+        elif standing >= 0:
+            return UnitReaction.UNIT_REACTION_NEUTRAL
+        elif standing >= -300:
+            return UnitReaction.UNIT_REACTION_UNFRIENDLY
+        elif standing >- -600:
+            return UnitReaction.UNIT_REACTION_HOSTILE
+        else:
+            return UnitReaction.UNIT_REACTION_HATED

--- a/game/world/managers/objects/player/ReputationManager.py
+++ b/game/world/managers/objects/player/ReputationManager.py
@@ -40,12 +40,12 @@ class ReputationManager(object):
             return int(ReputationFlag.HIDDEN)
 
     @staticmethod
-    def get_stainding(faction):
+    def get_standing(faction):
         return faction.reputation_base_value
 
     @staticmethod
     def get_reaction(faction):
-        standing = ReputationManager.get_stainding(faction)
+        standing = ReputationManager.get_standing(faction)
 
         if standing >= 2100:
             return UnitReaction.UNIT_REACTION_REVERED
@@ -57,7 +57,7 @@ class ReputationManager(object):
             return UnitReaction.UNIT_REACTION_NEUTRAL
         elif standing >= -300:
             return UnitReaction.UNIT_REACTION_UNFRIENDLY
-        elif standing >- -600:
+        elif standing > - -600:
             return UnitReaction.UNIT_REACTION_HOSTILE
         else:
             return UnitReaction.UNIT_REACTION_HATED

--- a/game/world/managers/objects/player/ReputationManager.py
+++ b/game/world/managers/objects/player/ReputationManager.py
@@ -57,7 +57,7 @@ class ReputationManager(object):
             return UnitReaction.UNIT_REACTION_NEUTRAL
         elif standing >= -300:
             return UnitReaction.UNIT_REACTION_UNFRIENDLY
-        elif standing > - -600:
+        elif standing >= -600:
             return UnitReaction.UNIT_REACTION_HOSTILE
         else:
             return UnitReaction.UNIT_REACTION_HATED

--- a/game/world/managers/objects/player/ReputationManager.py
+++ b/game/world/managers/objects/player/ReputationManager.py
@@ -1,0 +1,44 @@
+from struct import pack
+
+from database.realm.RealmDatabaseManager import RealmDatabaseManager
+from network.packet.PacketWriter import PacketWriter
+from utils.constants.ObjectCodes import ReputationReacion
+from utils.constants.OpCodes import OpCode
+
+
+class ReputationManager(object):
+
+    @staticmethod
+    def send_player_reputations(player_mgr):
+        reputations = RealmDatabaseManager.charater_get_reputations(player_mgr.player)
+        rep_dict = {}
+        for reputation in reputations:
+            print(reputation.index)
+            rep_dict[reputation.index] = reputation
+
+        data = pack('<I', 64)  # Client always except 64 factions.
+        for rep_index in range(0, 64):
+            if rep_index in rep_dict:
+                data += pack('<Bi', rep_dict[rep_index].flags, rep_dict[rep_index].standing)
+            else:
+                data += pack('<Bi', 0, 0)
+
+        packet = PacketWriter.get_packet(OpCode.SMSG_INITIALIZE_FACTIONS, data)
+        player_mgr.session.enqueue_packet(packet)
+
+    @staticmethod
+    def get_reaction(standing):
+        if standing >= 2100:
+            return ReputationReacion.REVERED
+        elif standing >= 900:
+            return ReputationReacion.FRIENDLY
+        elif standing >= 300:
+            return ReputationReacion.AMIABLE
+        elif standing >= 0:
+            return ReputationReacion.NEUTRAL
+        elif standing >= -300:
+            return ReputationReacion.UNFRIENDLY
+        elif standing >- -600:
+            return ReputationReacion.HOSTILE
+        else:
+            return ReputationReacion.HATED

--- a/game/world/managers/objects/player/SkillManager.py
+++ b/game/world/managers/objects/player/SkillManager.py
@@ -238,7 +238,7 @@ class SkillManager(object):
         packets = []
         for proficiency in self.proficiencies:
             # TODO: Should check skill rank against proficiency.min_level, not sure how to map itemsubclass to the skill
-            if proficiency.acquire_method == 0:  # and player skill rank > proficiency.min_level
+            if proficiency.acquire_method == 0:  # and player skill rank < proficiency.min_level
                 continue
             if proficiency.acquire_method == 1 and self.player_mgr.level < proficiency.min_level:
                 continue

--- a/game/world/managers/objects/player/SkillManager.py
+++ b/game/world/managers/objects/player/SkillManager.py
@@ -238,11 +238,11 @@ class SkillManager(object):
         packets = []
         for proficiency in self.proficiencies:
             # TODO: Should check skill rank against proficiency.min_level, not sure how to map itemsubclass to the skill
-            if proficiency.acquire_method == 0: # and player skill rank > proficiency.min_level
+            if proficiency.acquire_method == 0:  # and player skill rank > proficiency.min_level
                 continue
             if proficiency.acquire_method == 1 and self.player_mgr.level < proficiency.min_level:
                 continue
-            if proficiency.acquire_method < 0: #  Not sure what this means.
+            if proficiency.acquire_method < 0:  # Not sure what this means '-1'.
                 continue
             data = pack('<bI', proficiency.item_class, proficiency.item_subclass_mask)
             packets.append(PacketWriter.get_packet(OpCode.SMSG_SET_PROFICIENCY, data))

--- a/game/world/managers/objects/player/proficiencies/proficiency.py
+++ b/game/world/managers/objects/player/proficiencies/proficiency.py
@@ -7,135 +7,104 @@ class Proficiency(object):
 
     @staticmethod
     def build_from_chr_proficiency(chr_proficiency):
-        proficiencies = []
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_1,
-                        chr_proficiency.Proficiency_AcquireMethod_1,
-                        chr_proficiency.Proficiency_ItemClass_1,
-                        chr_proficiency.Proficiency_ItemSubClassMask_1,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_2,
-                        chr_proficiency.Proficiency_AcquireMethod_2,
-                        chr_proficiency.Proficiency_ItemClass_2,
-                        chr_proficiency.Proficiency_ItemSubClassMask_2,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_3,
-                        chr_proficiency.Proficiency_AcquireMethod_3,
-                        chr_proficiency.Proficiency_ItemClass_3,
-                        chr_proficiency.Proficiency_ItemSubClassMask_3,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_4,
-                        chr_proficiency.Proficiency_AcquireMethod_4,
-                        chr_proficiency.Proficiency_ItemClass_4,
-                        chr_proficiency.Proficiency_ItemSubClassMask_4,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_5,
-                        chr_proficiency.Proficiency_AcquireMethod_5,
-                        chr_proficiency.Proficiency_ItemClass_5,
-                        chr_proficiency.Proficiency_ItemSubClassMask_5,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_6,
-                        chr_proficiency.Proficiency_AcquireMethod_6,
-                        chr_proficiency.Proficiency_ItemClass_6,
-                        chr_proficiency.Proficiency_ItemSubClassMask_6,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_7,
-                        chr_proficiency.Proficiency_AcquireMethod_7,
-                        chr_proficiency.Proficiency_ItemClass_7,
-                        chr_proficiency.Proficiency_ItemSubClassMask_7,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_8,
-                        chr_proficiency.Proficiency_AcquireMethod_8,
-                        chr_proficiency.Proficiency_ItemClass_8,
-                        chr_proficiency.Proficiency_ItemSubClassMask_8,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_9,
-                        chr_proficiency.Proficiency_AcquireMethod_9,
-                        chr_proficiency.Proficiency_ItemClass_9,
-                        chr_proficiency.Proficiency_ItemSubClassMask_9,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_10,
-                        chr_proficiency.Proficiency_AcquireMethod_10,
-                        chr_proficiency.Proficiency_ItemClass_10,
-                        chr_proficiency.Proficiency_ItemSubClassMask_10,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_11,
-                        chr_proficiency.Proficiency_AcquireMethod_11,
-                        chr_proficiency.Proficiency_ItemClass_11,
-                        chr_proficiency.Proficiency_ItemSubClassMask_11,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_12,
-                        chr_proficiency.Proficiency_AcquireMethod_12,
-                        chr_proficiency.Proficiency_ItemClass_12,
-                        chr_proficiency.Proficiency_ItemSubClassMask_12,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_13,
-                        chr_proficiency.Proficiency_AcquireMethod_13,
-                        chr_proficiency.Proficiency_ItemClass_13,
-                        chr_proficiency.Proficiency_ItemSubClassMask_13,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_14,
-                        chr_proficiency.Proficiency_AcquireMethod_14,
-                        chr_proficiency.Proficiency_ItemClass_14,
-                        chr_proficiency.Proficiency_ItemSubClassMask_14,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_15,
-                        chr_proficiency.Proficiency_AcquireMethod_15,
-                        chr_proficiency.Proficiency_ItemClass_15,
-                        chr_proficiency.Proficiency_ItemSubClassMask_15,
-                        )
-        )
-
-        proficiencies.append(
-            Proficiency(chr_proficiency.Proficiency_MinLevel_16,
-                        chr_proficiency.Proficiency_AcquireMethod_16,
-                        chr_proficiency.Proficiency_ItemClass_16,
-                        chr_proficiency.Proficiency_ItemSubClassMask_16,
-                        )
-        )
+        proficiencies = [
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_1,
+                chr_proficiency.Proficiency_AcquireMethod_1,
+                chr_proficiency.Proficiency_ItemClass_1,
+                chr_proficiency.Proficiency_ItemSubClassMask_1
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_2,
+                chr_proficiency.Proficiency_AcquireMethod_2,
+                chr_proficiency.Proficiency_ItemClass_2,
+                chr_proficiency.Proficiency_ItemSubClassMask_2
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_3,
+                chr_proficiency.Proficiency_AcquireMethod_3,
+                chr_proficiency.Proficiency_ItemClass_3,
+                chr_proficiency.Proficiency_ItemSubClassMask_3
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_4,
+                chr_proficiency.Proficiency_AcquireMethod_4,
+                chr_proficiency.Proficiency_ItemClass_4,
+                chr_proficiency.Proficiency_ItemSubClassMask_4
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_5,
+                chr_proficiency.Proficiency_AcquireMethod_5,
+                chr_proficiency.Proficiency_ItemClass_5,
+                chr_proficiency.Proficiency_ItemSubClassMask_5
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_6,
+                chr_proficiency.Proficiency_AcquireMethod_6,
+                chr_proficiency.Proficiency_ItemClass_6,
+                chr_proficiency.Proficiency_ItemSubClassMask_6
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_7,
+                chr_proficiency.Proficiency_AcquireMethod_7,
+                chr_proficiency.Proficiency_ItemClass_7,
+                chr_proficiency.Proficiency_ItemSubClassMask_7
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_8,
+                chr_proficiency.Proficiency_AcquireMethod_8,
+                chr_proficiency.Proficiency_ItemClass_8,
+                chr_proficiency.Proficiency_ItemSubClassMask_8
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_9,
+                chr_proficiency.Proficiency_AcquireMethod_9,
+                chr_proficiency.Proficiency_ItemClass_9,
+                chr_proficiency.Proficiency_ItemSubClassMask_9
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_10,
+                chr_proficiency.Proficiency_AcquireMethod_10,
+                chr_proficiency.Proficiency_ItemClass_10,
+                chr_proficiency.Proficiency_ItemSubClassMask_10
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_11,
+                chr_proficiency.Proficiency_AcquireMethod_11,
+                chr_proficiency.Proficiency_ItemClass_11,
+                chr_proficiency.Proficiency_ItemSubClassMask_11
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_12,
+                chr_proficiency.Proficiency_AcquireMethod_12,
+                chr_proficiency.Proficiency_ItemClass_12,
+                chr_proficiency.Proficiency_ItemSubClassMask_12
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_13,
+                chr_proficiency.Proficiency_AcquireMethod_13,
+                chr_proficiency.Proficiency_ItemClass_13,
+                chr_proficiency.Proficiency_ItemSubClassMask_13
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_14,
+                chr_proficiency.Proficiency_AcquireMethod_14,
+                chr_proficiency.Proficiency_ItemClass_14,
+                chr_proficiency.Proficiency_ItemSubClassMask_14
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_15,
+                chr_proficiency.Proficiency_AcquireMethod_15,
+                chr_proficiency.Proficiency_ItemClass_15,
+                chr_proficiency.Proficiency_ItemSubClassMask_15
+                ),
+            Proficiency(
+                chr_proficiency.Proficiency_MinLevel_16,
+                chr_proficiency.Proficiency_AcquireMethod_16,
+                chr_proficiency.Proficiency_ItemClass_16,
+                chr_proficiency.Proficiency_ItemSubClassMask_16
+                )
+        ]
 
         return proficiencies
 

--- a/game/world/managers/objects/player/proficiencies/proficiency.py
+++ b/game/world/managers/objects/player/proficiencies/proficiency.py
@@ -1,0 +1,141 @@
+class Proficiency(object):
+    def __init__(self, min_level, acquire_method, item_class, item_subclass_mask):
+        self.min_level = min_level
+        self.acquire_method = acquire_method
+        self.item_class = item_class
+        self.item_subclass_mask = item_subclass_mask
+
+    @staticmethod
+    def build_from_chr_proficiency(chr_proficiency):
+        proficiencies = []
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_1,
+                        chr_proficiency.Proficiency_AcquireMethod_1,
+                        chr_proficiency.Proficiency_ItemClass_1,
+                        chr_proficiency.Proficiency_ItemSubClassMask_1,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_2,
+                        chr_proficiency.Proficiency_AcquireMethod_2,
+                        chr_proficiency.Proficiency_ItemClass_2,
+                        chr_proficiency.Proficiency_ItemSubClassMask_2,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_3,
+                        chr_proficiency.Proficiency_AcquireMethod_3,
+                        chr_proficiency.Proficiency_ItemClass_3,
+                        chr_proficiency.Proficiency_ItemSubClassMask_3,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_4,
+                        chr_proficiency.Proficiency_AcquireMethod_4,
+                        chr_proficiency.Proficiency_ItemClass_4,
+                        chr_proficiency.Proficiency_ItemSubClassMask_4,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_5,
+                        chr_proficiency.Proficiency_AcquireMethod_5,
+                        chr_proficiency.Proficiency_ItemClass_5,
+                        chr_proficiency.Proficiency_ItemSubClassMask_5,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_6,
+                        chr_proficiency.Proficiency_AcquireMethod_6,
+                        chr_proficiency.Proficiency_ItemClass_6,
+                        chr_proficiency.Proficiency_ItemSubClassMask_6,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_7,
+                        chr_proficiency.Proficiency_AcquireMethod_7,
+                        chr_proficiency.Proficiency_ItemClass_7,
+                        chr_proficiency.Proficiency_ItemSubClassMask_7,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_8,
+                        chr_proficiency.Proficiency_AcquireMethod_8,
+                        chr_proficiency.Proficiency_ItemClass_8,
+                        chr_proficiency.Proficiency_ItemSubClassMask_8,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_9,
+                        chr_proficiency.Proficiency_AcquireMethod_9,
+                        chr_proficiency.Proficiency_ItemClass_9,
+                        chr_proficiency.Proficiency_ItemSubClassMask_9,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_10,
+                        chr_proficiency.Proficiency_AcquireMethod_10,
+                        chr_proficiency.Proficiency_ItemClass_10,
+                        chr_proficiency.Proficiency_ItemSubClassMask_10,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_11,
+                        chr_proficiency.Proficiency_AcquireMethod_11,
+                        chr_proficiency.Proficiency_ItemClass_11,
+                        chr_proficiency.Proficiency_ItemSubClassMask_11,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_12,
+                        chr_proficiency.Proficiency_AcquireMethod_12,
+                        chr_proficiency.Proficiency_ItemClass_12,
+                        chr_proficiency.Proficiency_ItemSubClassMask_12,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_13,
+                        chr_proficiency.Proficiency_AcquireMethod_13,
+                        chr_proficiency.Proficiency_ItemClass_13,
+                        chr_proficiency.Proficiency_ItemSubClassMask_13,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_14,
+                        chr_proficiency.Proficiency_AcquireMethod_14,
+                        chr_proficiency.Proficiency_ItemClass_14,
+                        chr_proficiency.Proficiency_ItemSubClassMask_14,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_15,
+                        chr_proficiency.Proficiency_AcquireMethod_15,
+                        chr_proficiency.Proficiency_ItemClass_15,
+                        chr_proficiency.Proficiency_ItemSubClassMask_15,
+                        )
+        )
+
+        proficiencies.append(
+            Proficiency(chr_proficiency.Proficiency_MinLevel_16,
+                        chr_proficiency.Proficiency_AcquireMethod_16,
+                        chr_proficiency.Proficiency_ItemClass_16,
+                        chr_proficiency.Proficiency_ItemSubClassMask_16,
+                        )
+        )
+
+        return proficiencies
+

--- a/game/world/opcode_handling/handlers/interface/CharCreateHandler.py
+++ b/game/world/opcode_handling/handlers/interface/CharCreateHandler.py
@@ -16,7 +16,7 @@ from utils.TextUtils import GameTextFormatter
 from utils.constants.CharCodes import *
 from utils.ConfigManager import config
 from utils.constants.ItemCodes import InventorySlots
-from utils.constants.ObjectCodes import SkillCategories, ReputationReacion, ReputationFlag
+from utils.constants.ObjectCodes import SkillCategories
 from utils.constants.SpellCodes import SpellEffects
 from utils.constants.UnitCodes import Teams, Classes
 
@@ -112,10 +112,10 @@ class CharCreateHandler(object):
             if faction.reputation_index > -1:
                 reputation_entry = CharacterReputation()
                 reputation_entry.character = guid
-                reputation_entry.faction = faction.id
+                reputation_entry.faction = faction.faction_id
                 reputation_entry.standing = faction.reputation_base_value
                 reputation_entry.index = faction.reputation_index
-                reputation_entry.flags = int(ReputationFlag.Visible)  # TODO
+                reputation_entry.flags = ReputationManager.get_reputation_flag(faction)
                 RealmDatabaseManager.character_add_reputation(reputation_entry)
 
     @staticmethod

--- a/game/world/opcode_handling/handlers/interface/CharCreateHandler.py
+++ b/game/world/opcode_handling/handlers/interface/CharCreateHandler.py
@@ -3,7 +3,9 @@ from struct import pack, unpack
 
 from database.dbc.DbcDatabaseManager import DbcDatabaseManager
 from game.world.managers.objects.item.ItemManager import ItemManager
+from game.world.managers.objects.player.FactionManager import FactionManager
 from game.world.managers.objects.player.PlayerManager import PlayerManager
+from game.world.managers.objects.player.ReputationManager import ReputationManager
 from game.world.managers.objects.player.SkillManager import SkillManager, SkillTypes
 from network.packet.PacketWriter import *
 from network.packet.PacketReader import *
@@ -14,7 +16,7 @@ from utils.TextUtils import GameTextFormatter
 from utils.constants.CharCodes import *
 from utils.ConfigManager import config
 from utils.constants.ItemCodes import InventorySlots
-from utils.constants.ObjectCodes import SkillCategories
+from utils.constants.ObjectCodes import SkillCategories, ReputationReacion, ReputationFlag
 from utils.constants.SpellCodes import SpellEffects
 from utils.constants.UnitCodes import Teams, Classes
 
@@ -80,6 +82,7 @@ class CharCreateHandler(object):
                                   power4=100 if class_ == Classes.CLASS_ROGUE else 0,
                                   level=config.Unit.Player.Defaults.starting_level)
             RealmDatabaseManager.character_create(character)
+            CharCreateHandler.generate_starting_reputations(character.guid)
             CharCreateHandler.generate_starting_spells(character.guid, race, class_, character.level)
             CharCreateHandler.generate_starting_items(character.guid, race, class_, gender)
             default_deathbind = CharacterDeathbind(
@@ -102,6 +105,18 @@ class CharCreateHandler(object):
     def get_starting_location(race, class_):
         info = WorldDatabaseManager.player_create_info_get(race, class_)
         return info.map, info.zone, info.position_x, info.position_y, info.position_z, info.orientation
+
+    @staticmethod
+    def generate_starting_reputations(guid):
+        for faction in FactionManager.FACTIONS.values():
+            if faction.reputation_index > -1:
+                reputation_entry = CharacterReputation()
+                reputation_entry.character = guid
+                reputation_entry.faction = faction.id
+                reputation_entry.standing = faction.reputation_base_value
+                reputation_entry.index = faction.reputation_index
+                reputation_entry.flags = int(ReputationFlag.Visible)  # TODO
+                RealmDatabaseManager.character_add_reputation(reputation_entry)
 
     @staticmethod
     def generate_starting_spells(guid, race, class_, level):

--- a/game/world/opcode_handling/handlers/player/PlayerLoginHandler.py
+++ b/game/world/opcode_handling/handlers/player/PlayerLoginHandler.py
@@ -58,6 +58,7 @@ class PlayerLoginHandler(object):
         world_session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_LOGIN_SETTIMESPEED,
                                                              PlayerLoginHandler._get_login_timespeed()))
 
+        world_session.player_mgr.skill_manager.load_proficiencies()
         world_session.player_mgr.spell_manager.load_spells()
 
         world_session.player_mgr.deathbind = RealmDatabaseManager.character_get_deathbind(world_session.player_mgr.guid)
@@ -67,6 +68,8 @@ class PlayerLoginHandler(object):
         ReputationManager.send_player_reputations(world_session.player_mgr)
         # Tutorials aren't implemented in 0.5.3
         # world_session.enqueue_packet(world_session.player_mgr.get_tutorial_packet())
+        for proficiency_packet in world_session.player_mgr.skill_manager.get_proficiencies_packets():
+            world_session.enqueue_packet(proficiency_packet)
         world_session.enqueue_packet(world_session.player_mgr.spell_manager.get_initial_spells())
         world_session.enqueue_packet(world_session.player_mgr.get_action_buttons())
 

--- a/game/world/opcode_handling/handlers/player/PlayerLoginHandler.py
+++ b/game/world/opcode_handling/handlers/player/PlayerLoginHandler.py
@@ -4,6 +4,7 @@ from struct import unpack
 
 from game.world.WorldSessionStateHandler import WorldSessionStateHandler
 from game.world.managers.objects.player.GroupManager import GroupManager
+from game.world.managers.objects.player.ReputationManager import ReputationManager
 from game.world.managers.objects.player.guild.GuildManager import GuildManager
 from game.world.managers.objects.player.guild.PetitionManager import PetitionManager
 from network.packet.PacketWriter import *
@@ -63,6 +64,7 @@ class PlayerLoginHandler(object):
         world_session.player_mgr.friends_manager.load_from_db(RealmDatabaseManager.character_get_social(world_session.player_mgr.guid))
 
         world_session.enqueue_packet(world_session.player_mgr.get_deathbind_packet())
+        ReputationManager.send_player_reputations(world_session.player_mgr)
         # Tutorials aren't implemented in 0.5.3
         # world_session.enqueue_packet(world_session.player_mgr.get_tutorial_packet())
         world_session.enqueue_packet(world_session.player_mgr.spell_manager.get_initial_spells())

--- a/utils/constants/ObjectCodes.py
+++ b/utils/constants/ObjectCodes.py
@@ -264,26 +264,11 @@ class LootTypes(IntEnum):
     LOOT_TYPE_FISHING = 3
 
 
-class FactionGroupType(IntEnum):
-    Default = 0
-    Player = 1
-    Alliance = 2
-    Horde = 4
-    Monster = 8
-
-class ReputationReacion(IntEnum):
-    HATED = 0
-    HOSTILE = 1
-    UNFRIENDLY = 2
-    NEUTRAL = 3
-    AMIABLE = 4
-    FRIENDLY = 5
-    REVERED = 6
-
 class ReputationFlag(IntEnum):
-    Hidden = 0
-    Visible = 1
-    AtWar = 2
+    HIDDEN = 0
+    VISIBLE = 1
+    ATWAR = 2
+
 
 class QuestState(IntEnum):
     QUEST_GREETING = 0

--- a/utils/constants/ObjectCodes.py
+++ b/utils/constants/ObjectCodes.py
@@ -264,6 +264,27 @@ class LootTypes(IntEnum):
     LOOT_TYPE_FISHING = 3
 
 
+class FactionGroupType(IntEnum):
+    Default = 0
+    Player = 1
+    Alliance = 2
+    Horde = 4
+    Monster = 8
+
+class ReputationReacion(IntEnum):
+    HATED = 0
+    HOSTILE = 1
+    UNFRIENDLY = 2
+    NEUTRAL = 3
+    AMIABLE = 4
+    FRIENDLY = 5
+    REVERED = 6
+
+class ReputationFlag(IntEnum):
+    Hidden = 0
+    Visible = 1
+    AtWar = 2
+
 class QuestState(IntEnum):
     QUEST_GREETING = 0
     QUEST_OFFER = 1


### PR DESCRIPTION
* Initialize factions, according to DBC data, there are only 4 visible reputations or 4 reputations which standing can change:
- Bloodsail Buccaneers (Hostile)
- Booty Bay (Neutral)
- Gelkis (Unfriendly)
- Magram (Unfriendly)
/ Other alliance or horde cities were apparently not handled yet.

* Persist initial reputations on db
* Calculate and send player proficiencies upon login based on DBC data. (Still need to figure how to link rank based proficiencies to the actual skill, e.g. Fishing)
* Move allegiance_status_checker out from UnitManager into FactionManager