### PR TITLE
Upgraded player OpCode handlers to use type-hinting, with some exceptions

### DIFF
--- a/game/world/opcode_handling/handlers/player/DebugAIStateHandler.py
+++ b/game/world/opcode_handling/handlers/player/DebugAIStateHandler.py
@@ -1,6 +1,8 @@
 from struct import unpack, pack
 
 from game.world.managers.maps.MapManager import MapManager
+from game.world.managers.objects.ObjectManager import ObjectManager
+from network.packet.PacketReader import PacketReader
 from network.packet.PacketWriter import PacketWriter
 from utils.constants.OpCodes import OpCode
 
@@ -11,10 +13,10 @@ from utils.constants.OpCodes import OpCode
 class DebugAIStateHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if len(reader.data) >= 8:  # Avoid handling empty debug AI state packet.
-            guid = unpack('<Q', reader.data[:8])[0]
-            world_object = MapManager.get_surrounding_unit_by_guid(world_session.player_mgr, guid,
+            guid: int = unpack('<Q', reader.data[:8])[0]
+            world_object: ObjectManager = MapManager.get_surrounding_unit_by_guid(world_session.player_mgr, guid,
                                                                    include_players=True)
 
             # If no Unit or Player, try to get a Gameobject.
@@ -25,15 +27,15 @@ class DebugAIStateHandler(object):
             if not world_object:
                 return 0
 
-            messages = world_object.get_debug_messages()
-            data = pack(
+            messages: list[str] = world_object.get_debug_messages()
+            data: bytes = pack(
                 '<QI',
                 guid,
                 len(messages)
             )
 
             for message in messages:
-                message_bytes = PacketWriter.string_to_bytes(message[:127])  # Max length is 128 (127 + null byte).
+                message_bytes: bytes = PacketWriter.string_to_bytes(message[:127])  # Max length is 128 (127 + null byte).
                 data += pack(
                     f'<{len(message_bytes)}s',
                     message_bytes

--- a/game/world/opcode_handling/handlers/player/DuelAcceptHandler.py
+++ b/game/world/opcode_handling/handlers/player/DuelAcceptHandler.py
@@ -1,7 +1,10 @@
+from network.packet.PacketReader import PacketReader
+
+
 class DuelAcceptHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if world_session.player_mgr.duel_manager:  # Ignore accept from duel-sender
             world_session.player_mgr.duel_manager.handle_duel_accept(world_session.player_mgr)
         return 0

--- a/game/world/opcode_handling/handlers/player/DuelCanceledHandler.py
+++ b/game/world/opcode_handling/handlers/player/DuelCanceledHandler.py
@@ -1,7 +1,10 @@
+from network.packet.PacketReader import PacketReader
+
+
 class DuelCanceledHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         # You can trigger cancel by using /yield without being in a duel.
         if world_session.player_mgr.duel_manager:
             world_session.player_mgr.duel_manager.handle_duel_canceled(world_session.player_mgr)

--- a/game/world/opcode_handling/handlers/player/InspectHandler.py
+++ b/game/world/opcode_handling/handlers/player/InspectHandler.py
@@ -1,23 +1,26 @@
+from network.packet.PacketReader import PacketReader
 from struct import unpack
 
+from game.world.managers.objects.player.PlayerManager import PlayerManager
 from game.world.managers.maps.MapManager import MapManager
+from network.packet.PacketReader import PacketReader
 from network.packet.PacketWriter import *
 
 
 class InspectHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if len(reader.data) >= 8:  # Avoid handling empty inspect packet.
-            guid = unpack('<Q', reader.data[:8])[0]
+            guid: int = unpack('<Q', reader.data[:8])[0]
             if guid > 0:
-                inspected_player = MapManager.get_surrounding_player_by_guid(world_session.player_mgr, guid)
+                inspected_player: PlayerManager = MapManager.get_surrounding_player_by_guid(world_session.player_mgr, guid)
                 if not inspected_player or not inspected_player.is_alive:
                     return 0
 
                 world_session.player_mgr.set_current_selection(guid)
                 world_session.player_mgr.set_dirty()
 
-                data = pack('<Q', world_session.player_mgr.guid)
+                data: bytes = pack('<Q', world_session.player_mgr.guid)
                 inspected_player.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_INSPECT, data))
         return 0

--- a/game/world/opcode_handling/handlers/player/LogoutCancelHandler.py
+++ b/game/world/opcode_handling/handlers/player/LogoutCancelHandler.py
@@ -1,3 +1,4 @@
+from network.packet.PacketReader import PacketReader
 from network.packet.PacketWriter import *
 from utils.constants.UnitCodes import StandState
 
@@ -5,7 +6,7 @@ from utils.constants.UnitCodes import StandState
 class LogoutCancelHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         world_session.player_mgr.set_stand_state(StandState.UNIT_STANDING)
         world_session.player_mgr.set_root(False)
         world_session.player_mgr.set_dirty()

--- a/game/world/opcode_handling/handlers/player/LogoutRequestHandler.py
+++ b/game/world/opcode_handling/handlers/player/LogoutRequestHandler.py
@@ -1,3 +1,4 @@
+from network.packet.PacketReader import PacketReader
 from network.packet.PacketWriter import *
 from utils.constants.MiscCodes import LogoutResponseCodes
 from utils.constants.UnitCodes import StandState
@@ -6,9 +7,9 @@ from utils.constants.UnitCodes import StandState
 class LogoutRequestHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if world_session.player_mgr.in_combat:
-            res = LogoutResponseCodes.LOGOUT_CANCEL
+            res: LogoutResponseCodes = LogoutResponseCodes.LOGOUT_CANCEL
         else:
             res = LogoutResponseCodes.LOGOUT_PROCEED
             world_session.player_mgr.set_stand_state(StandState.UNIT_SITTING)

--- a/game/world/opcode_handling/handlers/player/MountSpecialAnimHandler.py
+++ b/game/world/opcode_handling/handlers/player/MountSpecialAnimHandler.py
@@ -1,14 +1,16 @@
+from network.packet.PacketReader import PacketReader
 from game.world.managers.maps.MapManager import MapManager
+from network.packet.PacketReader import *
 from network.packet.PacketWriter import *
 
 
 class MountSpecialAnimHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         # TODO Not working, wrong packet data, or animation not implemented client side?
-        player_guid = pack('<Q', world_session.player_mgr.guid)
-        mount_anim_packet = PacketWriter.get_packet(OpCode.SMSG_MOUNTSPECIAL_ANIM, player_guid)
+        player_guid: bytes = pack('<Q', world_session.player_mgr.guid)
+        mount_anim_packet: bytes = PacketWriter.get_packet(OpCode.SMSG_MOUNTSPECIAL_ANIM, player_guid)
         MapManager.send_surrounding(PacketWriter.get_packet(OpCode.SMSG_TEXT_EMOTE, mount_anim_packet),
                                     world_session.player_mgr, include_self=True)
 

--- a/game/world/opcode_handling/handlers/player/MovementHandler.py
+++ b/game/world/opcode_handling/handlers/player/MovementHandler.py
@@ -1,7 +1,9 @@
+from network.packet.PacketReader import PacketReader
 from struct import unpack, error
 
 from game.world.managers.maps.MapManager import MapManager
 from game.world.managers.objects import MovementManager
+from network.packet.PacketReader import *
 from network.packet.PacketWriter import *
 from utils.Logger import Logger
 from utils.constants.MiscCodes import MoveFlags
@@ -12,10 +14,10 @@ from utils.constants.UnitCodes import StandState
 class MovementHandler(object):
 
     @staticmethod
-    def handle_movement_status(world_session, socket, reader):
+    def handle_movement_status(world_session, socket: int, reader: PacketReader) -> int:
         # Avoid handling malformed movement packets, or handling them while no player or player teleporting.
         if world_session.player_mgr and len(reader.data) >= 48:
-            try:
+            try: # TODO type hint these
                 transport_guid, transport_x, transport_y, transport_z, transport_o, x, y, z, o, pitch, flags = \
                     unpack('<Q9fI', reader.data[:48])
 
@@ -52,7 +54,7 @@ class MovementHandler(object):
                     world_session.player_mgr.movement_spline = MovementManager.MovementSpline.from_bytes(
                         reader.data[48:])
 
-                movement_data = pack(f'<Q{len(reader.data)}s',
+                movement_data: bytes = pack(f'<Q{len(reader.data)}s',
                                      world_session.player_mgr.guid,
                                      reader.data)
 

--- a/game/world/opcode_handling/handlers/player/NameQueryHandler.py
+++ b/game/world/opcode_handling/handlers/player/NameQueryHandler.py
@@ -1,7 +1,9 @@
+from network.packet.PacketReader import PacketReader
 from struct import pack, unpack
 
 from database.realm.RealmDatabaseManager import RealmDatabaseManager
 from game.world.managers.maps.MapManager import MapManager
+from network.packet.PacketReader import PacketReader
 from network.packet.PacketWriter import PacketWriter
 from utils.constants.OpCodes import OpCode
 
@@ -9,10 +11,10 @@ from utils.constants.OpCodes import OpCode
 class NameQueryHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if len(reader.data) >= 8:  # Avoid handling empty name query packet.
-            guid = unpack('<Q', reader.data[:8])[0]
-            player_mgr = MapManager.get_surrounding_player_by_guid(world_session.player_mgr, guid)
+            guid: int = unpack('<Q', reader.data[:8])[0]
+            player_mgr = MapManager.get_surrounding_player_by_guid(world_session.player_mgr, guid) # Can't type hint due to circular import
 
             if player_mgr:
                 player = player_mgr.player
@@ -25,9 +27,9 @@ class NameQueryHandler(object):
         return 0
 
     @staticmethod
-    def get_query_details(player):
-        name_bytes = PacketWriter.string_to_bytes(player.name)
-        player_data = pack(
+    def get_query_details(player) -> bytes:
+        name_bytes: bytes = PacketWriter.string_to_bytes(player.name)
+        player_data: bytes = pack(
             f'<Q{len(name_bytes)}s3I',
             player.guid,
             name_bytes,

--- a/game/world/opcode_handling/handlers/player/PingHandler.py
+++ b/game/world/opcode_handling/handlers/player/PingHandler.py
@@ -1,10 +1,11 @@
+from network.packet.PacketReader import *
 from network.packet.PacketWriter import *
 
 
 class PingHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if len(reader.data) >= 4:  # Avoid handling empty ping packet.
             world_session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_PONG, reader.data))
 

--- a/game/world/opcode_handling/handlers/player/PlayedTimeHandler.py
+++ b/game/world/opcode_handling/handlers/player/PlayedTimeHandler.py
@@ -1,12 +1,13 @@
+from network.packet.PacketReader import *
 from network.packet.PacketWriter import *
 
 
 class PlayedTimeHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         # In seconds
-        data = pack('<2I',
+        data: bytes = pack('<2I',
                     int(world_session.player_mgr.player.totaltime),
                     int(world_session.player_mgr.player.leveltime))
         world_session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_PLAYED_TIME, data))

--- a/game/world/opcode_handling/handlers/player/PlayerLogoutHandler.py
+++ b/game/world/opcode_handling/handlers/player/PlayerLogoutHandler.py
@@ -1,7 +1,10 @@
+from network.packet.PacketReader import *
+
+
 class PlayerLogoutHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         world_session.player_mgr.logout()
 
         return 0

--- a/game/world/opcode_handling/handlers/player/RandomRollHandler.py
+++ b/game/world/opcode_handling/handlers/player/RandomRollHandler.py
@@ -1,19 +1,23 @@
+from game.world.managers.objects.player.PlayerManager import PlayerManager
 from random import randint
 from struct import unpack
 
+from network.packet.PacketReader import *
 from network.packet.PacketWriter import *
 
 
 class RandomRollHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if len(reader.data) >= 8:  # Avoid handling empty random roll packet.
-            minimum, maximum = unpack('<2I', reader.data[:8])
-            roll = randint(minimum, maximum)
-            player = world_session.player_mgr
+            minimum: int = unpack('<I', reader.data[:4])[0]
+            maximum: int = unpack('<I', reader.data[4:8])[0]
 
-            roll_packet = PacketWriter.get_packet(OpCode.MSG_RANDOM_ROLL,
+            roll: int = randint(minimum, maximum)
+            player: PlayerManager = world_session.player_mgr
+
+            roll_packet: bytes = PacketWriter.get_packet(OpCode.MSG_RANDOM_ROLL,
                                                   pack('<3IQ', minimum, maximum, roll, player.guid))
 
             if player.group_manager and player.group_manager.is_party_formed():

--- a/game/world/opcode_handling/handlers/player/RepopRequestHandler.py
+++ b/game/world/opcode_handling/handlers/player/RepopRequestHandler.py
@@ -1,7 +1,10 @@
+from network.packet.PacketReader import *
+
+
 class RepopRequestHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         world_session.player_mgr.repop()
 
         return 0

--- a/game/world/opcode_handling/handlers/player/SetWeaponModeHandler.py
+++ b/game/world/opcode_handling/handlers/player/SetWeaponModeHandler.py
@@ -1,12 +1,13 @@
+from network.packet.PacketReader import *
 from struct import unpack
 
 
 class SetWeaponModeHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if len(reader.data) >= 1:  # Avoid handling empty set weapon mode packet.
-            weapon_mode = unpack('<B', reader.data[:1])[0]
+            weapon_mode: bool = unpack('<B', reader.data[:1])[0]
             world_session.player_mgr.set_weapon_mode(weapon_mode)
             world_session.player_mgr.set_dirty()
 

--- a/game/world/opcode_handling/handlers/player/StandStateChangeHandler.py
+++ b/game/world/opcode_handling/handlers/player/StandStateChangeHandler.py
@@ -1,3 +1,4 @@
+from network.packet.PacketReader import *
 from struct import unpack
 
 from utils.constants.UnitCodes import StandState
@@ -6,9 +7,9 @@ from utils.constants.UnitCodes import StandState
 class StandStateChangeHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if len(reader.data) >= 4:  # Avoid handling empty stand state packet.
-            state = unpack('<I', reader.data[:4])[0]
+            state: int = unpack('<I', reader.data[:4])[0]
             world_session.player_mgr.set_stand_state(StandState(state))
             world_session.player_mgr.set_dirty()
 

--- a/game/world/opcode_handling/handlers/player/cheats/CheatSetMoneyHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/CheatSetMoneyHandler.py
@@ -1,15 +1,16 @@
+from network.packet.PacketReader import PacketReader
 from struct import unpack
 
 
 class CheatSetMoneyHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if len(reader.data) >= 4:  # Avoid handling empty cheat set money packet.
             if not world_session.player_mgr.is_gm:
                 return 0
 
-            new_money = unpack('<I', reader.data[:4])[0]
+            new_money: int = unpack('<I', reader.data[:4])[0]
             world_session.player_mgr.mod_money(new_money)
 
         return 0

--- a/game/world/opcode_handling/handlers/player/cheats/GodModeHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/GodModeHandler.py
@@ -1,12 +1,13 @@
 from struct import unpack
 
+from network.packet.PacketReader import *
 from network.packet.PacketWriter import *
 
 
 class GodModeHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if len(reader.data) >= 1:  # Avoid handling empty god mode packet.
             if not world_session.player_mgr.is_gm:
                 return 0

--- a/game/world/opcode_handling/handlers/player/cheats/LevelCheatHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/LevelCheatHandler.py
@@ -1,15 +1,16 @@
+from network.packet.PacketReader import PacketReader
 from struct import unpack
 
 
 class LevelCheatHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if len(reader.data) >= 4:  # Avoid empty packet level cheat packet.
             if not world_session.player_mgr.is_gm:
                 return 0
 
-            new_level = unpack('<I', reader.data[:4])[0]
+            new_level: int = unpack('<I', reader.data[:4])[0]
             world_session.player_mgr.mod_level(new_level)
 
         return 0

--- a/game/world/opcode_handling/handlers/player/cheats/LevelUpCheatHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/LevelUpCheatHandler.py
@@ -1,7 +1,10 @@
+from network.packet.PacketReader import PacketReader
+
+
 class LevelUpCheatHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if not world_session.player_mgr.is_gm:
             return 0
 

--- a/game/world/opcode_handling/handlers/player/cheats/SpeedCheatHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/SpeedCheatHandler.py
@@ -1,11 +1,12 @@
 from network.packet.PacketWriter import *
+from network.packet.PacketReader import *
 from utils.Logger import Logger
 
 
 class SpeedCheatHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if not world_session.player_mgr.is_gm:
             Logger.anticheat(f'Player {world_session.player_mgr.player.name} ({world_session.player_mgr.guid}) tried to use speed hacks.')
             if reader.opcode == OpCode.MSG_MOVE_SET_RUN_SPEED_CHEAT:

--- a/game/world/opcode_handling/handlers/player/cheats/TriggerCinematicCheatHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/TriggerCinematicCheatHandler.py
@@ -1,3 +1,4 @@
+from network.packet.PacketReader import PacketReader
 from struct import unpack
 
 from database.dbc.DbcDatabaseManager import DbcDatabaseManager
@@ -7,14 +8,14 @@ from network.packet.PacketWriter import *
 class TriggerCinematicCheatHandler(object):
 
     @staticmethod
-    def handle(world_session, socket, reader):
+    def handle(world_session, socket: int, reader: PacketReader) -> int:
         if len(reader.data) >= 4:  # Avoid handling empty trigger cinematic cheat packet.
             if not world_session.player_mgr.is_gm:
                 return 0
 
-            cinematic_id = unpack('<I', reader.data[:4])[0]
+            cinematic_id: int = unpack('<I', reader.data[:4])[0]
             if DbcDatabaseManager.cinematic_sequences_get_by_id(cinematic_id):
-                data = pack('<I', cinematic_id)
+                data: bytes = pack('<I', cinematic_id)
                 world_session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_TRIGGER_CINEMATIC, data))
 
         return 0


### PR DESCRIPTION
Changed all of the player OpCode handlers so that they now use type hinting. I used the mypy linter.

There are some peculiarities in converting the project to use type hinting; one major issue is the fact that you can't do circular imports (so it isn't possible to type hint everything).