### PR TITLE
Taxi & Movement packets fixes.

### DIFF
--- a/game/world/managers/objects/MovementManager.py
+++ b/game/world/managers/objects/MovementManager.py
@@ -166,7 +166,7 @@ class MovementManager(object):
         spline.total_time = int(self.total_waypoint_time * 1000)
         spline.points = waypoints
 
-        # Set spline and save the original waypoints.
+        # Set spline and last position.
         self.unit.movement_spline = spline
         self.last_position = self.unit.location
 

--- a/game/world/managers/objects/MovementManager.py
+++ b/game/world/managers/objects/MovementManager.py
@@ -162,7 +162,7 @@ class MovementManager(object):
         spline.total_time = int(self.total_waypoint_time * 1000)
         spline.points = waypoints
 
-        # Set split and save the original waypoints.
+        # Set spline and save the original waypoints.
         self.unit.movement_spline = spline
         self.source_waypoints = waypoints
         self.last_position = self.unit.location

--- a/game/world/managers/objects/player/TaxiManager.py
+++ b/game/world/managers/objects/player/TaxiManager.py
@@ -1,14 +1,98 @@
 from struct import pack, unpack
 from bitarray import bitarray
 from database.dbc.DbcDatabaseManager import DbcDatabaseManager
-from database.realm.RealmDatabaseManager import RealmDatabaseManager
+from game.world.managers.abstractions.Vector import Vector
 from network.packet.PacketWriter import PacketWriter, OpCode
+from utils.ConfigManager import config
+from utils.constants.UnitCodes import UnitFlags, Teams, SplineFlags
+from utils.constants.UpdateFields import UnitFields
+
+
+GRYPHON_DISPLAY_ID = 1149
+HIPPOGRYPH_DISPLAY_ID = 1936
+BAT_DISPLAY_ID = 1566
+WIND_RIDER_DISPLAY_ID = 2157
+
+HIPPOGRYPH_MASTERS = (3838, 3841, 4267, 4319, 4407, 6706, 8019, 10897, 11138, 12577, 12578)
+BAT_HANDLERS = (2226, 2389, 3575, 4551, 12636)
 
 
 class TaxiManager(object):
     def __init__(self, player_mgr):
         self.owner = player_mgr
         self.available_taxi_nodes = bitarray(player_mgr.player.taximask, 'little')
