### PR TITLE
More cheat handlers and vendor bug fix

### DIFF
--- a/game/world/opcode_handling/Definitions.py
+++ b/game/world/opcode_handling/Definitions.py
@@ -96,6 +96,9 @@ from game.world.opcode_handling.handlers.player.SetWeaponModeHandler import SetW
 from game.world.opcode_handling.handlers.player.StandStateChangeHandler import StandStateChangeHandler
 from game.world.opcode_handling.handlers.player.cheats.GodModeHandler import GodModeHandler
 from game.world.opcode_handling.handlers.player.cheats.SpeedCheatHandler import SpeedCheatHandler
+from game.world.opcode_handling.handlers.player.cheats.MoneyCheatHandler import MoneyCheatHandler
+from game.world.opcode_handling.handlers.player.cheats.LevelCheatHandler import LevelCheatHandler
+from game.world.opcode_handling.handlers.player.cheats.LevelUpCheatHandler import LevelUpCheatHandler
 from game.world.opcode_handling.handlers.player.cheats.TriggerCinematicCheatHandler import TriggerCinematicCheatHandler
 from game.world.opcode_handling.handlers.quest.QuestGiverAcceptQuestHandler import QuestGiverAcceptQuestHandler
 from game.world.opcode_handling.handlers.quest.QuestGiverChooseRewardHandler import QuestGiverChooseRewardHandler
@@ -268,6 +271,9 @@ HANDLER_DEFINITIONS = {
     OpCode.CMSG_DUEL_CANCELLED: DuelCanceledHandler.handle,
     OpCode.CMSG_TRIGGER_CINEMATIC_CHEAT: TriggerCinematicCheatHandler.handle,
     OpCode.CMSG_GODMODE: GodModeHandler.handle,
+    OpCode.CMSG_CHEAT_SETMONEY: MoneyCheatHandler.handle,
+    OpCode.CMSG_LEVEL_CHEAT: LevelCheatHandler.handle,
+    OpCode.CMSG_LEVELUP_CHEAT: LevelUpCheatHandler.handle,
     OpCode.CMSG_DEBUG_AISTATE: DebugAIStateHandler.handle,
     OpCode.CMSG_BANKER_ACTIVATE: BankerActivateHandler.handle,
     OpCode.CMSG_BUY_BANK_SLOT: BuyBankSlotHandler.handle,

--- a/game/world/opcode_handling/handlers/npc/ListInventoryHandler.py
+++ b/game/world/opcode_handling/handlers/npc/ListInventoryHandler.py
@@ -13,6 +13,7 @@ class ListInventoryHandler(object):
             if npc_guid > 0:
                 vendor = MapManager.get_surrounding_unit_by_guid(world_session.player_mgr, npc_guid)
                 if vendor:
-                    vendor.send_inventory_list(world_session)
+                    if vendor.is_within_interactable_distance(world_session.player_mgr):
+                        vendor.send_inventory_list(world_session)
 
         return 0

--- a/game/world/opcode_handling/handlers/player/cheats/LevelCheatHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/LevelCheatHandler.py
@@ -1,0 +1,20 @@
+# OPCODE: CMSG_LEVEL_CHEAT
+from game.world.managers.objects.player.ChatManager import ChatManager
+
+from struct import unpack
+
+from network.packet.PacketWriter import *
+
+class LevelCheatHandler(object):
+
+    @staticmethod
+    def handle(world_session, socket, reader):
+        if len(reader.data) >= 4: # Avoid empty packet
+            if not world_session.player_mgr.is_gm:
+                return 0
+
+            newLevel = unpack('<L', reader.data[:4])[0]
+            world_session.player_mgr.mod_level(newLevel)
+            ChatManager.send_system_message(world_session, f'You are now level {newLevel}!')
+
+        return 0

--- a/game/world/opcode_handling/handlers/player/cheats/LevelUpCheatHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/LevelUpCheatHandler.py
@@ -1,0 +1,15 @@
+# OPCODE: CMSG_LEVELUP_CHEAT -- NOT THE SAME AS CMSG_LEVEL_CHEAT!
+from struct import unpack
+
+from network.packet.PacketWriter import *
+
+class LevelUpCheatHandler(object):
+
+    @staticmethod
+    def handle(world_session, socket, reader):
+        if not world_session.player_mgr.is_gm:
+            return 0
+
+        world_session.player_mgr.mod_level(world_session.player_mgr.level + 1)
+
+        return 0

--- a/game/world/opcode_handling/handlers/player/cheats/MoneyCheatHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/MoneyCheatHandler.py
@@ -1,0 +1,19 @@
+# OPCODE: CMSG_CHEAT_SETMONEY
+from game.world.managers.objects.player.ChatManager import ChatManager
+from struct import unpack
+
+from network.packet.PacketWriter import *
+
+class MoneyCheatHandler(object):
+
+    @staticmethod
+    def handle(world_session, socket, reader):
+        if len(reader.data) >= 4: # Avoid handling empty packet!!
+            if not world_session.player_mgr.is_gm:
+                return 0
+
+            newMoney = unpack('<L', reader.data[:4])[0]
+            world_session.player_mgr.mod_money(newMoney)
+            ChatManager.send_system_message(world_session, f'You receive {newMoney} copper.')
+
+        return 0


### PR DESCRIPTION
In the built-in console, GM only commands:

money [x-amt]
level [x-level]
levelup

Fixed bug when right-clicking on vendors while out of range. The client seems to check distance, but the server was not, causing the vendor bag noise to play.