### PR TITLE
Quests game object selective interaction.

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -14,5 +14,17 @@ begin not atomic
 
         insert into applied_updates values ('270920211');
     end if;
+	
+	-- 15/01/2022 1
+	if (select count(*) from applied_updates where id='150120221') = 0 then
+		UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10874.13', `spawn_positionY` = '923.626', `spawn_positionZ` = '1317.481' WHERE (`spawn_id` = '49589');
+		UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10874.27', `spawn_positionY` = '917.391', `spawn_positionZ` = '1317.544' WHERE (`spawn_id` = '49590');
+		UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10881.17', `spawn_positionY` = '914.299', `spawn_positionZ` = '1317.358' WHERE (`spawn_id` = '49591');
+		UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10896.01', `spawn_positionY` = '920.324', `spawn_positionZ` = '1319.054' WHERE (`spawn_id` = '49593');
+		UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10900.56', `spawn_positionY` = '920.812', `spawn_positionZ` = '1319.237' WHERE (`spawn_id` = '49595');
+		UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10903.92', `spawn_positionY` = '927.207', `spawn_positionZ` = '1319.866' WHERE (`spawn_id` = '49596');
+		
+		insert into applied_updates values ('150120221');
+    end if;
 end $
 delimiter ;

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -290,7 +290,7 @@ class MapManager(object):
         return current_cell in destination_cells
 
     @staticmethod
-    def update_object(world_object):
+    def update_object(world_object, position_only=True):
         if world_object.current_cell:
             old_map = int(world_object.current_cell.split(':')[-1])
             old_grid_manager = MapManager.get_grid_manager_by_map_id(old_map)
@@ -298,7 +298,7 @@ class MapManager(object):
             old_grid_manager = None
 
         grid_manager = MapManager.get_grid_manager_by_map_id(world_object.map_)
-        grid_manager.update_object(world_object, old_grid_manager)
+        grid_manager.update_object(world_object, old_grid_manager, position_only=position_only)
 
     @staticmethod
     def remove_object(world_object):

--- a/game/world/managers/objects/ObjectManager.py
+++ b/game/world/managers/objects/ObjectManager.py
@@ -79,15 +79,15 @@ class ObjectManager(object):
             type_value |= type_
         return type_value
 
-    def generate_proper_update_packet(self, is_self=False, create=False):
-        update_packet = UpdatePacketFactory.compress_if_needed(PacketWriter.get_packet(
-            OpCode.SMSG_UPDATE_OBJECT,
-            self.get_full_update_packet(is_self=is_self) if create else self.get_partial_update_packet()))
-        return update_packet
+    def generate_proper_update_packet(self, is_self=False, create=False, is_interactive=False):
+        if create:
+            data = self.get_full_update_packet(is_self=is_self)
+        else:
+            data = self.get_partial_update_packet()
 
-    def send_create_packet_surroundings(self, **kwargs):
-        update_packet = self.generate_proper_update_packet(False, True)
-        MapManager.send_surrounding(update_packet, self, include_self=False)
+        update_packet = UpdatePacketFactory.compress_if_needed(PacketWriter.get_packet(OpCode.SMSG_UPDATE_OBJECT,data))
+
+        return update_packet
 
     def get_object_create_packet(self, is_self=True):
         from game.world.managers.objects.units import UnitManager
@@ -260,7 +260,7 @@ class ObjectManager(object):
         pass
 
     # override
-    def get_full_update_packet(self, is_self=True):
+    def get_full_update_packet(self, is_self=True, is_interactive=False):
         pass
 
     # override

--- a/game/world/managers/objects/item/ItemManager.py
+++ b/game/world/managers/objects/item/ItemManager.py
@@ -320,7 +320,7 @@ class ItemManager(ObjectManager):
         return PacketWriter.get_packet(OpCode.SMSG_ITEM_QUERY_SINGLE_RESPONSE, data)
 
     # override