+        self.taxi_path = player_mgr.player.taxi_path
+        self.start_node = 0
+        self.dest_node = 0
+        self.mount_display_id = 0
+        self.remaining_waypoints = 0
+
+    def resume_taxi_flight(self):
+        data = self.taxi_path.rsplit(',')
+        start_node = int(data[0])
+        dest_node = int(data[1])
+        mount_display_id = int(data[2])
+        waypoints = int(data[3])
+
+        taxi_path = DbcDatabaseManager.taxi_path_get(start_node, dest_node)
+        if taxi_path:
+            self.begin_taxi_flight(taxi_path, start_node, dest_node, mount_display_id=mount_display_id, remaining_wp=waypoints)
+
+    def begin_taxi_flight(self, taxi_path, start_node, dest_node, flight_master=None, mount_display_id=None, remaining_wp=None):
+        waypoints = []
+        nodes = DbcDatabaseManager.TaxiPathNodesHolder.taxi_nodes_get_by_path_id(taxi_path.ID)
+
+        for i in range(0, len(nodes)):
+            waypoints.append(Vector(nodes[i].LocX, nodes[i].LocY, nodes[i].LocZ))
+
+        if remaining_wp:
+            while len(waypoints) != remaining_wp:
+                waypoints.pop(0)
+
+        # Get the proper display_id for the mount.
+        # This information is not stored in the dbc like in later versions.
+        if flight_master:
+            if flight_master.entry in HIPPOGRYPH_MASTERS:
+                mount_display_id = HIPPOGRYPH_DISPLAY_ID
+            elif flight_master.entry in BAT_HANDLERS:
+                mount_display_id = BAT_DISPLAY_ID
+            elif self.owner.team == Teams.TEAM_HORDE:
+                mount_display_id = WIND_RIDER_DISPLAY_ID
+            else:
+                mount_display_id = GRYPHON_DISPLAY_ID
+
+        self.owner.unit_flags |= UnitFlags.UNIT_FLAG_FROZEN | UnitFlags.UNIT_FLAG_TAXI_FLIGHT
+        self.owner.set_uint32(UnitFields.UNIT_FIELD_FLAGS, self.owner.unit_flags)
+        dest_taxi_node = DbcDatabaseManager.TaxiNodesHolder.taxi_nodes_get_by_map_and_id(self.owner.map_, dest_node)
+        self.owner.pending_taxi_destination = Vector(dest_taxi_node.X, dest_taxi_node.Y, dest_taxi_node.Z)
+        self.owner.mount(mount_display_id)
+        self.owner.set_dirty()
+
+        speed = config.Unit.Player.Defaults.flight_speed
+        spline = SplineFlags.SPLINEFLAG_FLYING
+
+        # Set current flight state.
+        self.start_node = start_node
+        self.dest_node = dest_node
+        self.mount_display_id = mount_display_id
+        self.remaining_waypoints = len(waypoints)
+        self.taxi_path = f'{self.start_node},{self.dest_node},{self.mount_display_id},{len(waypoints)}'
+        # Notify player and surroundings.
+        self.owner.movement_manager.send_move_to(waypoints, speed, spline)
+
+    # Save partial flight update.
+    def update_flight_state(self):
+        if self.owner.movement_manager.unit_is_moving():
+            self.taxi_path = f'{self.start_node},{self.dest_node},{self.mount_display_id},{len(self.owner.movement_manager.source_waypoints)}'
+        else:
+            self.clear_flight_state()
+
+    def clear_flight_state(self):
+        self.start_node = 0
+        self.dest_node = 0
+        self.mount_display_id = 0
+        self.remaining_waypoints = 0
+        self.taxi_path = ''
 
     # Enable all taxi node bits.
     def enable_all_taxi_nodes(self):

--- a/game/world/managers/objects/player/TaxiManager.py
+++ b/game/world/managers/objects/player/TaxiManager.py
@@ -80,7 +80,6 @@ class TaxiManager(object):
         # Notify player and surroundings.
         self.owner.movement_manager.send_move_to(waypoints, speed, spline)
 
-    # Save partial flight update.
     def update_flight_state(self):
         if self.owner.movement_manager.unit_is_moving():
             self.taxi_path = f'{self.start_node},{self.dest_node},{self.mount_display_id},{len(self.owner.movement_manager.source_waypoints)}'

--- a/game/world/managers/objects/player/TaxiManager.py
+++ b/game/world/managers/objects/player/TaxiManager.py
@@ -82,7 +82,7 @@ class TaxiManager(object):
 
     def update_flight_state(self):
         if self.owner.movement_manager.unit_is_moving():
-            self.taxi_path = f'{self.start_node},{self.dest_node},{self.mount_display_id},{len(self.owner.movement_manager.source_waypoints)}'
+            self.taxi_path = f'{self.start_node},{self.dest_node},{self.mount_display_id},{len(self.owner.movement_manager.pending_waypoints)}'
         else:
             self.clear_flight_state()
 

--- a/game/world/managers/objects/player/TaxiManager.py
+++ b/game/world/managers/objects/player/TaxiManager.py
@@ -49,17 +49,9 @@ class TaxiManager(object):
             while len(waypoints) != remaining_wp:
                 waypoints.pop(0)
 
-        # Get the proper display_id for the mount.
-        # This information is not stored in the dbc like in later versions.
+        # Get mount according to Flight Master if this is an initial flight trigger.
         if flight_master:
-            if flight_master.entry in HIPPOGRYPH_MASTERS:
-                mount_display_id = HIPPOGRYPH_DISPLAY_ID
-            elif flight_master.entry in BAT_HANDLERS:
-                mount_display_id = BAT_DISPLAY_ID
-            elif self.owner.team == Teams.TEAM_HORDE:
-                mount_display_id = WIND_RIDER_DISPLAY_ID
-            else:
-                mount_display_id = GRYPHON_DISPLAY_ID
+            mount_display_id = self.get_mount_display_id(flight_master)
 
         self.owner.unit_flags |= UnitFlags.UNIT_FLAG_FROZEN | UnitFlags.UNIT_FLAG_TAXI_FLIGHT
         self.owner.set_uint32(UnitFields.UNIT_FIELD_FLAGS, self.owner.unit_flags)
@@ -79,6 +71,20 @@ class TaxiManager(object):
         self.taxi_path = f'{self.start_node},{self.dest_node},{self.mount_display_id},{len(waypoints)}'
         # Notify player and surroundings.
         self.owner.movement_manager.send_move_to(waypoints, speed, spline)
+
+    # Get the proper display_id for the mount.
+    # This information is not stored in the dbc like in later versions.
+    def get_mount_display_id(self, flight_master=None):
+        if flight_master:
+            if flight_master.entry in HIPPOGRYPH_MASTERS:
+                return HIPPOGRYPH_DISPLAY_ID
+            elif flight_master.entry in BAT_HANDLERS:
+                return BAT_DISPLAY_ID
+
+        if self.owner.team == Teams.TEAM_HORDE:
+            return WIND_RIDER_DISPLAY_ID
+        else:
+            return GRYPHON_DISPLAY_ID
 
     def update_flight_state(self):
         if self.owner.movement_manager.unit_is_moving():

--- a/game/world/opcode_handling/handlers/interface/CharCreateHandler.py
+++ b/game/world/opcode_handling/handlers/interface/CharCreateHandler.py
@@ -78,6 +78,7 @@ class CharCreateHandler(object):
             CharCreateHandler.generate_starting_items(character.guid, race, class_, gender)
             CharCreateHandler.generate_starting_buttons(character.guid, race, class_)
             CharCreateHandler.generate_starting_taxi_nodes(character, race)
