### PR TITLE
* Some work on chests.

### DIFF
--- a/database/world/WorldDatabaseManager.py
+++ b/database/world/WorldDatabaseManager.py
@@ -170,6 +170,29 @@ class WorldDatabaseManager(object):
         res = world_db_session.query(GameobjectTemplate).filter_by(entry=entry).first()
         return res, world_db_session
 
+    @staticmethod
+    def gameobject_get_loot_template():
+        world_db_session = SessionHolder()
+        res = world_db_session.query(GameobjectLootTemplate).all()
+        world_db_session.close()
+        return res
+
+    class GameObjectLootTemplateHolder:
+        GAMEOBJECTS_LOOT_TEMPLATES = {}
+
+        @staticmethod
+        def load_gameobjects_loot_template(gameobject_template):
+            if gameobject_template.entry not in WorldDatabaseManager.GameObjectLootTemplateHolder.GAMEOBJECTS_LOOT_TEMPLATES:
+                WorldDatabaseManager.GameObjectLootTemplateHolder.GAMEOBJECTS_LOOT_TEMPLATES[gameobject_template.entry] = []
+
+            WorldDatabaseManager.GameObjectLootTemplateHolder.GAMEOBJECTS_LOOT_TEMPLATES[gameobject_template.entry]\
+                .append(gameobject_template)
+
+        @staticmethod
+        def gameobject_loot_template_get_by_object(gameobject_entry):
+            return WorldDatabaseManager.GameObjectLootTemplateHolder.GAMEOBJECTS_LOOT_TEMPLATES[gameobject_entry] \
+                if gameobject_entry in WorldDatabaseManager.GameObjectLootTemplateHolder.GAMEOBJECTS_LOOT_TEMPLATES else []
+
     # Creature stuff
 
     @staticmethod
@@ -305,3 +328,4 @@ class WorldDatabaseManager(object):
         res = world_db_session.query(QuestTemplate).filter_by(ignored=0).all()
         world_db_session.close()
         return res
+

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -21,6 +21,7 @@ class WorldLoader:
         # Gameobject spawns
         if config.Server.Settings.load_gameobjects:
             WorldLoader.load_gameobjects()
+            WorldLoader.load_gameobject_loot_templates()
         else:
             Logger.info('Skipped game object loading.')
 
@@ -98,6 +99,19 @@ class WorldLoader:
             WorldDatabaseManager.CreatureLootTemplateHolder.load_creature_loot_template(loot_template)
             count += 1
             Logger.progress('Loading creature loot templates...', count, length)
+
+        return length
+
+    @staticmethod
+    def load_gameobject_loot_templates():
+        gameobject_loot_templates = WorldDatabaseManager.gameobject_get_loot_template()
+        length = len(gameobject_loot_templates)
+        count = 0
+
+        for loot_template in gameobject_loot_templates:
+            WorldDatabaseManager.GameObjectLootTemplateHolder.load_gameobjects_loot_template(loot_template)
+            count += 1
+            Logger.progress('Loading gameobject loot templates...', count, length)
 
         return length
 

--- a/game/world/managers/objects/GameObjectManager.py
+++ b/game/world/managers/objects/GameObjectManager.py
@@ -91,12 +91,14 @@ class GameObjectManager(ObjectManager):
             # Activate chest open animation, while active, it won't let any other player loot.
             if self.state == GameObjectStates.GO_STATE_READY:
                 self.state = GameObjectStates.GO_STATE_ACTIVE
-            self.send_update_surrounding()
+                self.send_update_surrounding()
+            # Generate loot if its empty.
             if not self.loot_manager.has_loot():
                 self.loot_manager.generate_loot(player)
+
             player.send_loot(self)
 
-    def release(self):
+    def set_ready(self):
         if self.state != GameObjectStates.GO_STATE_READY:
             self.state = GameObjectStates.GO_STATE_READY
             self.send_update_surrounding()

--- a/game/world/managers/objects/GameObjectManager.py
+++ b/game/world/managers/objects/GameObjectManager.py
@@ -6,6 +6,7 @@ from database.dbc.DbcDatabaseManager import DbcDatabaseManager
 from game.world.managers.abstractions.Vector import Vector
 from game.world.managers.maps.MapManager import MapManager
 from game.world.managers.objects.ObjectManager import ObjectManager
