### PR TITLE
Changes to teleport and update system.

### DIFF
--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -21,23 +21,23 @@ class WorldLoader:
         MapManager.initialize_area_tables()
 
         # Gameobject spawns
-        if config.Server.Settings.load_gameobjects:
-            WorldLoader.load_gameobjects()
-            WorldLoader.load_gameobject_loot_templates()
-        else:
-            Logger.info('Skipped game object loading.')
-
-        # Creature spawns
-        if config.Server.Settings.load_creatures:
-            WorldLoader.load_creature_loot_templates()
-            WorldLoader.load_creatures()
-            WorldLoader.load_creature_quest_starters()
-            WorldLoader.load_creature_quest_finishers()
-            WorldLoader.load_creature_model_info()
-            WorldLoader.load_npc_gossip()
-            WorldLoader.load_npc_text()
-        else:
-            Logger.info('Skipped creature loading.')
+        # if config.Server.Settings.load_gameobjects:
+        #     WorldLoader.load_gameobjects()
+        #     WorldLoader.load_gameobject_loot_templates()
+        # else:
+        #     Logger.info('Skipped game object loading.')
+        #
+        # # Creature spawns
+        # if config.Server.Settings.load_creatures:
+        #     WorldLoader.load_creature_loot_templates()
+        #     WorldLoader.load_creatures()
+        #     WorldLoader.load_creature_quest_starters()
+        #     WorldLoader.load_creature_quest_finishers()
+        #     WorldLoader.load_creature_model_info()
+        #     WorldLoader.load_npc_gossip()
+        #     WorldLoader.load_npc_text()
+        # else:
+        #     Logger.info('Skipped creature loading.')
 
         WorldLoader.load_item_templates()
         WorldLoader.load_quests()

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -21,25 +21,25 @@ class WorldLoader:
         MapManager.initialize_area_tables()
 
         # Gameobject spawns
-        # if config.Server.Settings.load_gameobjects:
-        #     WorldLoader.load_gameobjects()
-        #     WorldLoader.load_gameobject_loot_templates()
-        # else:
-        #     Logger.info('Skipped game object loading.')
-        #
-        # # Creature spawns
-        # if config.Server.Settings.load_creatures:
-        #     WorldLoader.load_creature_loot_templates()
-        #     WorldLoader.load_creature_equip_templates()
-        #     WorldLoader.load_creatures()
-        #     WorldLoader.load_creature_quest_starters()
-        #     WorldLoader.load_creature_quest_finishers()
-        #     WorldLoader.load_creature_display_info()
-        #     WorldLoader.load_creature_model_info()
-        #     WorldLoader.load_npc_gossip()
-        #     WorldLoader.load_npc_text()
-        # else:
-        #     Logger.info('Skipped creature loading.')
+        if config.Server.Settings.load_gameobjects:
+            WorldLoader.load_gameobjects()
+            WorldLoader.load_gameobject_loot_templates()
+        else:
+            Logger.info('Skipped game object loading.')
+
+        # Creature spawns
+        if config.Server.Settings.load_creatures:
+            WorldLoader.load_creature_loot_templates()
+            WorldLoader.load_creature_equip_templates()
+            WorldLoader.load_creatures()
+            WorldLoader.load_creature_quest_starters()
+            WorldLoader.load_creature_quest_finishers()
+            WorldLoader.load_creature_display_info()
+            WorldLoader.load_creature_model_info()
+            WorldLoader.load_npc_gossip()
+            WorldLoader.load_npc_text()
+        else:
+            Logger.info('Skipped creature loading.')
 
         WorldLoader.load_item_templates()
         WorldLoader.load_quests()

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -21,25 +21,25 @@ class WorldLoader:
         MapManager.initialize_area_tables()
 
         # Gameobject spawns