+            CharCreateHandler.generate_initial_taxi_path(character)
             default_deathbind = CharacterDeathbind(
                 player_guid=character.guid,
                 creature_binder_guid=0,
@@ -113,6 +114,11 @@ class CharCreateHandler(object):
     def generate_starting_taxi_nodes(character, race):
         info = DbcDatabaseManager.chr_races_get_by_race(race)
         character.taximask = bin(info.StartingTaxiNodes)[2:].zfill(64)[::-1]
+        RealmDatabaseManager.character_update(character)
+
+    @staticmethod
+    def generate_initial_taxi_path(character):
+        character.taxi_path = ''
         RealmDatabaseManager.character_update(character)
 
     @staticmethod

--- a/game/world/opcode_handling/handlers/npc/ActivateTaxiHandler.py
+++ b/game/world/opcode_handling/handlers/npc/ActivateTaxiHandler.py
@@ -1,22 +1,9 @@
 from struct import unpack, pack
-
 from database.dbc.DbcDatabaseManager import DbcDatabaseManager
-from game.world.managers.abstractions.Vector import Vector
 from game.world.managers.maps.MapManager import MapManager
 from network.packet.PacketWriter import PacketWriter
-from utils.ConfigManager import config
 from utils.constants.MiscCodes import ActivateTaxiReplies
 from utils.constants.OpCodes import OpCode
-from utils.constants.UnitCodes import SplineFlags, UnitFlags, Teams
-from utils.constants.UpdateFields import UnitFields
-
-GRYPHON_DISPLAY_ID = 1149
-HIPPOGRYPH_DISPLAY_ID = 1936
-BAT_DISPLAY_ID = 1566
-WIND_RIDER_DISPLAY_ID = 2157
-
-HIPPOGRYPH_MASTERS = (3838, 3841, 4267, 4319, 4407, 6706, 8019, 10897, 11138, 12577, 12578)
-BAT_HANDLERS = (2226, 2389, 3575, 4551, 12636)
 
 
 class ActivateTaxiHandler(object):
@@ -49,36 +36,6 @@ class ActivateTaxiHandler(object):
 
             if result == ActivateTaxiReplies.ERR_TAXIOK:
                 world_session.player_mgr.mod_money(-taxi_path.Cost)
-                waypoints = []
-                taxi_path_nodes = DbcDatabaseManager.TaxiPathNodesHolder.taxi_nodes_get_by_path_id(taxi_path.ID)
-                for taxi_path_node in taxi_path_nodes:
-                    waypoints.append(Vector(taxi_path_node.LocX, taxi_path_node.LocY, taxi_path_node.LocZ))
-
-                world_session.player_mgr.unit_flags |= UnitFlags.UNIT_FLAG_FROZEN | UnitFlags.UNIT_FLAG_TAXI_FLIGHT
-                world_session.player_mgr.set_uint32(UnitFields.UNIT_FIELD_FLAGS, world_session.player_mgr.unit_flags)
-                dest_taxi_node = DbcDatabaseManager.TaxiNodesHolder.taxi_nodes_get_by_map_and_id(
-                    world_session.player_mgr.map_, dest_node)
-                world_session.player_mgr.pending_taxi_destination = Vector(dest_taxi_node.X,
-                                                                           dest_taxi_node.Y,
-                                                                           dest_taxi_node.Z)
-
-                # Get the proper display_id for the mount.
-                # This information is not stored in the dbc like in later versions.
-                if flight_master.entry in HIPPOGRYPH_MASTERS:
-                    mount_display_id = HIPPOGRYPH_DISPLAY_ID
-                elif flight_master.entry in BAT_HANDLERS:
-                    mount_display_id = BAT_DISPLAY_ID
-                else:
-                    if world_session.player_mgr.team == Teams.TEAM_HORDE:
-                        mount_display_id = WIND_RIDER_DISPLAY_ID
-                    else:
-                        mount_display_id = GRYPHON_DISPLAY_ID
-
-                world_session.player_mgr.mount(mount_display_id)
-                world_session.player_mgr.set_dirty()
-
-                world_session.player_mgr.movement_manager.send_move_to(waypoints,
-                                                                       config.Unit.Player.Defaults.flight_speed,
-                                                                       SplineFlags.SPLINEFLAG_FLYING)
+                world_session.player_mgr.taxi_manager.begin_taxi_flight(taxi_path, start_node, dest_node, flight_master)
 
         return 0

--- a/game/world/opcode_handling/handlers/npc/ActivateTaxiHandler.py
+++ b/game/world/opcode_handling/handlers/npc/ActivateTaxiHandler.py
@@ -36,6 +36,6 @@ class ActivateTaxiHandler(object):
 
             if result == ActivateTaxiReplies.ERR_TAXIOK:
                 world_session.player_mgr.mod_money(-taxi_path.Cost)
-                world_session.player_mgr.taxi_manager.begin_taxi_flight(taxi_path, start_node, dest_node, flight_master)
+                world_session.player_mgr.taxi_manager.begin_taxi_flight(taxi_path, start_node, dest_node, flight_master=flight_master)
 
         return 0


### PR DESCRIPTION
/ Players should now be able to see other players flying on taxis even if they were not near that player when the taxi was triggered.
/ Flight state is now persisted and will continue if the player exits or the client crashes.
/ Fixed bug in which taxi mount display remained visible to surrounding players after arriving at the destination node.
/ Players will now also retrieve partial movement packets that were triggered by creatures before the player entered their active cell.