+from game.world.managers.objects.gameobjects.GameObjectLootManager import GameObjectLootManager
 from network.packet.PacketWriter import PacketWriter
 from network.packet.update.UpdatePacketFactory import UpdatePacketFactory
 from utils.constants.MiscCodes import ObjectTypes, ObjectTypeIds, HighGuid, GameObjectTypes, \
@@ -42,6 +43,8 @@ class GameObjectManager(ObjectManager):
             self.location.z = self.gobject_instance.spawn_positionZ
             self.location.o = self.gobject_instance.spawn_orientation
             self.map_ = self.gobject_instance.spawn_map
+
+        self.loot_manager = GameObjectLootManager(self)
 
         self.object_type.append(ObjectTypes.TYPE_GAMEOBJECT)
         self.update_packet_factory.init_values(GameObjectFields.GAMEOBJECT_END)
@@ -84,6 +87,10 @@ class GameObjectManager(ObjectManager):
                         y_lowest = y_i
                 player.teleport(player.map_, Vector(x_lowest, y_lowest, self.location.z, self.location.o))
                 player.set_stand_state(StandState.UNIT_SITTINGCHAIRLOW.value + height)
+        elif self.gobject_template.type == GameObjectTypes.TYPE_CHEST:
+            if not self.loot_manager.has_loot():
+                self.loot_manager.generate_loot(player)
+            player.send_loot(self)
 
     # override
     def set_display_id(self, display_id):

--- a/game/world/managers/objects/GameObjectManager.py
+++ b/game/world/managers/objects/GameObjectManager.py
@@ -88,11 +88,20 @@ class GameObjectManager(ObjectManager):
                 player.teleport(player.map_, Vector(x_lowest, y_lowest, self.location.z, self.location.o))
                 player.set_stand_state(StandState.UNIT_SITTINGCHAIRLOW.value + height)
         elif self.gobject_template.type == GameObjectTypes.TYPE_CHEST:
+            # Activate chest open animation, while active, it won't let any other player loot.
+            if self.state == GameObjectStates.GO_STATE_READY:
+                self.state = GameObjectStates.GO_STATE_ACTIVE
+            self.send_update_surrounding()
             if not self.loot_manager.has_loot():
                 self.loot_manager.generate_loot(player)
             player.send_loot(self)
 
-    # override
+    def release(self):
+        if self.state != GameObjectStates.GO_STATE_READY:
+            self.state = GameObjectStates.GO_STATE_READY
+            self.send_update_surrounding()
+
+            # override
     def set_display_id(self, display_id):
         super().set_display_id(display_id)
         if display_id <= 0 or not \

--- a/game/world/managers/objects/LootManager.py
+++ b/game/world/managers/objects/LootManager.py
@@ -21,7 +21,7 @@ class LootManager(object):
         self.world_object = world_object
         self.current_money = 0
         self.current_loot = []
-        self.loot_template = self.populate_loot_template()
+        self.loot_template = None
         self.active_looters = []
 
     # Needs overriding
@@ -53,7 +53,7 @@ class LootManager(object):
     def has_loot(self):
         return self.has_money() or self.has_items()
 
-    def get_loot_type(self, player, victim):
+    def get_loot_type(self, player, world_obj):
         return LootTypes.LOOT_TYPE_NOTALLOWED
 
     def add_active_looter(self, player_mgr):

--- a/game/world/managers/objects/LootManager.py
+++ b/game/world/managers/objects/LootManager.py
@@ -21,7 +21,7 @@ class LootManager(object):
         self.world_object = world_object
         self.current_money = 0
         self.current_loot = []
-        self.loot_template = None
+        self.loot_template = self.populate_loot_template()
         self.active_looters = []
 
     # Needs overriding

--- a/game/world/managers/objects/creature/CreatureLootManager.py
+++ b/game/world/managers/objects/creature/CreatureLootManager.py
@@ -13,9 +13,6 @@ class CreatureLootManager(LootManager):
 
     # override
     def generate_loot(self, requester):
