### PR TITLE
Changes to player update system.

### DIFF
--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -251,6 +251,16 @@ class Cell(object):
             self.players[world_object.guid] = world_object
             self.active_cell_callback(world_object)
 
+            # Player entered a new cell, notify others about self.
+            world_object.send_update_surrounding(
+                world_object.generate_proper_update_packet(create=True),
+                include_self=False,
+                create=True
+            )
+
+            # Player entered a new cell, notify self with surrounding world_objects.
+            world_object.update_surrounding_on_me()
+
             # Set this Cell and surrounding ones as Active
             for cell_key in list(grid_manager.get_surrounding_cell_keys(world_object)):
                 # Load tile maps of adjacent cells if there's at least one creature on them.

--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -252,11 +252,11 @@ class Cell(object):
             self.active_cell_callback(world_object)
 
             # Player entered a new cell, notify others about self.
-            world_object.send_update_surrounding(
-                world_object.generate_proper_update_packet(create=True),
+            world_object.send_update_surrounding(world_object.generate_proper_update_packet(
+                create=True if not world_object.is_relocating else False),
                 include_self=False,
-                create=True
-            )
+                create=True if not world_object.is_relocating else False,
+                force_inventory_update=True if not world_object.is_relocating else False)
 
             # Player entered a new cell, notify self with surrounding world_objects.
             world_object.update_surrounding_on_me()

--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -261,11 +261,13 @@ class Cell(object):
 
             # Set this Cell and surrounding ones as Active
             for cell_key in list(grid_manager.get_surrounding_cell_keys(world_object)):
-                # Load tile maps of adjacent cells if there's at least one creature on them.
-                creatures = list(grid_manager.cells[cell_key].creatures.values())
-                for creature in creatures:
-                    self.active_cell_callback(creature)
-                grid_manager.active_cell_keys.add(cell_key)
+                # Do not trigger active cell events and tile loading if this cell was already active.
+                if cell_key not in grid_manager.active_cell_keys:
+                    # Load tile maps of adjacent cells if there's at least one creature on them.
+                    creatures = list(grid_manager.cells[cell_key].creatures.values())
+                    for creature in creatures:
+                        self.active_cell_callback(creature)
+                    grid_manager.active_cell_keys.add(cell_key)
 
         elif world_object.get_type() == ObjectTypes.TYPE_UNIT:
             self.creatures[world_object.guid] = world_object

--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -276,6 +276,7 @@ class Cell(object):
 
         world_object.current_cell = self.key
 
+        # Always trigger cell changed event for players.
         if world_object.get_type() == ObjectTypes.TYPE_PLAYER:
             self.active_cell_callback(world_object)
 

--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -252,7 +252,7 @@ class Cell(object):
             # Player entered a new cell, notify self with surrounding world_objects.
             world_object.update_surrounding_on_me()
 
-            # Player entered a new cell, notify others about self.
+            # Notify others about self.
             world_object.send_update_surrounding(world_object.generate_proper_update_packet(
                 create=True if not world_object.is_relocating else False),
                 include_self=False,

--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -249,7 +249,8 @@ class Cell(object):
     def add(self, grid_manager, world_object):
         if world_object.get_type() == ObjectTypes.TYPE_PLAYER:
             self.players[world_object.guid] = world_object
-            self.active_cell_callback(world_object)
+            # Player entered a new cell, notify self with surrounding world_objects.
+            world_object.update_surrounding_on_me()
 
             # Player entered a new cell, notify others about self.
             world_object.send_update_surrounding(world_object.generate_proper_update_packet(
@@ -257,9 +258,6 @@ class Cell(object):
                 include_self=False,
                 create=True if not world_object.is_relocating else False,
                 force_inventory_update=True if not world_object.is_relocating else False)
-
-            # Player entered a new cell, notify self with surrounding world_objects.
-            world_object.update_surrounding_on_me()
 
             # Set this Cell and surrounding ones as Active
             for cell_key in list(grid_manager.get_surrounding_cell_keys(world_object)):
@@ -275,6 +273,9 @@ class Cell(object):
             self.gameobjects[world_object.guid] = world_object
 
         world_object.current_cell = self.key
+
+        if world_object.get_type() == ObjectTypes.TYPE_PLAYER:
+            self.active_cell_callback(world_object)
 
     def remove(self, world_object):
         if world_object.get_type() == ObjectTypes.TYPE_PLAYER:

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -226,7 +226,6 @@ class PlayerManager(UnitManager):
 
         # Place player in world and update surroundings.
         MapManager.update_object(self)
-        self.send_update_surrounding(self.generate_proper_update_packet(create=True), include_self=False, create=True)
 
         # Join default channels.
         ChannelManager.join_default_channels(self)
@@ -1406,7 +1405,6 @@ class PlayerManager(UnitManager):
 
     # override
     def on_cell_change(self):
-        self.update_surrounding_on_me()
         self.quest_manager.update_surrounding_quest_status()
 
     # override

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -448,12 +448,6 @@ class PlayerManager(UnitManager):
                               force_inventory_update=True if not self.is_relocating else False,
                               reset_fields=False)
 
-        self.send_update_surrounding(self.generate_proper_update_packet(
-            create=True if not self.is_relocating else False),
-            include_self=False,
-            create=True if not self.is_relocating else False,
-            force_inventory_update=True if not self.is_relocating else False)
-
         self.reset_fields_older_than(time.time())
         self.update_lock = False
         self.teleport_destination_map = -1

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -224,7 +224,7 @@ class PlayerManager(UnitManager):
     def complete_login(self, first_login=False):
         self.online = True
 
-        # Place player in world cell.
+        # Place player in a world cell.
         MapManager.update_object(self)
 
         # Join default channels.

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -224,7 +224,7 @@ class PlayerManager(UnitManager):
     def complete_login(self, first_login=False):
         self.online = True
 
-        # Place player in world and update surroundings.
+        # Place player in world cell.
         MapManager.update_object(self)
 
         # Join default channels.


### PR DESCRIPTION
/ This changes reduce crashes upon players simultaneous login/teleport/entering a new map cell.
/ Fixes a bug in which players could not see other players due to missing update packets. https://i.ibb.co/R9BKjSy/unknown.png
/ Do not trigger tile loading and active cell events if the cell was already active.
/ Player should now retrieve surrounding update packets and then notify self to its surroundings when entering a new cell.
/ Make sure both updates, including tile loading happens before setting a cell as active in order to avoid creatures thread updates.
/ Remove teleport player update, MapManager.update_object(player) should automatically trigger the above actions if the current cell changed.