### PR TITLE
Manage multiple level ups and level downs

### DIFF
--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -668,9 +668,16 @@ class PlayerManager(UnitManager):
             self.session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_LOG_XPGAIN, data))
 
         if new_xp >= self.next_level_xp:  # Level up!
+            level_amount = 1
+            # Burn off the experience needed to level from the currently gained XP
+            # If we overshoot double or triple then add it to the calculation
+            while (new_xp >= Formulas.PlayerFormulas.xp_to_level(self.level + level_amount)):
+                new_xp -= Formulas.PlayerFormulas.xp_to_level(self.level + level_amount)
+                level_amount += 1
+            
             self.xp = (new_xp - self.next_level_xp)  # Set the overload xp as current
             self.set_uint32(PlayerFields.PLAYER_XP, self.xp)
-            self.mod_level(self.level + 1)
+            self.mod_level(self.level + level_amount)
         else:
             self.xp = new_xp
             self.set_uint32(PlayerFields.PLAYER_XP, self.xp)


### PR DESCRIPTION
Changes:

- Appropriately count the difference between the starting level and the final level when setting it up with the gm command `.level` giving and taking away the respective talent and skill point for each level added/removed
- If the exp gained will overshoot the bar multiple times it will count and award the appropriate number of levels 