-        if not self.loot_template:
-            self.loot_template = self.populate_loot_template()
-
         money = randint(self.world_object.creature_template.gold_min, self.world_object.creature_template.gold_max)
         self.current_money = money
 
@@ -43,18 +40,18 @@ class CreatureLootManager(LootManager):
             .creature_loot_template_get_by_creature(self.world_object.entry)
 
     # override
-    def get_loot_type(self, player, world_obj):
+    def get_loot_type(self, player, creature):
         loot_type = LootTypes.LOOT_TYPE_NOTALLOWED
 
         # Not tagged, anyone can loot.
-        if not world_obj.killed_by:
+        if not creature.killed_by:
             loot_type = LootTypes.LOOT_TYPE_CORPSE
         # Killer has party and loot_method allows player to loot.
-        elif world_obj.killed_by and world_obj.killed_by.group_manager and world_obj.killed_by.group_manager.is_party_member(player.guid):
-            if player.guid in world_obj.killed_by.group_manager.get_allowed_looters(world_obj):
+        elif creature.killed_by and creature.killed_by.group_manager and creature.killed_by.group_manager.is_party_member(player.guid):
+            if player.guid in creature.killed_by.group_manager.get_allowed_looters(creature):
                 loot_type = LootTypes.LOOT_TYPE_CORPSE
         # No party but looter is the actual killer.
-        elif world_obj.killed_by == player:
+        elif creature.killed_by == player:
             loot_type = LootTypes.LOOT_TYPE_CORPSE
 
         return loot_type

--- a/game/world/managers/objects/gameobjects/GameObjectLootManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectLootManager.py
@@ -17,7 +17,8 @@ class GameObjectLootManager(LootManager):
         if len(self.loot_template) == 0:
             self.loot_template = self.populate_loot_template()
 
-        for loot_item in choices(self.loot_template, k=5):
+        # For now, randomly pick 1..7 items.
+        for loot_item in choices(self.loot_template, k=randint(1, 7)):
             chance = float(round(uniform(0.0, 1.0), 2) * 100)
             item_template = WorldDatabaseManager.ItemTemplateHolder.item_template_get_by_entry(loot_item.item)
             if item_template:
@@ -30,6 +31,7 @@ class GameObjectLootManager(LootManager):
                 item_chance = loot_item.ChanceOrQuestChance
                 item_chance = item_chance if item_chance > 0 else item_chance * -1
 
+                # TODO: ChanceOrQuestChance = 0 on Gameobjects equals 100% chance?
                 if item_chance >= 100 or chance - item_chance < 0 or loot_item.ChanceOrQuestChance == 0:
                     item = ItemManager.generate_item_from_entry(item_template.entry)
                     if item:
@@ -42,6 +44,4 @@ class GameObjectLootManager(LootManager):
 
     # override
     def get_loot_type(self, player, gameobject):
-        # TODO: Proper checks, just usable by one active looter. Need to release active looters upon SPELL_CAST_CANCEL
         return LootTypes.LOOT_TYPE_CORPSE
-

--- a/game/world/managers/objects/gameobjects/GameObjectLootManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectLootManager.py
@@ -9,12 +9,12 @@ from utils.constants.MiscCodes import LootTypes
 
 class GameObjectLootManager(LootManager):
     def __init__(self, object_mgr):
-        self.current_money = 0
         super(GameObjectLootManager, self).__init__(object_mgr)
 
     # override
     def generate_loot(self, requester):
-        if not self.loot_template:
+        # TODO: Even if called on parent, this is not properly est as CreatureLootManager.
+        if len(self.loot_template) == 0:
             self.loot_template = self.populate_loot_template()
 
         for loot_item in choices(self.loot_template, k=5):
@@ -41,7 +41,7 @@ class GameObjectLootManager(LootManager):
             .gameobject_loot_template_get_by_object(self.world_object.gobject_template.data1)
 
     # override
-    def get_loot_type(self, player, world_obj):
+    def get_loot_type(self, player, gameobject):
         # TODO: Proper checks, just usable by one active looter. Need to release active looters upon SPELL_CAST_CANCEL
         return LootTypes.LOOT_TYPE_CORPSE
 