-        if config.Server.Settings.load_gameobjects:
-            WorldLoader.load_gameobjects()
-            WorldLoader.load_gameobject_loot_templates()
-        else:
-            Logger.info('Skipped game object loading.')
-
-        # Creature spawns
-        if config.Server.Settings.load_creatures:
-            WorldLoader.load_creature_loot_templates()
-            WorldLoader.load_creature_equip_templates()
-            WorldLoader.load_creatures()
-            WorldLoader.load_creature_quest_starters()
-            WorldLoader.load_creature_quest_finishers()
-            WorldLoader.load_creature_display_info()
-            WorldLoader.load_creature_model_info()
-            WorldLoader.load_npc_gossip()
-            WorldLoader.load_npc_text()
-        else:
-            Logger.info('Skipped creature loading.')
+        # if config.Server.Settings.load_gameobjects:
+        #     WorldLoader.load_gameobjects()
+        #     WorldLoader.load_gameobject_loot_templates()
+        # else:
+        #     Logger.info('Skipped game object loading.')
+        #
+        # # Creature spawns
+        # if config.Server.Settings.load_creatures:
+        #     WorldLoader.load_creature_loot_templates()
+        #     WorldLoader.load_creature_equip_templates()
+        #     WorldLoader.load_creatures()
+        #     WorldLoader.load_creature_quest_starters()
+        #     WorldLoader.load_creature_quest_finishers()
+        #     WorldLoader.load_creature_display_info()
+        #     WorldLoader.load_creature_model_info()
+        #     WorldLoader.load_npc_gossip()
+        #     WorldLoader.load_npc_text()
+        # else:
+        #     Logger.info('Skipped creature loading.')
 
         WorldLoader.load_item_templates()
         WorldLoader.load_quests()

--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -286,7 +286,7 @@ class Cell(object):
         if world_object.get_type() == ObjectTypes.TYPE_PLAYER:
             self.active_cell_callback(world_object)
 
-    # Make each player update its surroundings, adding or removing world objects.
+    # Make each player update its surroundings, adding or removing world objects as needed.
     def update_players(self):
         for player in list(self.players.values()):
             player.update_surrounding_on_me()

--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -48,8 +48,6 @@ class GridManager(object):
                     old_gridmanager.remove_object(world_object)
                 else:
                     Logger.warning(f'Unable to locate GridManager for cell: {world_object.current_cell}.')
-            else:
-                Logger.warning(f'Unable to locate cell: {world_object.current_cell}.')
 
             new_cell = self.cells.get(cell_coords)
             # If the new cell already exists, add this world object.

--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -280,14 +280,15 @@ class Cell(object):
             self.gameobjects[world_object.guid] = world_object
 
         # A world_object entered this cell, notify players.
-        self.update_players(world_object)
+        self.update_players()
 
         # Always trigger cell changed event for players.
         if world_object.get_type() == ObjectTypes.TYPE_PLAYER:
             self.active_cell_callback(world_object)
 
-    def update_players(self, world_object):
-        for player in self.players.values():
+    # Make each player update its surroundings, adding or removing world objects.
+    def update_players(self):
+        for player in list(self.players.values()):
             player.update_surrounding_on_me()
 
     def remove(self, world_object):
@@ -298,7 +299,7 @@ class Cell(object):
         elif world_object.get_type() == ObjectTypes.TYPE_GAMEOBJECT:
             self.gameobjects.pop(world_object.guid, None)
 
-        self.update_players(world_object)
+        self.update_players()
 
     def send_all(self, packet, source=None, exclude=None, use_ignore=False):
         for guid, player_mgr in list(self.players.items()):

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -292,7 +292,7 @@ class MapManager(object):
     @staticmethod
     def update_object(world_object):
         grid_manager = MapManager.get_grid_manager_by_map_id(world_object.map_)
-        grid_manager.update_object(world_object)
+        grid_manager.update_object(world_object, MapManager)
 
     @staticmethod
     def remove_object(world_object):

--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -98,8 +98,6 @@ class GameObjectManager(ObjectManager):
             gameobject.faction = override_faction
 
         gameobject.load()
-        gameobject.send_update_surrounding()
-
         return gameobject
 
     def use(self, player):

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -1351,8 +1351,8 @@ class PlayerManager(UnitManager):
                 self.send_update_surrounding(self.generate_proper_update_packet())
                 if self.reset_fields_older_than(now):
                     self.set_dirty(is_dirty=False, dirty_inventory=False)
-            # Not dirty and pending teleport.
-            elif not self.dirty and self.pending_teleport_destination:
+            # Not dirty, has a pending teleport and a teleport is not ongoing.
+            elif not self.dirty and self.pending_teleport_destination and not self.update_lock:
                 self.trigger_teleport()
 
         self.last_tick = now

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -466,9 +466,9 @@ class PlayerManager(UnitManager):
         MapManager.update_object(self)
 
         self.reset_fields_older_than(time.time())
