### PR TITLE
Guild handlers fixes noticed by Yushe.

### DIFF
--- a/game/world/managers/objects/player/guild/GuildManager.py
+++ b/game/world/managers/objects/player/guild/GuildManager.py
@@ -378,9 +378,10 @@ class GuildManager(object):
             return False
 
         guild = GuildManager._create_guild("", guild_name, -1, -1, -1, -1, -1, player_mgr.guid)
-        player_mgr.guild_manager = GuildManager(guild)
-        GuildManager.GUILDS[guild_name] = player_mgr.guild_manager
-        player_mgr.guild_manager.add_new_member(player_mgr, is_guild_master=True)
+        guild_manager = GuildManager(guild)
+        player_mgr.guild_manager = guild_manager
+        GuildManager.GUILDS[guild_name] = guild_manager
+        guild_manager.add_new_member(player_mgr, is_guild_master=True)
 
         if petition:
             for member_signer in petition.characters:

--- a/game/world/managers/objects/player/guild/GuildManager.py
+++ b/game/world/managers/objects/player/guild/GuildManager.py
@@ -20,7 +20,6 @@ class GuildManager(object):
         self.guild = guild
         self.members = {}
         self.guild_master = None
-        GuildManager.GUILDS[self.guild.name] = self
 
     def load_guild_members(self):
         members = RealmDatabaseManager.guild_get_members(self.guild)
@@ -29,6 +28,11 @@ class GuildManager(object):
             self.members[member.guid] = member
             if member.rank == 0:
                 self.guild_master = member
+
+        if len(self.members) == 0:
+            RealmDatabaseManager.guild_destroy(self.guild)
+            return False
+        return True
 
     def set_guild_master(self, player_guid):
         member = self.members[player_guid]
@@ -354,8 +358,9 @@ class GuildManager(object):
 
     @staticmethod
     def load_guild(raw_guild):
-        GuildManager.GUILDS[raw_guild.name] = GuildManager(raw_guild)
-        GuildManager.GUILDS[raw_guild.name].load_guild_members()
+        group = GuildManager(raw_guild)
+        if group.load_guild_members():
+            GuildManager.GUILDS[raw_guild.name] = group
 
     @staticmethod
     def create_guild(player_mgr, guild_name, petition=None):
@@ -374,6 +379,7 @@ class GuildManager(object):
 
         guild = GuildManager._create_guild("", guild_name, -1, -1, -1, -1, -1, player_mgr.guid)
         player_mgr.guild_manager = GuildManager(guild)
+        GuildManager.GUILDS[guild_name] = player_mgr.guild_manager
         player_mgr.guild_manager.add_new_member(player_mgr, is_guild_master=True)
 
         if petition:

--- a/game/world/managers/objects/player/guild/GuildManager.py
+++ b/game/world/managers/objects/player/guild/GuildManager.py
@@ -285,6 +285,9 @@ class GuildManager(object):
         self.update_db_guild_members()
         return True
 
+    def has_members(self):
+        return len(self.members) > 1
+
     def has_member(self, player_guid):
         return player_guid in self.members
 

--- a/game/world/opcode_handling/handlers/guild/GuildLeaveHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildLeaveHandler.py
@@ -11,9 +11,11 @@ class GuildLeaveHandler(object):
         if not player.guild_manager:
             GuildManager.send_guild_command_result(player, GuildTypeCommand.GUILD_INVITE_S, '',
                                                    GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
-        elif player.guild_manager.get_rank(player.guid) == GuildRank.GUILDRANK_GUILD_MASTER:  # GM should use disband.
-            GuildManager.send_guild_command_result(player, GuildTypeCommand.GUILD_INVITE_S, '',
-                                                   GuildCommandResults.GUILD_INTERNAL)
+        elif player.guild_manager.get_rank(player.guid) == GuildRank.GUILDRANK_GUILD_MASTER and player.guild_manager.has_members():  # GM should use disband.
+            GuildManager.send_guild_command_result(player, GuildTypeCommand.GUILD_QUIT_S, '',
+                                                   GuildCommandResults.GUILD_LEADER_LEAVE)
+        elif player.guild_manager.get_rank(player.guid) == GuildRank.GUILDRANK_GUILD_MASTER and not player.guild_manager.has_members():
+            player.guild_manager.disband()
         else:
             player.guild_manager.leave(player.guid)
 

--- a/game/world/opcode_handling/handlers/guild/GuildRemoveMemberHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildRemoveMemberHandler.py
@@ -14,17 +14,28 @@ class GuildRemoveMemberHandler(object):
             player_mgr = world_session.player_mgr
 
             if not player_mgr.guild_manager:
-                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_CREATE_S, '',
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_QUIT_S, '',
                                                        GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
+            # Player does not exist.
             if not target_player_mgr:
-                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_QUIT_S, target_name,
                                                        GuildCommandResults.GUILD_PLAYER_NOT_FOUND)
+            # Member does not exist in the Guild.
             elif not player_mgr.guild_manager.has_member(target_player_mgr.guid):
-                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_QUIT_S, target_name,
                                                        GuildCommandResults.GUILD_PLAYER_NOT_IN_GUILD)
+            # Any rank below Officer is not allowed to kick another guild member.
             elif player_mgr.guild_manager.get_rank(player_mgr.guid) > GuildRank.GUILDRANK_OFFICER:
                 GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
                                                        GuildCommandResults.GUILD_PERMISSIONS)
+            # Officers can't kick the Guild Master or another Officer.
+            elif player_mgr.guild_manager.get_rank(target_player_mgr.guid) == GuildRank.GUILDRANK_OFFICER and player_mgr.guild_manager.get_rank(player_mgr.guid) <= GuildRank.GUILDRANK_OFFICER:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, '',
+                                                       GuildCommandResults.GUILD_PERMISSIONS)
+            # GM self kick attempt.
+            elif player_mgr.guild_manager.get_rank(target_player_mgr.guid) == GuildRank.GUILDRANK_GUILD_MASTER and player_mgr.guild_manager.get_rank(player_mgr.guid) == GuildRank.GUILDRANK_GUILD_MASTER:
+                GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_QUIT_S, '',
+                                                       GuildCommandResults.GUILD_LEADER_LEAVE)
             else:
                 player_mgr.guild_manager.remove_member(target_player_mgr.guid)
 


### PR DESCRIPTION
/ Guild master should now be able to use /gquit if there are no members left.
/ Proper error message if /gquit is used by GM and Guild has members.
/ Officers can't kick another officer or the GM.
/ GM can't self kick.