--- a/game/world/managers/objects/gameobjects/GameObjectLootManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectLootManager.py
@@ -13,7 +13,7 @@ class GameObjectLootManager(LootManager):
 
     # override
     def generate_loot(self, requester):
-        # TODO: Even if called on parent, this is not properly est as CreatureLootManager.
+        # TODO: Even if called on parent, this is not properly set as with CreatureLootManager.
         if len(self.loot_template) == 0:
             self.loot_template = self.populate_loot_template()
 

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -21,6 +21,7 @@ from game.world.opcode_handling.handlers.player.NameQueryHandler import NameQuer
 from network.packet.PacketWriter import *
 from network.packet.update.UpdatePacketFactory import UpdatePacketFactory
 from utils import Formulas
+from utils.Logger import Logger
 from utils.constants.DuelCodes import *
 from utils.constants.MiscCodes import ChatFlags, LootTypes
 from utils.constants.MiscCodes import ObjectTypes, ObjectTypeIds, PlayerFlags, WhoPartyStatus, HighGuid, \
@@ -560,30 +561,38 @@ class PlayerManager(UnitManager):
     def send_loot_release(self, guid):
         self.unit_flags &= ~UnitFlags.UNIT_FLAG_LOOTING
         self.set_uint32(UnitFields.UNIT_FIELD_FLAGS, self.unit_flags)
-        self.current_loot_selection = 0
-
+        
+        high_guid: HighGuid = self.extract_high_guid(self.current_loot_selection)
         data = pack('<QB', guid, 1)  # Must be 1 otherwise client keeps the loot window open
         self.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_LOOT_RELEASE_RESPONSE, data))
 
-        # If this release comes from the loot owner and has no party, set killed_by to None to allow FFA loot.
-        enemy = MapManager.get_surrounding_unit_by_guid(self, guid, include_players=False)
-        if enemy:
-            if enemy.killed_by and enemy.killed_by == self and not enemy.killed_by.group_manager:
-                enemy.killed_by = None
-            # If in party, check if this player has rights to release the loot for FFA.
-            elif enemy.killed_by and enemy.killed_by.group_manager:
-                if self in enemy.killed_by.group_manager.get_allowed_looters(enemy):
-                    if not enemy.loot_manager.has_loot():  # Flush looters for this enemy.
-                        enemy.killed_by.group_manager.clear_looters_for_victim(enemy)
+        if high_guid == HighGuid.HIGHGUID_UNIT:
+            # If this release comes from the loot owner and has no party, set killed_by to None to allow FFA loot.
+            enemy = MapManager.get_surrounding_unit_by_guid(self, guid, include_players=False)
+            if enemy:
+                if enemy.killed_by and enemy.killed_by == self and not enemy.killed_by.group_manager:
                     enemy.killed_by = None
+                # If in party, check if this player has rights to release the loot for FFA.
+                elif enemy.killed_by and enemy.killed_by.group_manager:
+                    if self in enemy.killed_by.group_manager.get_allowed_looters(enemy):
+                        if not enemy.loot_manager.has_loot():  # Flush looters for this enemy.
+                            enemy.killed_by.group_manager.clear_looters_for_victim(enemy)
+                        enemy.killed_by = None
 
-            if not enemy.loot_manager.has_loot():
-                enemy.set_lootable(False)
-                enemy.set_dirty()
-                enemy.loot_manager.clear()
+                if not enemy.loot_manager.has_loot():
+                    enemy.set_lootable(False)
+                    enemy.set_dirty()
+                    enemy.loot_manager.clear()
 
-            enemy.loot_manager.remove_active_looter(self)
+                enemy.loot_manager.remove_active_looter(self)
+        elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
+            game_object = MapManager.get_surrounding_gameobject_by_guid(self, self.current_loot_selection)
+            if game_object:
+                game_object.release()
+        else:
+            Logger.warning(f'Unhandled loot release for type {HighGuid(high_guid).name}')
 
+        self.current_loot_selection = 0
         self.set_dirty()
 
     def send_loot(self, world_obj):

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -602,7 +602,7 @@ class PlayerManager(UnitManager):
                     world_obj.guid,
                     loot_type,
                     world_obj.loot_manager.current_money,
