### PR TITLE
Fix server side creatures movement position calculation (Melee bug) & refactor.

### DIFF
--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -74,6 +74,21 @@ class GridManager(object):
                 for creature in list(cell.creatures.values()):
                     self.active_cell_callback(creature)
 
+    # Make a world object not visible to its surroundings but keep it inside a cell.
+    def despawn_object(self, world_object, update_player=True):
+        world_object.is_spawned = False
+        cell = self.cells.get(world_object.current_cell)
+        if update_player and cell:
+            self.update_players(cell.key)
+
+    # Turn an existing world object visible to its surroundings.
+    def respawn_object(self, world_object, update_players=True):
+        world_object.is_spawned = True
+        cell = self.cells.get(world_object.current_cell)
+        if update_players and cell:
+            self.update_players(cell.key)
+
+    # Destroy a world_object from others and remove it from its cell.
     def remove_object(self, world_object, update_players=True):
         cell = self.cells.get(world_object.current_cell)
         if cell:

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -305,6 +305,14 @@ class MapManager(object):
         MapManager.get_grid_manager_by_map_id(world_object.map_).remove_object(world_object)
 
     @staticmethod
+    def despawn_object(world_object):
+        MapManager.get_grid_manager_by_map_id(world_object.map_).despawn_object(world_object)
+
+    @staticmethod
+    def respawn_object(world_object):
+        MapManager.get_grid_manager_by_map_id(world_object.map_).respawn_object(world_object)
+
+    @staticmethod
     def send_surrounding(packet, world_object, include_self=True, exclude=None, use_ignore=False):
         MapManager.get_grid_manager_by_map_id(world_object.map_).send_surrounding(
             packet, world_object, include_self, exclude, use_ignore)

--- a/game/world/managers/objects/ObjectManager.py
+++ b/game/world/managers/objects/ObjectManager.py
@@ -255,23 +255,11 @@ class ObjectManager(object):
         return unpack('<f', self.update_packet_factory.update_values[index])[0]
 
     # override
-    def despawn(self):
-        self.is_spawned = False
-        if self.is_summon:
-            MapManager.remove_object(self)
-        else:
-            MapManager.send_surrounding(self.get_destroy_packet(), self, include_self=False)
-
-    # override
     def update(self):
         pass
 
     # override
     def get_full_update_packet(self, is_self=True):
-        pass
-
-    # override
-    def respawn(self):
         pass
 
     # override

--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -293,14 +293,18 @@ class GameObjectManager(ObjectManager):
         return PacketWriter.get_packet(OpCode.SMSG_GAMEOBJECT_QUERY_RESPONSE, data)
 
     # override
+    def despawn(self):
+        MapManager.despawn_object(self)
+
+    # override
     def respawn(self):
-        self.is_spawned = True
+        # Set properties before making it visible.
         self.state = GameObjectStates.GO_STATE_READY
         self.respawn_timer = 0
         self.respawn_time = randint(self.gobject_instance.spawntimesecsmin,
                                     self.gobject_instance.spawntimesecsmax)
 
-        self.send_create_packet_surroundings()
+        MapManager.respawn_object(self)
 
     # override
     def update(self):

--- a/game/world/managers/objects/units/MovementManager.py
+++ b/game/world/managers/objects/units/MovementManager.py
@@ -58,6 +58,8 @@ class MovementManager(object):
                                                                        map_id=map_id)
 
             if new_position:
+                self.waypoint_timer = 0
+                self.last_position = new_position.copy()
                 self.unit.location.x = new_position.x
                 self.unit.location.y = new_position.y
                 self.unit.location.z = new_position.z
@@ -68,7 +70,7 @@ class MovementManager(object):
                     self.unit.taxi_manager.update_flight_state()
         else:
             # Path finished.
-            if self.total_waypoint_timer > self.total_waypoint_time:
+            if self.total_waypoint_timer >= self.total_waypoint_time:
                 if self.is_player and self.unit.pending_taxi_destination:
                     self.unit.set_taxi_flying_state(False, set_dirty=True)
                     self.unit.teleport(self.unit.map_, self.unit.pending_taxi_destination, is_instant=True)

--- a/game/world/managers/objects/units/MovementManager.py
+++ b/game/world/managers/objects/units/MovementManager.py
@@ -40,7 +40,7 @@ class MovementManager(object):
         waypoint_length = len(self.pending_waypoints)
         if waypoint_length > 0:
             current_waypoint = self.pending_waypoints[0]
-            if self.total_waypoint_timer > current_waypoint.expected_timestamp:
+            if self.total_waypoint_timer >= current_waypoint.expected_timestamp:
                 new_position = current_waypoint.location
                 self.last_position = new_position
                 self.waypoint_timer = 0

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -484,7 +484,6 @@ class UnitManager(ObjectManager):
         # If unit is a creature and it's being attacked by another unit, automatically set combat target.
         if not self.combat_target and not is_player and source and source.get_type() != ObjectTypes.TYPE_GAMEOBJECT:
             # Make sure to first stop any movement right away.
-            self.movement_manager.reset()
             self.movement_manager.send_move_to([self.location], self.running_speed, SplineFlags.SPLINEFLAG_RUNMODE)
             self.attack(source)
 

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -483,6 +483,9 @@ class UnitManager(ObjectManager):
 
         # If unit is a creature and it's being attacked by another unit, automatically set combat target.
         if not self.combat_target and not is_player and source and source.get_type() != ObjectTypes.TYPE_GAMEOBJECT:
+            # Make sure to first stop any movement right away.
+            self.movement_manager.reset()
+            self.movement_manager.send_move_to([self.location], self.running_speed, SplineFlags.SPLINEFLAG_RUNMODE)
             self.attack(source)
 
         self.set_dirty()

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -907,9 +907,8 @@ class UnitManager(ObjectManager):
             return False
         self.is_alive = False
 
-        # Stop movement on death
-        if len(self.movement_manager.pending_waypoints) > 0:
-            self.movement_manager.send_move_to([self.location], self.running_speed, SplineFlags.SPLINEFLAG_NONE)
+        # Clear any pending waypoints.
+        self.movement_manager.reset()
 
         self.set_health(0)
         self.set_stand_state(StandState.UNIT_DEAD)
@@ -930,9 +929,6 @@ class UnitManager(ObjectManager):
                 killer.remove_combo_points()
                 killer.set_dirty()
 
-        # Clear all pending waypoint movement
-        self.movement_manager.reset()
-
         if killer:
             killer.spell_manager.remove_unit_from_all_cast_targets(self.guid)  # Interrupt casting on target death
             killer.aura_manager.check_aura_procs(killed_unit=True)
@@ -942,6 +938,9 @@ class UnitManager(ObjectManager):
 
         self.leave_combat()
         return True
+
+    def despawn(self):
+        pass
 
     def respawn(self):
         # Force leave combat just in case.


### PR DESCRIPTION
* Refactor Respawn/Despawn.
* Make sure creatures stop pending wandering movements as soon as they receive any damanage.
* Fixes melee combat unable to start when a creature was moving due bad server side calculation.

(Shane cubes represent the server side guessed position)
Position Bug:
https://streamable.com/5ge9rj

Fixed:
https://streamable.com/522ctg
