### PR TITLE
* Use MSG_SPLIT_MONEY while on group.

### DIFF
--- a/game/world/managers/objects/player/GroupManager.py
+++ b/game/world/managers/objects/player/GroupManager.py
@@ -273,15 +273,17 @@ class GroupManager(object):
             return False
 
         share = int(creature.loot_manager.current_money / len(surrounding_members))
+
+        # Notify the money looter 'You distribute <coinage> to your party'.
+        data = pack('<QI', looter.guid, int(creature.loot_manager.current_money))
+        split_packet = PacketWriter.get_packet(OpCode.MSG_SPLIT_MONEY, data)
+        looter.session.enqueue_packet(split_packet)
+
         # Append div remainder to the player who killed the creature for now.
         remainder = int(creature.loot_manager.current_money % len(surrounding_members))
 
         for member in surrounding_members:
             player_share = share if member != creature.killed_by else share + remainder
-            # TODO: MSG_SPLIT_MONEY seems not to have any effect on the client.
-            # data = pack('<Q2I', creature.guid, creature.loot_manager.current_money, ply_share)
-            # split_packet = PacketWriter.get_packet(OpCode.MSG_SPLIT_MONEY, data)
-            # member.session.enqueue_packet(split_packet)
             data = pack('<I', player_share)
             member.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_LOOT_MONEY_NOTIFY, data))
             member.mod_money(player_share)

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -524,6 +524,9 @@ class PlayerManager(UnitManager):
                     # Try to split money and finish on success.
                     if self.group_manager.reward_group_money(self, enemy):
                         return
+                    else:  # Not able to split, notify the whole amount to the sole player.
+                        data = pack('<I', enemy.loot_manager.current_money)
+                        self.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_LOOT_MONEY_NOTIFY, data))
 
                 # Not able to split money or no group, loot money to self only.
                 self.mod_money(enemy.loot_manager.current_money)


### PR DESCRIPTION
/ Fixed missing loot money notification while on group and split not possible.