### PR TITLE
Minor spell/aura related refactoring and fixes

### DIFF
--- a/game/world/managers/objects/spell/AppliedAura.py
+++ b/game/world/managers/objects/spell/AppliedAura.py
@@ -1,13 +1,89 @@
 import time
 from struct import pack
 
-from game.world.managers.objects.spell.AppliedAura import AppliedAura
 from game.world.managers.objects.spell.AuraEffectHandler import AuraEffectHandler
 from network.packet.PacketWriter import PacketWriter, OpCode
 from utils.constants.MiscCodes import ObjectTypes
-from utils.constants.SpellCodes import AuraTypes, AuraSlots, SpellEffects
+from utils.constants.SpellCodes import AuraTypes, ShapeshiftForms, AuraSlots, SpellEffects
 from utils.constants.UnitCodes import UnitFlags
 from utils.constants.UpdateFields import UnitFields
+
+
+class AppliedAura:
+    def __init__(self, caster, casting_spell, spell_effect, target):
+        self.target = target
+        self.source_spell = casting_spell
+
+        self.caster = caster
+        self.spell_id = casting_spell.spell_entry.ID
+        self.spell_effect = spell_effect
+        self.duration_entry = casting_spell.duration_entry
+        self.duration = self.duration_entry.Duration if self.duration_entry else -1
+        self.effective_level = casting_spell.caster_effective_level
+
+        self.period = spell_effect.aura_period
+
+        self.passive = casting_spell.is_passive()
+        for effect in casting_spell.effects:
+            if effect.effect_index >= spell_effect.effect_index:
+                break
+            if effect.effect_type == SpellEffects.SPELL_EFFECT_APPLY_AURA and \
+                    effect.implicit_target_a == self.spell_effect.implicit_target_a:
+                # Some buffs/debuffs have multiple effects in one aura, in which case they're merged in the UI
+                # If this spell has an effect with a lower index already applies an aura,
+                # this aura is set to passive to not display twice in client.
+                self.passive = True
+                break
+
+        self.aura_period_timestamps = []  # Set on application
+        self.index = -1  # Set on application
+
+    def has_duration(self) -> bool:
+        return self.duration != -1
+
+    def is_passive(self) -> bool:
+        return self.passive
+
+    def is_periodic(self) -> bool:
+        return self.period != 0
+
+    def is_harmful(self) -> bool:
+        if self.source_spell.initial_target_is_object():
+            return self.caster.is_enemy_to(self.target)  # TODO not always applicable, ie. arcane missiles
+
+        # Terrain-targeted aura
+        return not self.spell_effect.targets.can_target_friendly()
+
+    def is_past_next_period_timestamp(self) -> bool:
+        if len(self.aura_period_timestamps) == 0:
+            return False
+        return time.time() > self.aura_period_timestamps[-1]
+
+    def pop_period_timestamp(self):
+        if len(self.aura_period_timestamps) == 0:
+            return
+        self.aura_period_timestamps.pop()
+
+    def initialize_period_timestamps(self):
+        if self.period == 0 or self.duration == -1 or len(self.aura_period_timestamps) > 0:  # Don't overwrite old timestamps
+            return
+        period = self.period
+        ticks = int(self.duration / self.period)
+        period /= 1000  # Millis -> seconds
+        curr_time = time.time()
+
+        for i in range(ticks, 0, -1):  # timestamp stack for channel ticks, first element being last tick
+            self.aura_period_timestamps.append(curr_time + period * i)
+
+
+    def update(self, elapsed):
+        if self.has_duration():
+            self.duration -= int(elapsed * 1000)
+
+        if not self.target:  # Auras that are only tied to effects - ie. persistent area auras
+            return
+        if self.is_periodic():
+            AuraEffectHandler.handle_aura_effect_change(self)
 
 
 class AuraManager:

--- a/game/world/managers/objects/spell/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/AuraEffectHandler.py
@@ -1,0 +1,106 @@
+from utils.ConfigManager import config
+from utils.Logger import Logger
+from utils.constants.MiscCodes import Factions, ObjectTypes
+from utils.constants.SpellCodes import ShapeshiftForms, AuraTypes
+
+
+class AuraEffectHandler:
+    @staticmethod
+    def handle_aura_effect_change(aura, remove=False):
+        # if aura.spell_effect.effect_type != SpellEffects.SPELL_EFFECT_APPLY_AURA:
+        #     return  # TODO check all effects that apply auras
+        if aura.spell_effect.aura_type not in AURA_EFFECTS:
+            Logger.debug(f'Unimplemented aura effect called: {aura.spell_effect.aura_type}')
+            return
+
+        AURA_EFFECTS[aura.spell_effect.aura_type](aura, remove)
+
+    @staticmethod
+    def handle_shapeshift(aura, remove):
+        form = aura.spell_effect.misc_value if not remove else ShapeshiftForms.SHAPESHIFT_FORM_NONE
+        aura.target.set_shapeshift_form(form)
+        if remove or aura.spell_effect.misc_value not in SHAPESHIFT_MODEL_IDS:
+            aura.target.reset_display_id()
+            aura.target.reset_scale()
+            aura.target.set_dirty()
+            return
+
+        shapeshift_display_info = SHAPESHIFT_MODEL_IDS[aura.spell_effect.misc_value]
+        display_index = 1 if aura.target.faction == Factions.HORDE else 0
+        model_scale = shapeshift_display_info[2]
+        aura.target.set_display_id(shapeshift_display_info[display_index])
+        aura.target.set_scale(model_scale)
+        aura.target.set_dirty()
+
+    @staticmethod
+    def handle_mounted(aura, remove):  # TODO Summon Nightmare (5784) does not apply for other players ?
+        if remove:
+            aura.target.unmount()
+            aura.target.set_dirty()
+            return
+
+        creature_entry = aura.spell_effect.misc_value
+        if not aura.target.summon_mount(creature_entry):
+            Logger.error(f'SPELL_AURA_MOUNTED: Creature template ({creature_entry}) not found in database.')
+
+    @staticmethod
+    def handle_increase_mounted_speed(aura, remove):
+        # TODO: Should handle for creatures too? (refactor all change speed methods?)
+        if aura.target.get_type() != ObjectTypes.TYPE_PLAYER:
+            return
+        aura.target.change_speed()
+        if remove:
+            return
+
+        default_speed = config.Unit.Defaults.run_speed
+        speed_percentage = aura.spell_effect.get_effect_points(aura.effective_level) / 100.0
+        aura.target.change_speed(default_speed + (default_speed * speed_percentage))
+
+    @staticmethod
+    def handle_periodic_trigger_spell(aura, remove):
+        if not aura.is_past_next_period_timestamp() or remove:
+            return
+        aura.pop_period_timestamp()
+        new_spell_entry = aura.spell_effect.trigger_spell_entry
+        spell = aura.caster.spell_manager.try_initialize_spell(new_spell_entry, aura.caster, aura.source_spell.initial_target,
+                                                               aura.source_spell.spell_target_mask, validate=False)
+        aura.caster.spell_manager.perform_spell_cast(spell, validate=False)
+
+    @staticmethod
+    def handle_periodic_damage(aura, remove):
+        if not aura.is_past_next_period_timestamp() or remove:
+            return
+        aura.pop_period_timestamp()
+
+        spell = aura.source_spell
+        damage = aura.spell_effect.get_effect_points(aura.spell_effect.caster_effective_level)
+        aura.caster.deal_spell_damage(aura.target, damage, spell.spell_entry.School, spell.spell_entry.ID)
+
+    @staticmethod
+    def handle_periodic_leech(aura, remove):
+        if not aura.is_past_next_period_timestamp() or remove:
+            return
+        aura.pop_period_timestamp()
+
+        spell = aura.source_spell
+        damage = aura.spell_effect.get_effect_points(aura.spell_effect.caster_effective_level)
+        aura.caster.deal_spell_damage(aura.target, damage, spell.spell_entry.School, spell.spell_entry.ID)
+        # TODO Heal
+
+
+AURA_EFFECTS = {
+    AuraTypes.SPELL_AURA_MOD_SHAPESHIFT: AuraEffectHandler.handle_shapeshift,
+    AuraTypes.SPELL_AURA_MOUNTED: AuraEffectHandler.handle_mounted,
+    AuraTypes.SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED: AuraEffectHandler.handle_increase_mounted_speed,
+    AuraTypes.SPELL_AURA_PERIODIC_TRIGGER_SPELL: AuraEffectHandler.handle_periodic_trigger_spell,
+    AuraTypes.SPELL_AURA_PERIODIC_DAMAGE: AuraEffectHandler.handle_periodic_damage,
+    AuraTypes.SPELL_AURA_PERIODIC_LEECH: AuraEffectHandler.handle_periodic_leech,
+}
+
+# Alliance / Default display_id, Horde display_id, Scale
+SHAPESHIFT_MODEL_IDS = {
+    ShapeshiftForms.SHAPESHIFT_FORM_CAT: (892, 892, 0.8),
+    ShapeshiftForms.SHAPESHIFT_FORM_TREE: (864, 864, 1.0),
+    ShapeshiftForms.SHAPESHIFT_FORM_AQUATIC: (2428, 2428, 0.8),
+    ShapeshiftForms.SHAPESHIFT_FORM_BEAR: (2281, 2289, 1.0)
+}

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -43,6 +43,7 @@ class EffectTargets:
             SpellImplicitTargets.TARGET_PET: [],  # TODO
             SpellImplicitTargets.TARGET_CHAIN_DAMAGE: self.initial_target if not target_is_friendly else [],  # TODO - resolve chain targets
             SpellImplicitTargets.TARGET_INNKEEPER_COORDINATES: self.caster.get_deathbind_coordinates() if target_is_player else [],