-                    len(world_obj.loot_manager.current_loot),
+                    len(world_obj.loot_manager.current_loot)
                     )
 
         # Do not send loot if player has no permission.

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -561,7 +561,7 @@ class PlayerManager(UnitManager):
     def send_loot_release(self, guid):
         self.unit_flags &= ~UnitFlags.UNIT_FLAG_LOOTING
         self.set_uint32(UnitFields.UNIT_FIELD_FLAGS, self.unit_flags)
-        
+
         high_guid: HighGuid = self.extract_high_guid(self.current_loot_selection)
         data = pack('<QB', guid, 1)  # Must be 1 otherwise client keeps the loot window open
         self.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_LOOT_RELEASE_RESPONSE, data))
@@ -588,7 +588,7 @@ class PlayerManager(UnitManager):
         elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
             game_object = MapManager.get_surrounding_gameobject_by_guid(self, self.current_loot_selection)
             if game_object:
-                game_object.release()
+                game_object.set_ready()
         else:
             Logger.warning(f'Unhandled loot release for type {HighGuid(high_guid).name}')
 

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -161,5 +161,5 @@ SPELL_EFFECTS = {
     SpellEffects.SPELL_EFFECT_CREATE_ITEM: SpellEffectHandler.handle_create_item,
     SpellEffects.SPELL_EFFECT_TELEPORT_UNITS: SpellEffectHandler.handle_teleport_units,
     SpellEffects.SPELL_EFFECT_PERSISTENT_AREA_AURA: SpellEffectHandler.handle_persistent_area_aura,
-    SpellEffects.SPELL_EFFECT_OPEN_LOCK: SpellEffectHandler.handle_open_lock,
+    SpellEffects.SPELL_EFFECT_OPEN_LOCK: SpellEffectHandler.handle_open_lock
 }

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -66,7 +66,8 @@ class SpellEffectHandler(object):
 
     @staticmethod
     def handle_open_lock(casting_spell, effect, caster, target):
-        target.use(caster)
+        if caster and target:
+            target.use(caster)
 
     @staticmethod
     def handle_energize(casting_spell, effect, caster, target):

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -65,6 +65,10 @@ class SpellEffectHandler(object):
         caster.spell_manager.send_cast_result(casting_spell.spell_entry.ID, result)
 
     @staticmethod
+    def handle_open_lock(casting_spell, effect, caster, target):
+        target.use(caster)
+
+    @staticmethod
     def handle_energize(casting_spell, effect, caster, target):
         power_type = effect.misc_value
 
@@ -155,5 +159,6 @@ SPELL_EFFECTS = {
     SpellEffects.SPELL_EFFECT_INSTAKILL: SpellEffectHandler.handle_insta_kill,
     SpellEffects.SPELL_EFFECT_CREATE_ITEM: SpellEffectHandler.handle_create_item,
     SpellEffects.SPELL_EFFECT_TELEPORT_UNITS: SpellEffectHandler.handle_teleport_units,
-    SpellEffects.SPELL_EFFECT_PERSISTENT_AREA_AURA: SpellEffectHandler.handle_persistent_area_aura
+    SpellEffects.SPELL_EFFECT_PERSISTENT_AREA_AURA: SpellEffectHandler.handle_persistent_area_aura,
+    SpellEffects.SPELL_EFFECT_OPEN_LOCK: SpellEffectHandler.handle_open_lock,
 }

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -128,6 +128,7 @@ class SpellManager(object):
         self.consume_resources_for_cast(casting_spell)  # Remove resources - order matters for combo points
 
     def apply_spell_effects(self, casting_spell, targeted=True, remove=False):
+
         for effect in casting_spell.effects:
             if not targeted:  # Effects that resolve targets in handler - ie. rain of fire, blizzard
                 SpellEffectHandler.apply_effect(casting_spell, effect, casting_spell.spell_caster, None)


### PR DESCRIPTION
* Modified some loot related methods to be 'generic' to world_obj
* Player, had to add 'current_loot_selection', since gameobject interaction does not set 'current_selection' field, maybe we should be setting it on SpellManager after resolving a single target.

* Known issues:
/ Chest despawn/respawn? Fill loot table upon respawn, right now it will be filled everytime its empty.
/ @Fluglow , left you a comment over CastSpellHandler related to target resolving.