### PR TITLE
Proper handling for delayed cooldowns, fix to TARGET_INITIAL resolving

### DIFF
--- a/game/world/managers/objects/spell/AuraManager.py
+++ b/game/world/managers/objects/spell/AuraManager.py
@@ -206,7 +206,7 @@ class AuraManager:
 
         # Some spells start cooldown on aura remove, handle that case here
         if aura.source_spell.trigger_cooldown_on_aura_remove():
-            self.unit_mgr.spell_manager.set_on_cooldown(aura.source_spell.spell_entry)
+            self.unit_mgr.spell_manager.set_on_cooldown(aura.source_spell, start_locked_cooldown=True)
 
         if aura.passive:
             return  # Passive auras aren't written to unit

--- a/game/world/managers/objects/spell/CooldownEntry.py
+++ b/game/world/managers/objects/spell/CooldownEntry.py
@@ -6,15 +6,23 @@ class CooldownEntry(object):
     cooldown_category: int
     cooldown_length: int
     end_timestamp: int
+    locked: bool
 
-    def __init__(self, spell_entry, timestamp):
+    def __init__(self, spell_entry, timestamp, locked=False):
         self.spell_id = spell_entry.ID
         self.cooldown_category = spell_entry.Category if spell_entry.CategoryRecoveryTime > 0 else -1  # If category cd isn't provided, set to invalid category
         self.cooldown_length = spell_entry.CategoryRecoveryTime if self.cooldown_category != -1 else spell_entry.RecoveryTime
         self.end_timestamp = timestamp + self.cooldown_length/1000
+        self.locked = locked
 
     def is_valid(self):
-        return self.end_timestamp > time.time()
+        return self.locked or self.end_timestamp > time.time()
+
+    def unlock(self, timestamp):
+        if not self.locked:
+            return
+        self.locked = False
+        self.end_timestamp = timestamp + self.cooldown_length/1000
 
     def matches_spell(self, spell_entry):
         return self.spell_id == spell_entry.ID or self.cooldown_category == spell_entry.Category

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -64,9 +64,6 @@ class EffectTargets:
         }
 
     def resolve_implicit_targets_reference(self, implicit_target) -> Optional[list[Union[ObjectManager, Vector]]]:
-        if implicit_target == 0:
-            return []
-
         target = self.simple_targets[implicit_target] if implicit_target in self.simple_targets else TARGET_RESOLVERS[implicit_target](self.casting_spell, self.target_effect)
 
         # Avoid crash on unfinished implementation while target resolving isn't finished TODO

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -165,8 +165,8 @@ class SpellManager(object):
             if casting_spell.cast_state != SpellState.SPELL_STATE_ACTIVE:
                 self.remove_cast(casting_spell)
 
-        if not casting_spell.trigger_cooldown_on_aura_remove():
-            self.set_on_cooldown(casting_spell.spell_entry)
+        #if not casting_spell.trigger_cooldown_on_aura_remove():
+        self.set_on_cooldown(casting_spell)
 
         self.consume_resources_for_cast(casting_spell)  # Remove resources - order matters for combo points
 
@@ -552,10 +552,24 @@ class SpellManager(object):
         MapManager.send_surrounding(PacketWriter.get_packet(OpCode.SMSG_SPELL_GO, packed), self.unit_mgr,
                                     include_self=self.unit_mgr.get_type() == ObjectTypes.TYPE_PLAYER)
 
-    def set_on_cooldown(self, spell):
+    def set_on_cooldown(self, casting_spell, start_locked_cooldown=False):
+        spell = casting_spell.spell_entry
+
         if spell.RecoveryTime == 0 and spell.CategoryRecoveryTime == 0:
             return
-        cooldown_entry = CooldownEntry(spell, time.time())
+
+        timestamp = time.time()
+
+        if start_locked_cooldown:
+            data = pack('<IQ', spell.ID, self.unit_mgr.guid)
+            self.unit_mgr.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_COOLDOWN_EVENT, data))
+            for cooldown in self.cooldowns:
+                if cooldown.spell_id == spell.ID:
+                    cooldown.unlock(timestamp)
+                    return
+            Logger.warning(f'[SpellManager]: Attempted to unlock cooldown for spell {spell.ID}, but the cooldown didn\'t exist.')
+
+        cooldown_entry = CooldownEntry(spell, timestamp, casting_spell.trigger_cooldown_on_aura_remove())
         self.cooldowns.append(cooldown_entry)
 
         if self.unit_mgr.get_type() != ObjectTypes.TYPE_PLAYER:


### PR DESCRIPTION
- Fix delayed cooldowns (stealth, shapeshifts etc.) starting on aura removal.
- Remove check that made TARGET_INITIAL always resolve to no targets (leftover from the target being always resolved to nothing).