### PR TITLE
Change MapTile loading.

### DIFF
--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -70,6 +70,7 @@ class MapManager(object):
                     # Avoid loading tiles information if we already did.
                     if not MAPS[map_id].tiles[x + i][y + j]:
                         MAPS[map_id].tiles[x + i][y + j] = MapTile(map_id, x + i, y + j)
+                        MAPS[map_id].tiles[x + i][y + j].load()
 
         return True
 

--- a/game/world/managers/maps/MapTile.py
+++ b/game/world/managers/maps/MapTile.py
@@ -19,7 +19,6 @@ class MapTile(object):
         self.area_information = [[None for r in range(0, RESOLUTION_AREA_INFO)] for c in range(0, RESOLUTION_AREA_INFO)]
         self.liquid_information = [[None for r in range(0, RESOLUTION_LIQUIDS)] for c in range(0, RESOLUTION_LIQUIDS)]
         self.z_height_map = [[0 for r in range(0, RESOLUTION_ZMAP)] for c in range(0, RESOLUTION_ZMAP)]
-        self.load()
 
     def load(self):
         filename = f'{self.cell_map:03}{self.cell_x:02}{self.cell_y:02}.map'


### PR DESCRIPTION
/ Tile information remains as None untill the constructor finishes and returns an object, so in some scenarios where multiple entities would require the same tile, loading would trigger more than once. To avoid this, move map processing ouf of the ctor.