-    def get_full_update_packet(self, is_self=True):
+    def get_full_update_packet(self, is_self=True, is_interactive=False):
         if self.item_template and self.item_instance:
             from game.world.managers.objects.item.ContainerManager import ContainerManager
 

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -129,8 +129,6 @@ class CreatureManager(UnitManager):
             creature.faction = override_faction
 
         creature.load()
-        creature.send_create_packet_surroundings()
-
         return creature
 
     def generate_display_id(self):

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -342,7 +342,7 @@ class CreatureManager(UnitManager):
         return False
 
     # override
-    def get_full_update_packet(self, is_self=True):
+    def get_full_update_packet(self, is_self=True, is_interactive=False):
         self.finish_loading()
 
         # race, class, gender, power_type
@@ -514,10 +514,7 @@ class CreatureManager(UnitManager):
 
             # Check "dirtiness" to determine if this creature object should be updated yet or not.
             if self.dirty:
-                MapManager.send_surrounding(self.generate_proper_update_packet(create=False), self, include_self=False)
-                MapManager.update_object(self)
-                if self.reset_fields_older_than(now):
-                    self.set_dirty(is_dirty=False)
+                MapManager.update_object(self, position_only=False)
 
         self.last_tick = now
 

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1446,19 +1446,6 @@ class PlayerManager(UnitManager):
         if reset_fields:
             self.reset_fields_older_than(time.time())
 
-    # override
-    def send_create_packet_surroundings(self, update_packet, include_self=False, create=False,
-                                        force_inventory_update=False):
-        if create:
-            MapManager.send_surrounding(NameQueryHandler.get_query_details(self.player), self,
-                                        include_self=include_self)
-        else:
-            if self.dirty_inventory or force_inventory_update:
-                self.inventory.build_update()
-                self.inventory.send_inventory_update(is_self=False)
-
-        MapManager.send_surrounding(update_packet, self, include_self=include_self)
-
     def teleport_deathbind(self):
         self.teleport(self.deathbind.deathbind_map, Vector(self.deathbind.deathbind_position_x,
                                                            self.deathbind.deathbind_position_y,

--- a/game/world/managers/objects/units/player/quest/ActiveQuest.py
+++ b/game/world/managers/objects/units/player/quest/ActiveQuest.py
@@ -13,6 +13,24 @@ class ActiveQuest:
         self.quest = quest
         self.failed = False
 
+    def need_item_from_go(self, go_loot_template):
+        # Quest is complete.
+        if self.is_quest_complete(0):
+            return False
+
+        needed_items = list(filter((0).__ne__, QuestHelpers.generate_req_item_list(self.quest)))
+
+        # Not required items for this quest.
+        if len(needed_items) == 0:
+            return False
+
+        # Check if any needed items match the provided go_loot_template.
+        for entry in go_loot_template:
+            if entry.item in needed_items:
+                return True
+
+        return False
+
     def is_quest_complete(self, quest_giver_guid):
         if self.db_state.state != QuestState.QUEST_REWARD:
             return False


### PR DESCRIPTION
* More changes to update system:
* 'Dirtiness' updates and fields flushing are now mostly handled within Map/Grid manager.
* Removed unnecesary create packets, this are only needed when a player meets a world object for the first time.
* PlayerMgr update_surrounding_on_me is now in charge of polling either full or partial packets from world objects.
* (The above change might end up more expensive than creating one packets and propagating to everyone, but since game object interactions requires a flag only set for interested players, this was the only approach I could think of)
* Fixed WebWood Egg game objects placement. 
* Tested changes with quests WebWood Egg and Galgar's Cactus Apple Surprise

![Webwood Eggs](https://user-images.githubusercontent.com/72774832/149646245-79f1de2e-9bb3-4622-8c10-70b964c23635.PNG)
![Cactus Apple](https://user-images.githubusercontent.com/72774832/149646247-efdbe801-54c2-4cc3-b387-3024d3372a78.PNG)