+            SpellImplicitTargets.TARGET_11: [],  # Word of Recall Other - seems deprecated so return nothing
             SpellImplicitTargets.TARGET_SELECTED_FRIEND: self.initial_target if target_is_friendly else [],
             SpellImplicitTargets.TARGET_SELECTED_GAMEOBJECT: self.initial_target if target_is_gameobject else [],
             SpellImplicitTargets.TARGET_DUEL_VS_PLAYER: self.initial_target,  # Spells that can be cast on both hostile and friendly?

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -150,6 +150,11 @@ class SpellEffectHandler(object):
         for target in missing_targets:
             target.aura_manager.cancel_auras_by_spell_id(spell_id)
 
+    @staticmethod
+    def handle_learn_spell(casting_spell, effect, caster, target):
+        target_spell_id = effect.trigger_spell_id
+        target.spell_manager.learn_spell(target_spell_id)
+
 
 SPELL_EFFECTS = {
     SpellEffects.SPELL_EFFECT_SCHOOL_DAMAGE: SpellEffectHandler.handle_school_damage,
@@ -165,5 +170,6 @@ SPELL_EFFECTS = {
     SpellEffects.SPELL_EFFECT_CREATE_ITEM: SpellEffectHandler.handle_create_item,
     SpellEffects.SPELL_EFFECT_TELEPORT_UNITS: SpellEffectHandler.handle_teleport_units,
     SpellEffects.SPELL_EFFECT_PERSISTENT_AREA_AURA: SpellEffectHandler.handle_persistent_area_aura,
-    SpellEffects.SPELL_EFFECT_OPEN_LOCK: SpellEffectHandler.handle_open_lock
+    SpellEffects.SPELL_EFFECT_OPEN_LOCK: SpellEffectHandler.handle_open_lock,
+    SpellEffects.SPELL_EFFECT_LEARN_SPELL: SpellEffectHandler.handle_learn_spell
 }

--- a/utils/constants/UnitCodes.py
+++ b/utils/constants/UnitCodes.py
@@ -50,12 +50,12 @@ class Teams(IntEnum):
 
 
 class PowerTypes(IntEnum):
+    TYPE_HEALTH = -2
     TYPE_MANA = 0
     TYPE_RAGE = 1
     TYPE_FOCUS = 2
     TYPE_ENERGY = 3
     TYPE_HAPPINESS = 4
-    POWER_HEALTH = 0xFFFFFFFE
 
 
 class UnitFlags(IntEnum):


### PR DESCRIPTION
- Separate aura-related classes
- Implement learn_spell spelleffect and health cost handling for spells (Life Tap etc.)
- Add empty handler for Word of Recall Other. The ImplicitTarget is only used for this spell, so it's tough to know what the intended targeting was. Left it empty as it's unlikely players should be able to teleport each other without confirmation.