-        self.update_lock = False
         self.pending_teleport_destination_map = -1
         self.pending_teleport_destination = None
+        self.update_lock = False
         self.is_relocating = False
 
         # Update managers.

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -229,13 +229,7 @@ class PlayerManager(UnitManager):
         # Join default channels.
         ChannelManager.join_default_channels(self)
 
-        # Initialize stats first to have existing base stats for further calculations.
-        self.stat_manager.init_stats()
-
-        # Passive spells contain skill and proficiency learning.
-        # Perform passive spell casts after loading skills to avoid duplicate database entries.
-        self.spell_manager.cast_passive_spells()
-        self.skill_manager.init_proficiencies()
+        # Apply stat bonuses
         self.stat_manager.apply_bonuses(replenish=first_login)
 
         # Init faction status.

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -226,11 +226,14 @@ class PlayerManager(UnitManager):
     def complete_login(self, first_login=False):
         self.online = True
 
+        # Place player in a world cell.
+        MapManager.update_object(self)
+
+        # Calculate stat bonuses at this point.
+        self.stat_manager.apply_bonuses(replenish=first_login)
+
         # Join default channels.
         ChannelManager.join_default_channels(self)
-
-        # Apply stat bonuses
-        self.stat_manager.apply_bonuses(replenish=first_login)
 
         # Init faction status.
         self.reputation_manager.send_initialize_factions()

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -406,6 +406,10 @@ class PlayerManager(UnitManager):
         # If another teleport triggers from a client message, then it will proceed once this TP is done.
         self.update_lock = True
 
+        # Make sure to end duel before starting the teleport process.
+        if self.duel_manager:
+            self.duel_manager.force_duel_end(self)
+
         # New destination we will use when we receive an acknowledge message from client.
         self.teleport_destination_map = map_
         self.teleport_destination = Vector(location.x, location.y, location.z, location.o)
@@ -450,10 +454,6 @@ class PlayerManager(UnitManager):
         return True
 
     def spawn_player_from_teleport(self):
-        # Cancel any duel before updating player cell position.
-        if self.duel_manager:
-            self.duel_manager.force_duel_end(self)
-
         # Update new coordinates and map.
         if self.teleport_destination_map != -1 and self.teleport_destination:
             self.map_ = self.teleport_destination_map

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -246,14 +246,6 @@ class PlayerManager(UnitManager):
         if self.group_manager:
             self.group_manager.send_update()
 
-        # Notify player with create packet.
-        self.send_update_self(create=True if not self.is_relocating else False,
-                              force_inventory_update=True if not self.is_relocating else False,
-                              reset_fields=True)
-
-        # Place player in a world cell.
-        MapManager.update_object(self)
-
     def logout(self):
         self.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_LOGOUT_COMPLETE))
         self.online = False

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -1351,6 +1351,7 @@ class PlayerManager(UnitManager):
                 self.send_update_surrounding(self.generate_proper_update_packet())
                 if self.reset_fields_older_than(now):
                     self.set_dirty(is_dirty=False, dirty_inventory=False)
+            # Not dirty and pending teleport.
             elif not self.dirty and self.pending_teleport_destination:
                 self.trigger_teleport()
 

--- a/game/world/managers/objects/player/PlayerManager.py
+++ b/game/world/managers/objects/player/PlayerManager.py
@@ -65,9 +65,9 @@ class PlayerManager(UnitManager):
         super().__init__(**kwargs)
 
         self.session = session
-        self.update_lock = False
         self.pending_teleport_destination = None
         self.pending_teleport_destination_map = -1
+        self.update_lock = False
         self.is_relocating = False
         self.known_objects = dict()
 


### PR DESCRIPTION
/ GridManager will now automatically notify players when they need to update their surroundings in order to create new world objects or destroy them.
/ Actual teleport action is now triggered within the player update thread and when the player has no dirty pending fields. (This fixes a silent client crash).
/ Object creation/destruction will now properly trigger each time a known objects goes out of player scope  (Active cell + adjacents), also if the GridManager changed we will now also destroy self from the old location.
/ PlayerMgr update_lock is now only set from a teleport action.
/ PlayerMgr 'dirtines' will no longer call MapManager.update().
/ Known issue: Creatures wandering between active/non active cell edges will continuously trigger create/destroy packets.