### PR TITLE
 Fix MirrorTimer

### DIFF
--- a/game/world/managers/objects/timers/MirrorTimer.py
+++ b/game/world/managers/objects/timers/MirrorTimer.py
@@ -16,6 +16,7 @@ class MirrorTimer(object):
         self.active = False
         self.remaining = self.duration  # In seconds, sent in milliseconds.
         self.chunk_elapsed = 0  # Seconds, compared versus interval.
+        self.stop_on_tick = False
 
     def start(self, elapsed, spell_id=0):
         if not self.active and self.owner.is_alive:
@@ -42,6 +43,7 @@ class MirrorTimer(object):
     def stop(self):
         if self.active:
             self.active = False
+            self.stop_on_tick = False
             data = pack('<I', self._get_type())
             packet = PacketWriter.get_packet(OpCode.SMSG_STOP_MIRROR_TIMER, data)
             self.owner.session.enqueue_packet(packet)
@@ -84,19 +86,23 @@ class MirrorTimer(object):
                 self.set_remaining(self.chunk_elapsed)
                 self.chunk_elapsed = 0
 
-                if self.type == MirrorTimerTypes.BREATH:
-                    self.handle_damage_timer(0.10)  # Damage: 10% of players max health.
-                elif self.type == MirrorTimerTypes.FATIGUE:
-                    self.handle_damage_timer(0.20)  # Damage: 20% of players max health.
-                else:  # Feign Death.
-                    self.handle_feign_death_timer()
+                if self.stop_on_tick:
+                    self.stop()
+                else:
+                    if self.type == MirrorTimerTypes.BREATH:
+                        self.handle_damage_timer(0.10)  # Damage: 10% of players max health.
+                    elif self.type == MirrorTimerTypes.FATIGUE:
+                        self.handle_damage_timer(0.20)  # Damage: 20% of players max health.
+                    else:  # Feign Death.
+                        self.handle_feign_death_timer()
 
     # TODO, should we halt regeneration when drowning or fatigue?
     #  Find drowning damage formula.
     #  CombatLog should display drown and fatigue.
     def handle_damage_timer(self, dmg_multiplier):
         if self.remaining == self.duration:
-            self.stop()  # Replenished.
+            # Replenished, stop next tick since scale is greater than 1 and client needs to fill its timer bar.
+            self.stop_on_tick = True
         elif self.remaining == 0 and self.owner.health > 0:
             damage = int(self.owner.max_health * dmg_multiplier)
             if self.owner.health - damage <= 0:


### PR DESCRIPTION
/ Client timer should now remain visible until the bar is fully filled.