### PR TITLE
Restart docker containers on failure only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "9100:9100"
     volumes:
       - .:/var/wow/
-    restart: always
+    restart: on-failure
   sql:
     image: alpha-mariadb:latest
     build: etc/docker/sql
@@ -25,3 +25,4 @@ services:
       - "3306:3306"
     volumes:
       - ./etc/databases/:/etc/databases/
+    restart: on-failure


### PR DESCRIPTION
This will prevent the docker containers to automatically start and boot up when rebooting the host machine even after explicitly stopping the docker containers.