### PR TITLE
* Remove quest db items if the player destroy them.

### DIFF
--- a/game/world/managers/objects/creature/CreatureManager.py
+++ b/game/world/managers/objects/creature/CreatureManager.py
@@ -343,8 +343,10 @@ class CreatureManager(UnitManager):
         if killer and killer.get_type() == ObjectTypes.TYPE_PLAYER:
             self.reward_kill_xp(killer)
             self.killed_by = killer
-            # If the player has a quest where this creature needs to be killed, update the player.
-            if self.killed_by.quest_manager.reward_creature_or_go(self):
+            # If the player/group requires the kill, reward it to them.
+            if self.killed_by.group_manager:
+                self.killed_by.group_manager.reward_group_creature_or_go(self.killed_by, self)
+            elif self.killed_by.quest_manager.reward_creature_or_go(self):
                 self.killed_by.send_update_self()
             # If the player is in a group, set the group as allowed looters if needed.
             if self.killed_by.group_manager and self.loot_manager.has_loot():

--- a/game/world/managers/objects/player/GroupManager.py
+++ b/game/world/managers/objects/player/GroupManager.py
@@ -299,6 +299,14 @@ class GroupManager(object):
         for member in surrounding_members:
             member.give_xp([base_xp * member.level / sum_levels], creature)
 
+    def reward_group_creature_or_go(self, player, creature):
+        surrounding_players = MapManager.get_surrounding_players(player).values()
+        surrounding_members = [player for player in surrounding_players if player.guid in self.members]
+
+        for member in surrounding_members:
+            member.quest_manager.reward_creature_or_go(creature)
+            member.send_update_self()
+
     def send_invite_decline(self, player_name):
         player_mgr = WorldSessionStateHandler.find_player_by_guid(self.group.leader_guid)
         if player_mgr:

--- a/game/world/managers/objects/player/InventoryManager.py
+++ b/game/world/managers/objects/player/InventoryManager.py
@@ -316,7 +316,8 @@ class InventoryManager(object):
                     return item
         return None
 
-    def remove_item(self, target_bag, target_slot, clear_slot=True):  # Clear_slot should be set as False if another item will be placed in this slot (swap_item)
+    # Clear_slot should be set as False if another item will be placed in this slot (swap_item)
+    def remove_item(self, target_bag, target_slot, clear_slot=True):
         target_container = self.get_container(target_bag)
         if not target_container:
             return
@@ -332,6 +333,10 @@ class InventoryManager(object):
 
         if clear_slot:
             RealmDatabaseManager.character_inventory_delete(target_item.item_instance)
+
+        # If this was a required item for a quest, update the quest db state.
+        if self.owner.quest_manager.item_is_required_by_quest(target_item.item_template.entry):
+            self.owner.quest_manager.pop_item(target_item.item_template.entry, target_item.item_instance.stackcount)
 
         if target_container.is_backpack and \
                 self.is_bag_pos(target_slot) and self.get_container(target_slot):  # Equipped bags

--- a/game/world/managers/objects/player/quest/QuestManager.py
+++ b/game/world/managers/objects/player/quest/QuestManager.py
@@ -561,6 +561,11 @@ class QuestManager(object):
         self.build_update()
         self.player_mgr.send_update_self()
 
+    def pop_item(self, item_entry, item_count):
+        for active_quest in list(self.active_quests.values()):
+            if active_quest.requires_item(item_entry):
+                active_quest.pop_item(item_entry, item_count)
+
     def reward_item(self, item_entry, item_count):
         for quest_id, active_quest in self.active_quests.items():
             if active_quest.requires_item(item_entry):


### PR DESCRIPTION
/ Make give_xp() notification skippable, some scenarios like completing quests, will make the client announce given XP, this fixes a visible glitch in which two XP notifications overlapped.