### PR TITLE
Rework Update System.

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -288,20 +288,6 @@ begin not atomic
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '87.223' WHERE (`spawn_id` = '99875'); 
         -- Musty Tome Trap Z placement. 
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '71.66' WHERE (`spawn_id` = '12342'); 
-        -- Incendicite Mineral Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '168.787' WHERE (`spawn_id` = '443'); 
-        -- Incendicite Mineral Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '166.461' WHERE (`spawn_id` = '444'); 
-        -- Incendicite Mineral Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '172.447' WHERE (`spawn_id` = '449'); 
-        -- Incendicite Mineral Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '160.752' WHERE (`spawn_id` = '450'); 
-        -- Incendicite Mineral Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '170.525' WHERE (`spawn_id` = '452'); 
-        -- Incendicite Mineral Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '168.753' WHERE (`spawn_id` = '454'); 
-        -- Incendicite Mineral Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '165.485' WHERE (`spawn_id` = '455'); 
         -- Dwarven Brazier Z placement. 
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.887' WHERE (`spawn_id` = '512'); 
         -- Campfire Damage Z placement. 
@@ -371,6 +357,273 @@ begin not atomic
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5935.646', `spawn_positionY` = '-2903.753', `spawn_positionZ` = '369.238' WHERE (`spawn_id` = '1183'); 
         -- Burning Embers Z placement. 
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '7.126' WHERE (`spawn_id` = '47504'); 
+        -- Peacebloom Flower Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-2.65' WHERE (`spawn_id` = '1392'); 
+        -- Peacebloom Flower Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-21.168' WHERE (`spawn_id` = '1399'); 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '47458'); 
+        -- Peacebloom Flower Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.838' WHERE (`spawn_id` = '1475'); 
+        -- Peacebloom Flower Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.913' WHERE (`spawn_id` = '1490'); 
+        -- Greatwood Vale Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.42' WHERE (`spawn_id` = '47451'); 
+        -- Peacebloom Flower Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '96.275' WHERE (`spawn_id` = '1513'); 
+        -- Peacebloom Flower Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-17.469' WHERE (`spawn_id` = '1557'); 
+        -- Peacebloom Flower Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '42.99' WHERE (`spawn_id` = '1608'); 
+        -- Peacebloom Flower Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.13' WHERE (`spawn_id` = '1609'); 
+        -- Peacebloom Flower Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.349' WHERE (`spawn_id` = '1676'); 
+        -- Peacebloom Flower Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '31.074' WHERE (`spawn_id` = '1690'); 
+        -- Wild Steelbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '114.355' WHERE (`spawn_id` = '47317'); 
+        -- Wild Steelbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '145.642' WHERE (`spawn_id` = '47317'); 
+        -- Peacebloom Flower Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '37.011' WHERE (`spawn_id` = '1698'); 
+        -- Deepmoss Eggs Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '178.876' WHERE (`spawn_id` = '47193'); 
+        -- Deepmoss Eggs Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '178.858' WHERE (`spawn_id` = '47192'); 
+        -- Snakeroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.089' WHERE (`spawn_id` = '1786'); 
+        -- Snakeroot XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '3.716', `spawn_positionY` = '-1831.217', `spawn_positionZ` = '96.578' WHERE (`spawn_id` = '1813'); 
+        -- Snakeroot XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '380.849', `spawn_positionY` = '1152.36', `spawn_positionZ` = '89.758' WHERE (`spawn_id` = '1840'); 
+        -- Snakeroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.38' WHERE (`spawn_id` = '1901'); 
+        -- Snakeroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.503' WHERE (`spawn_id` = '1925'); 
+        -- Snakeroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '30.935' WHERE (`spawn_id` = '1937'); 
+        -- Snakeroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.03' WHERE (`spawn_id` = '1955'); 
+        -- Snakeroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '23.483' WHERE (`spawn_id` = '2003'); 
+        -- Snakeroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '20.166' WHERE (`spawn_id` = '2004'); 
+        -- Snakeroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.283' WHERE (`spawn_id` = '2005'); 
+        -- Snakeroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '24.98' WHERE (`spawn_id` = '2009'); 
+        -- Snakeroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '22.561' WHERE (`spawn_id` = '2028'); 
+        -- Snakeroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.658' WHERE (`spawn_id` = '2042'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.603' WHERE (`spawn_id` = '2088'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.902' WHERE (`spawn_id` = '2096'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.784' WHERE (`spawn_id` = '2098'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.925' WHERE (`spawn_id` = '2108'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.701' WHERE (`spawn_id` = '2158'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '95.836' WHERE (`spawn_id` = '2160'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '107.194' WHERE (`spawn_id` = '2166'); 
+        -- Common Magebloom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '642.629', `spawn_positionY` = '-1575.349', `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '2179'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.064' WHERE (`spawn_id` = '2191'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.355' WHERE (`spawn_id` = '2192'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.876' WHERE (`spawn_id` = '2193'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.712' WHERE (`spawn_id` = '2213'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '81.35' WHERE (`spawn_id` = '2222'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '82.583' WHERE (`spawn_id` = '2229'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '28.848' WHERE (`spawn_id` = '2233'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '327.869' WHERE (`spawn_id` = '2237'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '16.457' WHERE (`spawn_id` = '2240'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.891' WHERE (`spawn_id` = '2244'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.433' WHERE (`spawn_id` = '2253'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '30.168' WHERE (`spawn_id` = '2283'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.759' WHERE (`spawn_id` = '2285'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '19.253' WHERE (`spawn_id` = '2295'); 
+        -- Common Magebloom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '561.842', `spawn_positionY` = '-3738.942', `spawn_positionZ` = '17.718' WHERE (`spawn_id` = '2311'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '19.601' WHERE (`spawn_id` = '2327'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '23.601' WHERE (`spawn_id` = '2333'); 
+        -- Deepmoss Eggs Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '178.876' WHERE (`spawn_id` = '44657'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.76' WHERE (`spawn_id` = '2339'); 
+        -- Common Magebloom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1028.345', `spawn_positionY` = '-1991.585', `spawn_positionZ` = '79.704' WHERE (`spawn_id` = '2341'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '13.253' WHERE (`spawn_id` = '2346'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '87.728' WHERE (`spawn_id` = '2347'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.406' WHERE (`spawn_id` = '2348'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '90.639' WHERE (`spawn_id` = '2350'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.651' WHERE (`spawn_id` = '2377'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.153' WHERE (`spawn_id` = '2397'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.761' WHERE (`spawn_id` = '2398'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.971' WHERE (`spawn_id` = '2401'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '29.151' WHERE (`spawn_id` = '2403'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.875' WHERE (`spawn_id` = '2406'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '32.255' WHERE (`spawn_id` = '2407'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.887' WHERE (`spawn_id` = '2423'); 
+        -- Deepmoss Eggs Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '178.861' WHERE (`spawn_id` = '44655'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '74.319' WHERE (`spawn_id` = '2474'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '15.991' WHERE (`spawn_id` = '2481'); 
+        -- Deepmoss Eggs Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '175.121' WHERE (`spawn_id` = '44654'); 
+        -- Deepmoss Eggs Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '178.876' WHERE (`spawn_id` = '44653'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '59.329' WHERE (`spawn_id` = '2501'); 
+        -- Deepmoss Eggs Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '178.876' WHERE (`spawn_id` = '44652'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.71' WHERE (`spawn_id` = '2515'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '2537'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '58.858' WHERE (`spawn_id` = '2561'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '15.231' WHERE (`spawn_id` = '2577'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '130.707' WHERE (`spawn_id` = '2579'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '102.218' WHERE (`spawn_id` = '2592'); 
+        -- Thornroot XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10371.842', `spawn_positionY` = '-1318.831', `spawn_positionZ` = '52.909' WHERE (`spawn_id` = '2608'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '101.945' WHERE (`spawn_id` = '2612'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '150.395' WHERE (`spawn_id` = '2614'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-10.439' WHERE (`spawn_id` = '2619'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.352' WHERE (`spawn_id` = '2625'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '102.397' WHERE (`spawn_id` = '2628'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '32.502' WHERE (`spawn_id` = '2661'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '31.331' WHERE (`spawn_id` = '2671'); 
+        -- Thornroot XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '650.887', `spawn_positionY` = '1382.366', `spawn_positionZ` = '82.77' WHERE (`spawn_id` = '2687'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '44.492' WHERE (`spawn_id` = '2690'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '31.089' WHERE (`spawn_id` = '2706'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '42.293' WHERE (`spawn_id` = '2710'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '5.749' WHERE (`spawn_id` = '2717'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.131' WHERE (`spawn_id` = '2725'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '129.152' WHERE (`spawn_id` = '2731'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.43' WHERE (`spawn_id` = '2732'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '42.477' WHERE (`spawn_id` = '2740'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '32.451' WHERE (`spawn_id` = '2806'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '98.731' WHERE (`spawn_id` = '2822'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '88.464' WHERE (`spawn_id` = '2835'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '101.467' WHERE (`spawn_id` = '2868'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '55.729' WHERE (`spawn_id` = '2869'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.827' WHERE (`spawn_id` = '2899'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '49.912' WHERE (`spawn_id` = '2900'); 
+        -- Bruiseweed ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '2931'); 
+        -- Bruiseweed ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '2932'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '86.101' WHERE (`spawn_id` = '3042'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '123.902' WHERE (`spawn_id` = '3078'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '46.646' WHERE (`spawn_id` = '3109'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '107.369' WHERE (`spawn_id` = '3118'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.168' WHERE (`spawn_id` = '3133'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.716' WHERE (`spawn_id` = '3138'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.39' WHERE (`spawn_id` = '3159'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '53.212' WHERE (`spawn_id` = '3205'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '53.15' WHERE (`spawn_id` = '3207'); 
+        -- Bruiseweed ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '3221'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '20.52' WHERE (`spawn_id` = '3260'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '53.36' WHERE (`spawn_id` = '3262'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '51.686' WHERE (`spawn_id` = '3289'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '57.602' WHERE (`spawn_id` = '3329'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '117.274' WHERE (`spawn_id` = '3364'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '252.407' WHERE (`spawn_id` = '3394'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.889' WHERE (`spawn_id` = '3395'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.847' WHERE (`spawn_id` = '3401'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.583' WHERE (`spawn_id` = '3469'); 
+        -- Bruiseweed XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2041.671', `spawn_positionY` = '-3208.335', `spawn_positionZ` = '101.091' WHERE (`spawn_id` = '3478'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.175' WHERE (`spawn_id` = '3515'); 
+        -- Bruiseweed XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2587.874', `spawn_positionY` = '-2382.282', `spawn_positionZ` = '79.878' WHERE (`spawn_id` = '3531'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.03' WHERE (`spawn_id` = '3538'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-55.438' WHERE (`spawn_id` = '3587'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '17.642' WHERE (`spawn_id` = '3597'); 
 
         insert into applied_updates values ('190120221');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -845,6 +845,325 @@ begin not atomic
         -- Iron Deposit Z placement. 
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '6229'); 
 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '131.359' WHERE (`spawn_id` = '6241'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '113.478' WHERE (`spawn_id` = '6242'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '176.463' WHERE (`spawn_id` = '6249'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '6250'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.387' WHERE (`spawn_id` = '6252'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.092' WHERE (`spawn_id` = '6288'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '79.7' WHERE (`spawn_id` = '6298'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '68.58' WHERE (`spawn_id` = '6304'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-58.749' WHERE (`spawn_id` = '6322'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '178.669' WHERE (`spawn_id` = '6349'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '101.954' WHERE (`spawn_id` = '6366'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '90.481' WHERE (`spawn_id` = '6372'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '87.957' WHERE (`spawn_id` = '6373'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4992.803', `spawn_positionY` = '-2291.727', `spawn_positionZ` = '-61.709' WHERE (`spawn_id` = '6378'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-814.5', `spawn_positionY` = '-3883.0', `spawn_positionZ` = '180.319' WHERE (`spawn_id` = '6414'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6643.518', `spawn_positionY` = '-3714.351', `spawn_positionZ` = '278.994' WHERE (`spawn_id` = '6449'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '40.434' WHERE (`spawn_id` = '14954'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '24.255' WHERE (`spawn_id` = '6485'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10954.143', `spawn_positionY` = '-3706.594', `spawn_positionZ` = '18.849' WHERE (`spawn_id` = '6492'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5099.394', `spawn_positionY` = '1781.258', `spawn_positionZ` = '51.33' WHERE (`spawn_id` = '6495'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '40.564' WHERE (`spawn_id` = '14953'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6467.737', `spawn_positionY` = '-2480.182', `spawn_positionZ` = '326.823' WHERE (`spawn_id` = '6503'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '40.467' WHERE (`spawn_id` = '14952'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-13134.521', `spawn_positionY` = '-481.502', `spawn_positionZ` = '4.085' WHERE (`spawn_id` = '6521'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '40.3' WHERE (`spawn_id` = '14951'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.921' WHERE (`spawn_id` = '14950'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '90.485' WHERE (`spawn_id` = '6551'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-7310.229', `spawn_positionY` = '-1956.119', `spawn_positionZ` = '308.881' WHERE (`spawn_id` = '6556'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.005' WHERE (`spawn_id` = '14949'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.002' WHERE (`spawn_id` = '14948'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4982.301', `spawn_positionY` = '-2316.412', `spawn_positionZ` = '-56.926' WHERE (`spawn_id` = '6560'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5016.368', `spawn_positionY` = '1794.606', `spawn_positionZ` = '65.902' WHERE (`spawn_id` = '6577'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.329' WHERE (`spawn_id` = '6587'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5046.849', `spawn_positionY` = '1792.557', `spawn_positionZ` = '57.756' WHERE (`spawn_id` = '6588'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.695' WHERE (`spawn_id` = '6592'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.181' WHERE (`spawn_id` = '14947'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.168' WHERE (`spawn_id` = '14946'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-884.0', `spawn_positionY` = '-3912.0', `spawn_positionZ` = '147.56' WHERE (`spawn_id` = '6614'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.677' WHERE (`spawn_id` = '6624'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4944.349', `spawn_positionY` = '-2341.905', `spawn_positionZ` = '-57.6' WHERE (`spawn_id` = '6625'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2975.015', `spawn_positionY` = '-3154.677', `spawn_positionZ` = '52.554' WHERE (`spawn_id` = '6639'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '15.414' WHERE (`spawn_id` = '6645'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2024.515', `spawn_positionY` = '-3336.165', `spawn_positionZ` = '49.725' WHERE (`spawn_id` = '6651'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '86.288' WHERE (`spawn_id` = '6661'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '90.169' WHERE (`spawn_id` = '6668'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '6676'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.112' WHERE (`spawn_id` = '6678'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.206' WHERE (`spawn_id` = '6704'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4937.387', `spawn_positionY` = '-2349.707', `spawn_positionZ` = '-48.827' WHERE (`spawn_id` = '6718'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2038.625', `spawn_positionY` = '-3371.98', `spawn_positionZ` = '46.037' WHERE (`spawn_id` = '6729'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.511' WHERE (`spawn_id` = '6737'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '29.002' WHERE (`spawn_id` = '6740'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '146.556' WHERE (`spawn_id` = '6744'); 
+        -- TEMP Nearby Tubers Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '82.474' WHERE (`spawn_id` = '99868'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-7829.0', `spawn_positionY` = '-5004.78', `spawn_positionZ` = '23.592' WHERE (`spawn_id` = '6751'); 
+        -- Open To Pass Your Rite. Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '183.149' WHERE (`spawn_id` = '29644'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.493' WHERE (`spawn_id` = '34172'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.676' WHERE (`spawn_id` = '34164'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '34163'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '34162'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.319' WHERE (`spawn_id` = '34161'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.019' WHERE (`spawn_id` = '34150'); 
+        -- Atal'ai Artifact Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-75.333' WHERE (`spawn_id` = '30559'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '34077'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '33911'); 
+        -- Dwarven Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '6836'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '6839'); 
+        -- Tin Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-811.035', `spawn_positionY` = '155.677', `spawn_positionZ` = '2.727' WHERE (`spawn_id` = '21273'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '64.457' WHERE (`spawn_id` = '33555'); 
+        -- Dwarven Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '6872'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '6874'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '9.839' WHERE (`spawn_id` = '35551'); 
+        -- Tin Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-814.012', `spawn_positionY` = '164.024', `spawn_positionZ` = '0.648' WHERE (`spawn_id` = '21259'); 
+        -- Tammra Gaea Sapling Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '33531'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-28.823' WHERE (`spawn_id` = '21249'); 
+        -- Atal'ai Artifact Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '16.693' WHERE (`spawn_id` = '30383'); 
+        -- Campfire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '64.457' WHERE (`spawn_id` = '32863'); 
+        -- Atal'ai Artifact Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-25.613' WHERE (`spawn_id` = '30378'); 
+        -- Anvil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '32669'); 
+        -- Anvil ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '32667'); 
+        -- Meat Smoker ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '32659'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '47.605' WHERE (`spawn_id` = '14930'); 
+        -- Campfire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '186.07' WHERE (`spawn_id` = '32654'); 
+        -- Tear of Theradras XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2351.913', `spawn_positionY` = '2413.787', `spawn_positionZ` = '61.14' WHERE (`spawn_id` = '32647'); 
+        -- Tear of Theradras XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2347.225', `spawn_positionY` = '2413.241', `spawn_positionZ` = '62.401' WHERE (`spawn_id` = '32647'); 
+        -- Tear of Theradras XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2399.662', `spawn_positionY` = '2420.426', `spawn_positionZ` = '58.416' WHERE (`spawn_id` = '32604'); 
+        -- Alliance Chest Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '54.189' WHERE (`spawn_id` = '20885'); 
+        -- Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '119.487' WHERE (`spawn_id` = '7070'); 
+        -- Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.102' WHERE (`spawn_id` = '7141'); 
+        -- Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '79.674' WHERE (`spawn_id` = '7146'); 
+        -- Mithril Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2067.0', `spawn_positionY` = '-3350.525', `spawn_positionZ` = '40.86' WHERE (`spawn_id` = '7177'); 
+        -- Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '7.082' WHERE (`spawn_id` = '7199'); 
+        -- Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '90.748' WHERE (`spawn_id` = '7302'); 
+        -- Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '115.395' WHERE (`spawn_id` = '7315'); 
+        -- Liferoot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '13.363' WHERE (`spawn_id` = '7335'); 
+        -- Liferoot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '124.15' WHERE (`spawn_id` = '7538'); 
+        -- Liferoot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.062' WHERE (`spawn_id` = '7545'); 
+        -- Fadeleaf Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '121.3' WHERE (`spawn_id` = '7577'); 
+        -- Fadeleaf Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '117.919' WHERE (`spawn_id` = '7579'); 
+        -- Fadeleaf Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '118.866' WHERE (`spawn_id` = '7660'); 
+        -- Khadgar's Whisker Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.715' WHERE (`spawn_id` = '14613'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.405' WHERE (`spawn_id` = '14604'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.006' WHERE (`spawn_id` = '13672'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.853' WHERE (`spawn_id` = '13671'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.834' WHERE (`spawn_id` = '13670'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '12.188' WHERE (`spawn_id` = '13669'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.248' WHERE (`spawn_id` = '13657'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.207' WHERE (`spawn_id` = '13656'); 
+        -- Khadgar's Whisker Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '120.349' WHERE (`spawn_id` = '7935'); 
+        -- Khadgar's Whisker Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '15.518' WHERE (`spawn_id` = '7963'); 
+        -- Khadgar's Whisker Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.441' WHERE (`spawn_id` = '7966'); 
+        -- Khadgar's Whisker Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.142' WHERE (`spawn_id` = '8047'); 
+        -- Khadgar's Whisker Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '122.04' WHERE (`spawn_id` = '8119'); 
+        -- Khadgar's Whisker Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.448' WHERE (`spawn_id` = '8163'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.824' WHERE (`spawn_id` = '8224'); 
+        -- Stranglekelp ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8234'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.635' WHERE (`spawn_id` = '8235'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.678' WHERE (`spawn_id` = '8237'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.618' WHERE (`spawn_id` = '8238'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.333' WHERE (`spawn_id` = '8243'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.599' WHERE (`spawn_id` = '8248'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.302' WHERE (`spawn_id` = '8250'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.56' WHERE (`spawn_id` = '8259'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.528' WHERE (`spawn_id` = '8261'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.147' WHERE (`spawn_id` = '8262'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.808' WHERE (`spawn_id` = '8263'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.844' WHERE (`spawn_id` = '8264'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.659' WHERE (`spawn_id` = '8266'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.637' WHERE (`spawn_id` = '8267'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.459' WHERE (`spawn_id` = '8268'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-3.279' WHERE (`spawn_id` = '8272'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.555' WHERE (`spawn_id` = '8298'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.091' WHERE (`spawn_id` = '8299'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.231' WHERE (`spawn_id` = '8304'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.386' WHERE (`spawn_id` = '8308'); 
+        -- Stranglekelp ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8311'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.147' WHERE (`spawn_id` = '8316'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.556' WHERE (`spawn_id` = '8318'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.972' WHERE (`spawn_id` = '8319'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.729' WHERE (`spawn_id` = '8330'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.64' WHERE (`spawn_id` = '8331'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.574' WHERE (`spawn_id` = '8337'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-2.104' WHERE (`spawn_id` = '8339'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-4.136' WHERE (`spawn_id` = '8340'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.625' WHERE (`spawn_id` = '8369'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.859' WHERE (`spawn_id` = '8385'); 
+        -- Fadeleaf Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '39.598' WHERE (`spawn_id` = '13641'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.527' WHERE (`spawn_id` = '8404'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.857' WHERE (`spawn_id` = '8406'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.681' WHERE (`spawn_id` = '8411'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.039' WHERE (`spawn_id` = '8428'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.188' WHERE (`spawn_id` = '8442'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-4.566' WHERE (`spawn_id` = '8447'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.087' WHERE (`spawn_id` = '8454'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.651' WHERE (`spawn_id` = '8457'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-2.548' WHERE (`spawn_id` = '8468'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.568' WHERE (`spawn_id` = '8501'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '12.563' WHERE (`spawn_id` = '8508'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.412' WHERE (`spawn_id` = '8509'); 
+
         insert into applied_updates values ('190120221');
     end if;
 end $

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -18,2540 +18,2540 @@ begin not atomic
     -- 19/01/2022 1
     if (select count(*) from applied_updates where id='190120221') = 0 then
         -- Webwood Eggs proper placement.
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10874.13', `spawn_positionY` = '923.626', `spawn_positionZ` = '1317.481' WHERE (`spawn_id` = '49589');
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10874.27', `spawn_positionY` = '917.391', `spawn_positionZ` = '1317.544' WHERE (`spawn_id` = '49590');
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10881.17', `spawn_positionY` = '914.299', `spawn_positionZ` = '1317.358' WHERE (`spawn_id` = '49591');
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10896.01', `spawn_positionY` = '920.324', `spawn_positionZ` = '1319.054' WHERE (`spawn_id` = '49593');
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10900.56', `spawn_positionY` = '920.812', `spawn_positionZ` = '1319.237' WHERE (`spawn_id` = '49595');
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10903.92', `spawn_positionY` = '927.207', `spawn_positionZ` = '1319.866' WHERE (`spawn_id` = '49596');
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '10874.13', `spawn_positionY` = '923.626', `spawn_positionZ` = '1317.481' WHERE (`spawn_id` = '49589');
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '10874.27', `spawn_positionY` = '917.391', `spawn_positionZ` = '1317.544' WHERE (`spawn_id` = '49590');
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '10881.17', `spawn_positionY` = '914.299', `spawn_positionZ` = '1317.358' WHERE (`spawn_id` = '49591');
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '10896.01', `spawn_positionY` = '920.324', `spawn_positionZ` = '1319.054' WHERE (`spawn_id` = '49593');
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '10900.56', `spawn_positionY` = '920.812', `spawn_positionZ` = '1319.237' WHERE (`spawn_id` = '49595');
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '10903.92', `spawn_positionY` = '927.207', `spawn_positionZ` = '1319.866' WHERE (`spawn_id` = '49596');
 	
         -- Fix Webwood Spiders wrong Z.
-        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1334.94' WHERE (`spawn_id` = '47061');
-        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1335.55' WHERE (`spawn_id` = '47249');
-        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1335.60' WHERE (`spawn_id` = '47003');
-        UPDATE `alpha_world`.`spawns_creatures` SET `position_x` = '10832.00', `position_y` = '921.21', `position_z` = '1337.127' WHERE (`spawn_id` = '47002');
-        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1332.67' WHERE (`spawn_id` = '47017');
-        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1326.44' WHERE (`spawn_id` = '47018');
-        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1321.23' WHERE (`spawn_id` = '47023');
-        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1319.51' WHERE (`spawn_id` = '47056');
+        UPDATE `spawns_creatures` SET `position_z` = '1334.94' WHERE (`spawn_id` = '47061');
+        UPDATE `spawns_creatures` SET `position_z` = '1335.55' WHERE (`spawn_id` = '47249');
+        UPDATE `spawns_creatures` SET `position_z` = '1335.60' WHERE (`spawn_id` = '47003');
+        UPDATE `spawns_creatures` SET `position_x` = '10832.00', `position_y` = '921.21', `position_z` = '1337.127' WHERE (`spawn_id` = '47002');
+        UPDATE `spawns_creatures` SET `position_z` = '1332.67' WHERE (`spawn_id` = '47017');
+        UPDATE `spawns_creatures` SET `position_z` = '1326.44' WHERE (`spawn_id` = '47018');
+        UPDATE `spawns_creatures` SET `position_z` = '1321.23' WHERE (`spawn_id` = '47023');
+        UPDATE `spawns_creatures` SET `position_z` = '1319.51' WHERE (`spawn_id` = '47056');
 
         -- Small Thorium Vein ignored, out of reach.
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '132');
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '132');
         -- Small Thorium Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '53.964', `spawn_positionY` = '-4194.94', `spawn_positionZ` = '119.66' WHERE (`spawn_id` = '131');
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '53.964', `spawn_positionY` = '-4194.94', `spawn_positionZ` = '119.66' WHERE (`spawn_id` = '131');
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.767' WHERE (`spawn_id` = '136');
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.767' WHERE (`spawn_id` = '136');
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.132' WHERE (`spawn_id` = '141');
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.132' WHERE (`spawn_id` = '141');
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '480.185' WHERE (`spawn_id` = '144');
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '480.185' WHERE (`spawn_id` = '144');
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '15.19' WHERE (`spawn_id` = '148');
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '15.19' WHERE (`spawn_id` = '148');
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.39' WHERE (`spawn_id` = '152');
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.39' WHERE (`spawn_id` = '152');
         -- Quilboar Watering Hole placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '99864'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '99864'); 
         -- Alliance Chest ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '47590'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '47590'); 
         -- Alliance Chest ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '47589'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '47589'); 
         -- Dwarven Brazier Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.878' WHERE (`spawn_id` = '19'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '519.878' WHERE (`spawn_id` = '19'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.878' WHERE (`spawn_id` = '20'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '519.878' WHERE (`spawn_id` = '20'); 
         -- Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '25.874' WHERE (`spawn_id` = '30737'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '25.874' WHERE (`spawn_id` = '30737'); 
         -- Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.126' WHERE (`spawn_id` = '30646'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '2.126' WHERE (`spawn_id` = '30646'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '46'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '46'); 
         -- No object template, set ignored.
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '52'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '52'); 
         -- Dwarven Brazier Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '423.01' WHERE (`spawn_id` = '58'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '423.01' WHERE (`spawn_id` = '58'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '423.01' WHERE (`spawn_id` = '59'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '423.01' WHERE (`spawn_id` = '59'); 
         -- Forge ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '47586'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '47586'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '22.465' WHERE (`spawn_id` = '30591'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '22.465' WHERE (`spawn_id` = '30591'); 
         -- Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '20.76' WHERE (`spawn_id` = '30589'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '20.76' WHERE (`spawn_id` = '30589'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '93'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '93'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '155.184' WHERE (`spawn_id` = '30035'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '155.184' WHERE (`spawn_id` = '30035'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.14' WHERE (`spawn_id` = '136'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-0.14' WHERE (`spawn_id` = '136'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '65.924' WHERE (`spawn_id` = '156'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '65.924' WHERE (`spawn_id` = '156'); 
         -- Small Thorium Vein ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '157'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '157'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-27.0' WHERE (`spawn_id` = '163'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-27.0' WHERE (`spawn_id` = '163'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '70.317' WHERE (`spawn_id` = '165'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '70.317' WHERE (`spawn_id` = '165'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '700.815' WHERE (`spawn_id` = '166'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '700.815' WHERE (`spawn_id` = '166'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '697.121' WHERE (`spawn_id` = '167'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '697.121' WHERE (`spawn_id` = '167'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.955' WHERE (`spawn_id` = '171'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.955' WHERE (`spawn_id` = '171'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '55.253' WHERE (`spawn_id` = '173'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '55.253' WHERE (`spawn_id` = '173'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '57.667' WHERE (`spawn_id` = '174'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '57.667' WHERE (`spawn_id` = '174'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '240.779' WHERE (`spawn_id` = '175'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '240.779' WHERE (`spawn_id` = '175'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '693.624' WHERE (`spawn_id` = '185'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '693.624' WHERE (`spawn_id` = '185'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '594.675' WHERE (`spawn_id` = '191'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '594.675' WHERE (`spawn_id` = '191'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '153.33' WHERE (`spawn_id` = '194'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '153.33' WHERE (`spawn_id` = '194'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.598' WHERE (`spawn_id` = '195'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.598' WHERE (`spawn_id` = '195'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '110.99' WHERE (`spawn_id` = '201'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '110.99' WHERE (`spawn_id` = '201'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '7.772' WHERE (`spawn_id` = '204'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '7.772' WHERE (`spawn_id` = '204'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-215.479' WHERE (`spawn_id` = '209'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-215.479' WHERE (`spawn_id` = '209'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '934.929' WHERE (`spawn_id` = '210'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '934.929' WHERE (`spawn_id` = '210'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.213' WHERE (`spawn_id` = '214'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '21.213' WHERE (`spawn_id` = '214'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '692.923' WHERE (`spawn_id` = '220'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '692.923' WHERE (`spawn_id` = '220'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '9.668' WHERE (`spawn_id` = '221'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '9.668' WHERE (`spawn_id` = '221'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '5.86' WHERE (`spawn_id` = '222'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '5.86' WHERE (`spawn_id` = '222'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '66.006' WHERE (`spawn_id` = '226'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '66.006' WHERE (`spawn_id` = '226'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '74.424' WHERE (`spawn_id` = '227'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '74.424' WHERE (`spawn_id` = '227'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '461.16' WHERE (`spawn_id` = '228'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '461.16' WHERE (`spawn_id` = '228'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '42.558' WHERE (`spawn_id` = '230'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '42.558' WHERE (`spawn_id` = '230'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '161.934' WHERE (`spawn_id` = '233'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '161.934' WHERE (`spawn_id` = '233'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '906.364' WHERE (`spawn_id` = '238'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '906.364' WHERE (`spawn_id` = '238'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '940.785' WHERE (`spawn_id` = '239'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '940.785' WHERE (`spawn_id` = '239'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '882.397' WHERE (`spawn_id` = '246'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '882.397' WHERE (`spawn_id` = '246'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '424.27' WHERE (`spawn_id` = '251'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '424.27' WHERE (`spawn_id` = '251'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.77' WHERE (`spawn_id` = '254'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '4.77' WHERE (`spawn_id` = '254'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '70.562' WHERE (`spawn_id` = '255'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '70.562' WHERE (`spawn_id` = '255'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.585' WHERE (`spawn_id` = '257'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-0.585' WHERE (`spawn_id` = '257'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '242.406' WHERE (`spawn_id` = '258'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '242.406' WHERE (`spawn_id` = '258'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '67.875' WHERE (`spawn_id` = '260'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '67.875' WHERE (`spawn_id` = '260'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '336.134' WHERE (`spawn_id` = '263'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '336.134' WHERE (`spawn_id` = '263'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.657' WHERE (`spawn_id` = '266'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '10.657' WHERE (`spawn_id` = '266'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '604.286' WHERE (`spawn_id` = '269'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '604.286' WHERE (`spawn_id` = '269'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.938' WHERE (`spawn_id` = '273'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '0.938' WHERE (`spawn_id` = '273'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '565.656' WHERE (`spawn_id` = '278'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '565.656' WHERE (`spawn_id` = '278'); 
         -- Small Thorium Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6354.948', `spawn_positionY` = '-1878.964', `spawn_positionZ` = '-196.699' WHERE (`spawn_id` = '280'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-6354.948', `spawn_positionY` = '-1878.964', `spawn_positionZ` = '-196.699' WHERE (`spawn_id` = '280'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-258.303' WHERE (`spawn_id` = '282'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-258.303' WHERE (`spawn_id` = '282'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '944.186' WHERE (`spawn_id` = '287'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '944.186' WHERE (`spawn_id` = '287'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.265' WHERE (`spawn_id` = '288'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '14.265' WHERE (`spawn_id` = '288'); 
         -- Small Thorium Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '6417.55', `spawn_positionY` = '-4285.0', `spawn_positionZ` = '627.528' WHERE (`spawn_id` = '292'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '6417.55', `spawn_positionY` = '-4285.0', `spawn_positionZ` = '627.528' WHERE (`spawn_id` = '292'); 
         -- Small Thorium Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '6417.55', `spawn_positionY` = '-4285.0', `spawn_positionZ` = '699.082' WHERE (`spawn_id` = '292'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '6417.55', `spawn_positionY` = '-4285.0', `spawn_positionZ` = '699.082' WHERE (`spawn_id` = '292'); 
         -- Small Thorium Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '5765.252', `spawn_positionY` = '-4931.604', `spawn_positionZ` = '762.81' WHERE (`spawn_id` = '293'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '5765.252', `spawn_positionY` = '-4931.604', `spawn_positionZ` = '762.81' WHERE (`spawn_id` = '293'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-31.202' WHERE (`spawn_id` = '294'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-31.202' WHERE (`spawn_id` = '294'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '66.178' WHERE (`spawn_id` = '295'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '66.178' WHERE (`spawn_id` = '295'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '85.641' WHERE (`spawn_id` = '298'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '85.641' WHERE (`spawn_id` = '298'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-257.122' WHERE (`spawn_id` = '299'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-257.122' WHERE (`spawn_id` = '299'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '28.691' WHERE (`spawn_id` = '302'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '28.691' WHERE (`spawn_id` = '302'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '67.088' WHERE (`spawn_id` = '307'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '67.088' WHERE (`spawn_id` = '307'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '19.638' WHERE (`spawn_id` = '310'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '19.638' WHERE (`spawn_id` = '310'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '15.455' WHERE (`spawn_id` = '312'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '15.455' WHERE (`spawn_id` = '312'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '454.778' WHERE (`spawn_id` = '314'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '454.778' WHERE (`spawn_id` = '314'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-260.0' WHERE (`spawn_id` = '315'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-260.0' WHERE (`spawn_id` = '315'); 
         -- Small Thorium Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-7212.61', `spawn_positionY` = '-2299.323', `spawn_positionZ` = '-253.81' WHERE (`spawn_id` = '317'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-7212.61', `spawn_positionY` = '-2299.323', `spawn_positionZ` = '-253.81' WHERE (`spawn_id` = '317'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '75.38' WHERE (`spawn_id` = '328'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '75.38' WHERE (`spawn_id` = '328'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.836' WHERE (`spawn_id` = '335'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.836' WHERE (`spawn_id` = '335'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-264.636' WHERE (`spawn_id` = '338'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-264.636' WHERE (`spawn_id` = '338'); 
         -- Small Thorium Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-7976.028', `spawn_positionY` = '-2348.022', `spawn_positionZ` = '-24.016' WHERE (`spawn_id` = '339'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-7976.028', `spawn_positionY` = '-2348.022', `spawn_positionZ` = '-24.016' WHERE (`spawn_id` = '339'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '911.426' WHERE (`spawn_id` = '340'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '911.426' WHERE (`spawn_id` = '340'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.373' WHERE (`spawn_id` = '343'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.373' WHERE (`spawn_id` = '343'); 
         -- Small Thorium Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10604.152', `spawn_positionY` = '-3387.443', `spawn_positionZ` = '39.09' WHERE (`spawn_id` = '344'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-10604.152', `spawn_positionY` = '-3387.443', `spawn_positionZ` = '39.09' WHERE (`spawn_id` = '344'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '941.338' WHERE (`spawn_id` = '348'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '941.338' WHERE (`spawn_id` = '348'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-243.0' WHERE (`spawn_id` = '353'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-243.0' WHERE (`spawn_id` = '353'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '792.443' WHERE (`spawn_id` = '358'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '792.443' WHERE (`spawn_id` = '358'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '144.124' WHERE (`spawn_id` = '361'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '144.124' WHERE (`spawn_id` = '361'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-244.884' WHERE (`spawn_id` = '367'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-244.884' WHERE (`spawn_id` = '367'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '71.464' WHERE (`spawn_id` = '368'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '71.464' WHERE (`spawn_id` = '368'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-269.5' WHERE (`spawn_id` = '374'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-269.5' WHERE (`spawn_id` = '374'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-205.952' WHERE (`spawn_id` = '377'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-205.952' WHERE (`spawn_id` = '377'); 
         -- Small Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '789.403' WHERE (`spawn_id` = '384'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '789.403' WHERE (`spawn_id` = '384'); 
         -- Solid Chest Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '52.58' WHERE (`spawn_id` = '30018'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '52.58' WHERE (`spawn_id` = '30018'); 
         -- Anvil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.676' WHERE (`spawn_id` = '47584'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.676' WHERE (`spawn_id` = '47584'); 
         -- Greatwood Vale Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '311.76' WHERE (`spawn_id` = '47583'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '311.76' WHERE (`spawn_id` = '47583'); 
         -- Campfire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.676' WHERE (`spawn_id` = '47582'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.676' WHERE (`spawn_id` = '47582'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '63.369' WHERE (`spawn_id` = '29993'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '63.369' WHERE (`spawn_id` = '29993'); 
         -- Campfire XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '817.833', `spawn_positionY` = '945.833', `spawn_positionZ` = '94.343' WHERE (`spawn_id` = '47580'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '817.833', `spawn_positionY` = '945.833', `spawn_positionZ` = '94.343' WHERE (`spawn_id` = '47580'); 
         -- TEMP Shadra'Alor Altar Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '87.223' WHERE (`spawn_id` = '99875'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '87.223' WHERE (`spawn_id` = '99875'); 
         -- Musty Tome Trap Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '71.66' WHERE (`spawn_id` = '12342'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '71.66' WHERE (`spawn_id` = '12342'); 
         -- Dwarven Brazier Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.887' WHERE (`spawn_id` = '512'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '519.887' WHERE (`spawn_id` = '512'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.888' WHERE (`spawn_id` = '513'); 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.887' WHERE (`spawn_id` = '516'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '519.888' WHERE (`spawn_id` = '513'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '519.887' WHERE (`spawn_id` = '516'); 
         -- Silverleaf Bush Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.575' WHERE (`spawn_id` = '522'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '34.575' WHERE (`spawn_id` = '522'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '528.499' WHERE (`spawn_id` = '524'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '528.499' WHERE (`spawn_id` = '524'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '520.165' WHERE (`spawn_id` = '526'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '520.165' WHERE (`spawn_id` = '526'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.887' WHERE (`spawn_id` = '544'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '519.887' WHERE (`spawn_id` = '544'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '590'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '590'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '592'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '592'); 
         -- Dwarven Brazier Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.876' WHERE (`spawn_id` = '596'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '519.876' WHERE (`spawn_id` = '596'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.876' WHERE (`spawn_id` = '601'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '519.876' WHERE (`spawn_id` = '601'); 
         -- Dwarven Brazier Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '523.496' WHERE (`spawn_id` = '603'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '523.496' WHERE (`spawn_id` = '603'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '523.496' WHERE (`spawn_id` = '610'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '523.496' WHERE (`spawn_id` = '610'); 
         -- Dwarven Brazier Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '523.496' WHERE (`spawn_id` = '611'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '523.496' WHERE (`spawn_id` = '611'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '523.496' WHERE (`spawn_id` = '612'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '523.496' WHERE (`spawn_id` = '612'); 
         -- Dwarven Brazier Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '525.949' WHERE (`spawn_id` = '613'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '525.949' WHERE (`spawn_id` = '613'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '525.949' WHERE (`spawn_id` = '617'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '525.949' WHERE (`spawn_id` = '617'); 
         -- Silverleaf Bush Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-5.602' WHERE (`spawn_id` = '631'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-5.602' WHERE (`spawn_id` = '631'); 
         -- Silverleaf Bush Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '28.038' WHERE (`spawn_id` = '687'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '28.038' WHERE (`spawn_id` = '687'); 
         -- Silverleaf Bush Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '30.138' WHERE (`spawn_id` = '764'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '30.138' WHERE (`spawn_id` = '764'); 
         -- Barrel of Milk Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.852' WHERE (`spawn_id` = '47558'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '4.852' WHERE (`spawn_id` = '47558'); 
         -- Dwarven High Back Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '780'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '780'); 
         -- Barrel of Milk Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.873' WHERE (`spawn_id` = '47557'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '0.873' WHERE (`spawn_id` = '47557'); 
         -- Barrel of Milk ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '47552'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '47552'); 
         -- Dwarven High Back Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '804'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '804'); 
         -- Silverleaf Bush Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '53.714' WHERE (`spawn_id` = '955'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '53.714' WHERE (`spawn_id` = '955'); 
         -- Silverleaf Bush Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-3.627' WHERE (`spawn_id` = '974'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-3.627' WHERE (`spawn_id` = '974'); 
         -- Silverleaf Bush Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.649' WHERE (`spawn_id` = '1004'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.649' WHERE (`spawn_id` = '1004'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '495.26' WHERE (`spawn_id` = '1009'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '495.26' WHERE (`spawn_id` = '1009'); 
         -- Silverleaf Bush XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1173.445', `spawn_positionY` = '-3001.554', `spawn_positionZ` = '99.832' WHERE (`spawn_id` = '1078'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1173.445', `spawn_positionY` = '-3001.554', `spawn_positionZ` = '99.832' WHERE (`spawn_id` = '1078'); 
         -- Silverleaf Bush Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.03' WHERE (`spawn_id` = '1146'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.03' WHERE (`spawn_id` = '1146'); 
         -- Campfire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '407.117' WHERE (`spawn_id` = '1173'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '407.117' WHERE (`spawn_id` = '1173'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '407.117' WHERE (`spawn_id` = '1174'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '407.117' WHERE (`spawn_id` = '1174'); 
         -- Silverleaf Bush XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5935.646', `spawn_positionY` = '-2903.753', `spawn_positionZ` = '369.238' WHERE (`spawn_id` = '1183'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-5935.646', `spawn_positionY` = '-2903.753', `spawn_positionZ` = '369.238' WHERE (`spawn_id` = '1183'); 
         -- Burning Embers Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '7.126' WHERE (`spawn_id` = '47504'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '7.126' WHERE (`spawn_id` = '47504'); 
         -- Peacebloom Flower Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-2.65' WHERE (`spawn_id` = '1392'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-2.65' WHERE (`spawn_id` = '1392'); 
         -- Peacebloom Flower Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-21.168' WHERE (`spawn_id` = '1399'); 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '47458'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-21.168' WHERE (`spawn_id` = '1399'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '47458'); 
         -- Peacebloom Flower Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.838' WHERE (`spawn_id` = '1475'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.838' WHERE (`spawn_id` = '1475'); 
         -- Peacebloom Flower Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.913' WHERE (`spawn_id` = '1490'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.913' WHERE (`spawn_id` = '1490'); 
         -- Greatwood Vale Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.42' WHERE (`spawn_id` = '47451'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '21.42' WHERE (`spawn_id` = '47451'); 
         -- Peacebloom Flower Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '96.275' WHERE (`spawn_id` = '1513'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '96.275' WHERE (`spawn_id` = '1513'); 
         -- Peacebloom Flower Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-17.469' WHERE (`spawn_id` = '1557'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-17.469' WHERE (`spawn_id` = '1557'); 
         -- Peacebloom Flower Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '42.99' WHERE (`spawn_id` = '1608'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '42.99' WHERE (`spawn_id` = '1608'); 
         -- Peacebloom Flower Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.13' WHERE (`spawn_id` = '1609'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '33.13' WHERE (`spawn_id` = '1609'); 
         -- Peacebloom Flower Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.349' WHERE (`spawn_id` = '1676'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '4.349' WHERE (`spawn_id` = '1676'); 
         -- Peacebloom Flower Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '31.074' WHERE (`spawn_id` = '1690'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '31.074' WHERE (`spawn_id` = '1690'); 
         -- Wild Steelbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '114.355' WHERE (`spawn_id` = '47317'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '114.355' WHERE (`spawn_id` = '47317'); 
         -- Wild Steelbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '145.642' WHERE (`spawn_id` = '47317'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '145.642' WHERE (`spawn_id` = '47317'); 
         -- Peacebloom Flower Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '37.011' WHERE (`spawn_id` = '1698'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '37.011' WHERE (`spawn_id` = '1698'); 
         -- Deepmoss Eggs Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '178.876' WHERE (`spawn_id` = '47193'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '178.876' WHERE (`spawn_id` = '47193'); 
         -- Deepmoss Eggs Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '178.858' WHERE (`spawn_id` = '47192'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '178.858' WHERE (`spawn_id` = '47192'); 
         -- Snakeroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.089' WHERE (`spawn_id` = '1786'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '38.089' WHERE (`spawn_id` = '1786'); 
         -- Snakeroot XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '3.716', `spawn_positionY` = '-1831.217', `spawn_positionZ` = '96.578' WHERE (`spawn_id` = '1813'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '3.716', `spawn_positionY` = '-1831.217', `spawn_positionZ` = '96.578' WHERE (`spawn_id` = '1813'); 
         -- Snakeroot XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '380.849', `spawn_positionY` = '1152.36', `spawn_positionZ` = '89.758' WHERE (`spawn_id` = '1840'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '380.849', `spawn_positionY` = '1152.36', `spawn_positionZ` = '89.758' WHERE (`spawn_id` = '1840'); 
         -- Snakeroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.38' WHERE (`spawn_id` = '1901'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '92.38' WHERE (`spawn_id` = '1901'); 
         -- Snakeroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.503' WHERE (`spawn_id` = '1925'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.503' WHERE (`spawn_id` = '1925'); 
         -- Snakeroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '30.935' WHERE (`spawn_id` = '1937'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '30.935' WHERE (`spawn_id` = '1937'); 
         -- Snakeroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.03' WHERE (`spawn_id` = '1955'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '10.03' WHERE (`spawn_id` = '1955'); 
         -- Snakeroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '23.483' WHERE (`spawn_id` = '2003'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '23.483' WHERE (`spawn_id` = '2003'); 
         -- Snakeroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '20.166' WHERE (`spawn_id` = '2004'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '20.166' WHERE (`spawn_id` = '2004'); 
         -- Snakeroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.283' WHERE (`spawn_id` = '2005'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '26.283' WHERE (`spawn_id` = '2005'); 
         -- Snakeroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '24.98' WHERE (`spawn_id` = '2009'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '24.98' WHERE (`spawn_id` = '2009'); 
         -- Snakeroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '22.561' WHERE (`spawn_id` = '2028'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '22.561' WHERE (`spawn_id` = '2028'); 
         -- Snakeroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.658' WHERE (`spawn_id` = '2042'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-0.658' WHERE (`spawn_id` = '2042'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.603' WHERE (`spawn_id` = '2088'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '92.603' WHERE (`spawn_id` = '2088'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.902' WHERE (`spawn_id` = '2096'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '38.902' WHERE (`spawn_id` = '2096'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.784' WHERE (`spawn_id` = '2098'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.784' WHERE (`spawn_id` = '2098'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.925' WHERE (`spawn_id` = '2108'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.925' WHERE (`spawn_id` = '2108'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.701' WHERE (`spawn_id` = '2158'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '36.701' WHERE (`spawn_id` = '2158'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '95.836' WHERE (`spawn_id` = '2160'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '95.836' WHERE (`spawn_id` = '2160'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '107.194' WHERE (`spawn_id` = '2166'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '107.194' WHERE (`spawn_id` = '2166'); 
         -- Common Magebloom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '642.629', `spawn_positionY` = '-1575.349', `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '2179'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '642.629', `spawn_positionY` = '-1575.349', `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '2179'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.064' WHERE (`spawn_id` = '2191'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '92.064' WHERE (`spawn_id` = '2191'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.355' WHERE (`spawn_id` = '2192'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.355' WHERE (`spawn_id` = '2192'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.876' WHERE (`spawn_id` = '2193'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.876' WHERE (`spawn_id` = '2193'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.712' WHERE (`spawn_id` = '2213'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.712' WHERE (`spawn_id` = '2213'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '81.35' WHERE (`spawn_id` = '2222'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '81.35' WHERE (`spawn_id` = '2222'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '82.583' WHERE (`spawn_id` = '2229'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '82.583' WHERE (`spawn_id` = '2229'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '28.848' WHERE (`spawn_id` = '2233'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '28.848' WHERE (`spawn_id` = '2233'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '327.869' WHERE (`spawn_id` = '2237'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '327.869' WHERE (`spawn_id` = '2237'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '16.457' WHERE (`spawn_id` = '2240'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '16.457' WHERE (`spawn_id` = '2240'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.891' WHERE (`spawn_id` = '2244'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '33.891' WHERE (`spawn_id` = '2244'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.433' WHERE (`spawn_id` = '2253'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '21.433' WHERE (`spawn_id` = '2253'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '30.168' WHERE (`spawn_id` = '2283'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '30.168' WHERE (`spawn_id` = '2283'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.759' WHERE (`spawn_id` = '2285'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.759' WHERE (`spawn_id` = '2285'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '19.253' WHERE (`spawn_id` = '2295'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '19.253' WHERE (`spawn_id` = '2295'); 
         -- Common Magebloom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '561.842', `spawn_positionY` = '-3738.942', `spawn_positionZ` = '17.718' WHERE (`spawn_id` = '2311'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '561.842', `spawn_positionY` = '-3738.942', `spawn_positionZ` = '17.718' WHERE (`spawn_id` = '2311'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '19.601' WHERE (`spawn_id` = '2327'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '19.601' WHERE (`spawn_id` = '2327'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '23.601' WHERE (`spawn_id` = '2333'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '23.601' WHERE (`spawn_id` = '2333'); 
         -- Deepmoss Eggs Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '178.876' WHERE (`spawn_id` = '44657'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '178.876' WHERE (`spawn_id` = '44657'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.76' WHERE (`spawn_id` = '2339'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.76' WHERE (`spawn_id` = '2339'); 
         -- Common Magebloom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1028.345', `spawn_positionY` = '-1991.585', `spawn_positionZ` = '79.704' WHERE (`spawn_id` = '2341'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1028.345', `spawn_positionY` = '-1991.585', `spawn_positionZ` = '79.704' WHERE (`spawn_id` = '2341'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '13.253' WHERE (`spawn_id` = '2346'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '13.253' WHERE (`spawn_id` = '2346'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '87.728' WHERE (`spawn_id` = '2347'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '87.728' WHERE (`spawn_id` = '2347'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.406' WHERE (`spawn_id` = '2348'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.406' WHERE (`spawn_id` = '2348'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '90.639' WHERE (`spawn_id` = '2350'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '90.639' WHERE (`spawn_id` = '2350'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.651' WHERE (`spawn_id` = '2377'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.651' WHERE (`spawn_id` = '2377'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.153' WHERE (`spawn_id` = '2397'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.153' WHERE (`spawn_id` = '2397'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.761' WHERE (`spawn_id` = '2398'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '14.761' WHERE (`spawn_id` = '2398'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.971' WHERE (`spawn_id` = '2401'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '92.971' WHERE (`spawn_id` = '2401'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '29.151' WHERE (`spawn_id` = '2403'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '29.151' WHERE (`spawn_id` = '2403'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.875' WHERE (`spawn_id` = '2406'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.875' WHERE (`spawn_id` = '2406'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '32.255' WHERE (`spawn_id` = '2407'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '32.255' WHERE (`spawn_id` = '2407'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.887' WHERE (`spawn_id` = '2423'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.887' WHERE (`spawn_id` = '2423'); 
         -- Deepmoss Eggs Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '178.861' WHERE (`spawn_id` = '44655'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '178.861' WHERE (`spawn_id` = '44655'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '74.319' WHERE (`spawn_id` = '2474'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '74.319' WHERE (`spawn_id` = '2474'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '15.991' WHERE (`spawn_id` = '2481'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '15.991' WHERE (`spawn_id` = '2481'); 
         -- Deepmoss Eggs Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '175.121' WHERE (`spawn_id` = '44654'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '175.121' WHERE (`spawn_id` = '44654'); 
         -- Deepmoss Eggs Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '178.876' WHERE (`spawn_id` = '44653'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '178.876' WHERE (`spawn_id` = '44653'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '59.329' WHERE (`spawn_id` = '2501'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '59.329' WHERE (`spawn_id` = '2501'); 
         -- Deepmoss Eggs Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '178.876' WHERE (`spawn_id` = '44652'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '178.876' WHERE (`spawn_id` = '44652'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.71' WHERE (`spawn_id` = '2515'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.71' WHERE (`spawn_id` = '2515'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '2537'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '2537'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '58.858' WHERE (`spawn_id` = '2561'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '58.858' WHERE (`spawn_id` = '2561'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '15.231' WHERE (`spawn_id` = '2577'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '15.231' WHERE (`spawn_id` = '2577'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '130.707' WHERE (`spawn_id` = '2579'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '130.707' WHERE (`spawn_id` = '2579'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '102.218' WHERE (`spawn_id` = '2592'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '102.218' WHERE (`spawn_id` = '2592'); 
         -- Thornroot XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10371.842', `spawn_positionY` = '-1318.831', `spawn_positionZ` = '52.909' WHERE (`spawn_id` = '2608'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-10371.842', `spawn_positionY` = '-1318.831', `spawn_positionZ` = '52.909' WHERE (`spawn_id` = '2608'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '101.945' WHERE (`spawn_id` = '2612'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '101.945' WHERE (`spawn_id` = '2612'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '150.395' WHERE (`spawn_id` = '2614'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '150.395' WHERE (`spawn_id` = '2614'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-10.439' WHERE (`spawn_id` = '2619'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-10.439' WHERE (`spawn_id` = '2619'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.352' WHERE (`spawn_id` = '2625'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.352' WHERE (`spawn_id` = '2625'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '102.397' WHERE (`spawn_id` = '2628'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '102.397' WHERE (`spawn_id` = '2628'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '32.502' WHERE (`spawn_id` = '2661'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '32.502' WHERE (`spawn_id` = '2661'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '31.331' WHERE (`spawn_id` = '2671'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '31.331' WHERE (`spawn_id` = '2671'); 
         -- Thornroot XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '650.887', `spawn_positionY` = '1382.366', `spawn_positionZ` = '82.77' WHERE (`spawn_id` = '2687'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '650.887', `spawn_positionY` = '1382.366', `spawn_positionZ` = '82.77' WHERE (`spawn_id` = '2687'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '44.492' WHERE (`spawn_id` = '2690'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '44.492' WHERE (`spawn_id` = '2690'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '31.089' WHERE (`spawn_id` = '2706'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '31.089' WHERE (`spawn_id` = '2706'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '42.293' WHERE (`spawn_id` = '2710'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '42.293' WHERE (`spawn_id` = '2710'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '5.749' WHERE (`spawn_id` = '2717'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '5.749' WHERE (`spawn_id` = '2717'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.131' WHERE (`spawn_id` = '2725'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '94.131' WHERE (`spawn_id` = '2725'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '129.152' WHERE (`spawn_id` = '2731'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '129.152' WHERE (`spawn_id` = '2731'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.43' WHERE (`spawn_id` = '2732'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '21.43' WHERE (`spawn_id` = '2732'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '42.477' WHERE (`spawn_id` = '2740'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '42.477' WHERE (`spawn_id` = '2740'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '32.451' WHERE (`spawn_id` = '2806'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '32.451' WHERE (`spawn_id` = '2806'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '98.731' WHERE (`spawn_id` = '2822'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '98.731' WHERE (`spawn_id` = '2822'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '88.464' WHERE (`spawn_id` = '2835'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '88.464' WHERE (`spawn_id` = '2835'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '101.467' WHERE (`spawn_id` = '2868'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '101.467' WHERE (`spawn_id` = '2868'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '55.729' WHERE (`spawn_id` = '2869'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '55.729' WHERE (`spawn_id` = '2869'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.827' WHERE (`spawn_id` = '2899'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '34.827' WHERE (`spawn_id` = '2899'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '49.912' WHERE (`spawn_id` = '2900'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '49.912' WHERE (`spawn_id` = '2900'); 
         -- Bruiseweed ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '2931'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '2931'); 
         -- Bruiseweed ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '2932'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '2932'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '86.101' WHERE (`spawn_id` = '3042'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '86.101' WHERE (`spawn_id` = '3042'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '123.902' WHERE (`spawn_id` = '3078'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '123.902' WHERE (`spawn_id` = '3078'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '46.646' WHERE (`spawn_id` = '3109'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '46.646' WHERE (`spawn_id` = '3109'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '107.369' WHERE (`spawn_id` = '3118'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '107.369' WHERE (`spawn_id` = '3118'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.168' WHERE (`spawn_id` = '3133'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '92.168' WHERE (`spawn_id` = '3133'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.716' WHERE (`spawn_id` = '3138'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '92.716' WHERE (`spawn_id` = '3138'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.39' WHERE (`spawn_id` = '3159'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.39' WHERE (`spawn_id` = '3159'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '53.212' WHERE (`spawn_id` = '3205'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '53.212' WHERE (`spawn_id` = '3205'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '53.15' WHERE (`spawn_id` = '3207'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '53.15' WHERE (`spawn_id` = '3207'); 
         -- Bruiseweed ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '3221'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '3221'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '20.52' WHERE (`spawn_id` = '3260'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '20.52' WHERE (`spawn_id` = '3260'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '53.36' WHERE (`spawn_id` = '3262'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '53.36' WHERE (`spawn_id` = '3262'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '51.686' WHERE (`spawn_id` = '3289'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '51.686' WHERE (`spawn_id` = '3289'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '57.602' WHERE (`spawn_id` = '3329'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '57.602' WHERE (`spawn_id` = '3329'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '117.274' WHERE (`spawn_id` = '3364'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '117.274' WHERE (`spawn_id` = '3364'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '252.407' WHERE (`spawn_id` = '3394'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '252.407' WHERE (`spawn_id` = '3394'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.889' WHERE (`spawn_id` = '3395'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.889' WHERE (`spawn_id` = '3395'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.847' WHERE (`spawn_id` = '3401'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.847' WHERE (`spawn_id` = '3401'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.583' WHERE (`spawn_id` = '3469'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.583' WHERE (`spawn_id` = '3469'); 
         -- Bruiseweed XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2041.671', `spawn_positionY` = '-3208.335', `spawn_positionZ` = '101.091' WHERE (`spawn_id` = '3478'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2041.671', `spawn_positionY` = '-3208.335', `spawn_positionZ` = '101.091' WHERE (`spawn_id` = '3478'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.175' WHERE (`spawn_id` = '3515'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '92.175' WHERE (`spawn_id` = '3515'); 
         -- Bruiseweed XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2587.874', `spawn_positionY` = '-2382.282', `spawn_positionZ` = '79.878' WHERE (`spawn_id` = '3531'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2587.874', `spawn_positionY` = '-2382.282', `spawn_positionZ` = '79.878' WHERE (`spawn_id` = '3531'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.03' WHERE (`spawn_id` = '3538'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '33.03' WHERE (`spawn_id` = '3538'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-55.438' WHERE (`spawn_id` = '3587'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-55.438' WHERE (`spawn_id` = '3587'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '17.642' WHERE (`spawn_id` = '3597'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '17.642' WHERE (`spawn_id` = '3597'); 
 		-- Ruins of Stardust Fountain Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '97.061' WHERE (`spawn_id` = '99862'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '97.061' WHERE (`spawn_id` = '99862'); 
         -- Atal'ai Artifact XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10525.458', `spawn_positionY` = '-3870.514', `spawn_positionZ` = '-17.858' WHERE (`spawn_id` = '30744'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-10525.458', `spawn_positionY` = '-3870.514', `spawn_positionZ` = '-17.858' WHERE (`spawn_id` = '30744'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '113.891' WHERE (`spawn_id` = '3665'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '113.891' WHERE (`spawn_id` = '3665'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.934' WHERE (`spawn_id` = '3692'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '92.934' WHERE (`spawn_id` = '3692'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.548' WHERE (`spawn_id` = '3732'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '6.548' WHERE (`spawn_id` = '3732'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '17.187' WHERE (`spawn_id` = '3739'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '17.187' WHERE (`spawn_id` = '3739'); 
         -- Bruiseweed ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '3741'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '3741'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-37.248' WHERE (`spawn_id` = '3787'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-37.248' WHERE (`spawn_id` = '3787'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '23.175' WHERE (`spawn_id` = '3793'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '23.175' WHERE (`spawn_id` = '3793'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.898' WHERE (`spawn_id` = '3854'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.898' WHERE (`spawn_id` = '3854'); 
         -- Wild Steelbloom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4286.811', `spawn_positionY` = '-2070.202', `spawn_positionZ` = '88.609' WHERE (`spawn_id` = '3923'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4286.811', `spawn_positionY` = '-2070.202', `spawn_positionZ` = '88.609' WHERE (`spawn_id` = '3923'); 
         -- Wild Steelbloom ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '3968'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '3968'); 
         -- Wild Steelbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '98.374' WHERE (`spawn_id` = '3969'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '98.374' WHERE (`spawn_id` = '3969'); 
         -- Wild Steelbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '255.354' WHERE (`spawn_id` = '4005'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '255.354' WHERE (`spawn_id` = '4005'); 
         -- Wild Steelbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '18.871' WHERE (`spawn_id` = '4024'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '18.871' WHERE (`spawn_id` = '4024'); 
         -- Wild Steelbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '253.799' WHERE (`spawn_id` = '4025'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '253.799' WHERE (`spawn_id` = '4025'); 
         -- Wild Steelbloom ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '4045'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '4045'); 
         -- Wild Steelbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-20.385' WHERE (`spawn_id` = '4050'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-20.385' WHERE (`spawn_id` = '4050'); 
         -- Wild Steelbloom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3600.042', `spawn_positionY` = '-1762.24', `spawn_positionZ` = '139.489' WHERE (`spawn_id` = '4065'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-3600.042', `spawn_positionY` = '-1762.24', `spawn_positionZ` = '139.489' WHERE (`spawn_id` = '4065'); 
         -- Wild Steelbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '72.52' WHERE (`spawn_id` = '4090'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '72.52' WHERE (`spawn_id` = '4090'); 
         -- Wild Steelbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.071' WHERE (`spawn_id` = '4095'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '6.071' WHERE (`spawn_id` = '4095'); 
         -- Wild Steelbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '253.317' WHERE (`spawn_id` = '4216'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '253.317' WHERE (`spawn_id` = '4216'); 
         -- Wild Steelbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '95.741' WHERE (`spawn_id` = '4267'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '95.741' WHERE (`spawn_id` = '4267'); 
         -- Wild Steelbloom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2639.203', `spawn_positionY` = '-2318.273', `spawn_positionZ` = '91.608' WHERE (`spawn_id` = '4268'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2639.203', `spawn_positionY` = '-2318.273', `spawn_positionZ` = '91.608' WHERE (`spawn_id` = '4268'); 
         -- Crownroyal Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '56.356' WHERE (`spawn_id` = '4294'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '56.356' WHERE (`spawn_id` = '4294'); 
         -- Crownroyal Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.98' WHERE (`spawn_id` = '4311'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-0.98' WHERE (`spawn_id` = '4311'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.389' WHERE (`spawn_id` = '28518'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.389' WHERE (`spawn_id` = '28518'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.116' WHERE (`spawn_id` = '18909'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '35.116' WHERE (`spawn_id` = '18909'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.625' WHERE (`spawn_id` = '18890'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '36.625' WHERE (`spawn_id` = '18890'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.81' WHERE (`spawn_id` = '18889'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '36.81' WHERE (`spawn_id` = '18889'); 
         -- Thornroot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.744' WHERE (`spawn_id` = '44642'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '36.744' WHERE (`spawn_id` = '44642'); 
         -- Burning Embers Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '40718'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '40718'); 
         -- Warm Fire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '40716'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '40716'); 
         -- Warm Fire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '40715'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '40715'); 
         -- Campfire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '86.9' WHERE (`spawn_id` = '40714'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '86.9' WHERE (`spawn_id` = '40714'); 
         -- Bruiseweed Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '117.836' WHERE (`spawn_id` = '29658'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '117.836' WHERE (`spawn_id` = '29658'); 
         -- Alliance Chest Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.586' WHERE (`spawn_id` = '29650'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '34.586' WHERE (`spawn_id` = '29650'); 
         -- DANGER! Do Not Open! Move Along! Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.99' WHERE (`spawn_id` = '29645'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '182.99' WHERE (`spawn_id` = '29645'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '32.669' WHERE (`spawn_id` = '4652'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '32.669' WHERE (`spawn_id` = '4652'); 
         -- Ironforge Main Gate ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '4691'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '4691'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '4699'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '4699'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '20.049' WHERE (`spawn_id` = '4711'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '20.049' WHERE (`spawn_id` = '4711'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-55.161' WHERE (`spawn_id` = '4728'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-55.161' WHERE (`spawn_id` = '4728'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.822' WHERE (`spawn_id` = '18888'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '36.822' WHERE (`spawn_id` = '18888'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-46.288' WHERE (`spawn_id` = '4762'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-46.288' WHERE (`spawn_id` = '4762'); 
         -- Black Lotus Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '53.845' WHERE (`spawn_id` = '3998089'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '53.845' WHERE (`spawn_id` = '3998089'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '186.07' WHERE (`spawn_id` = '4766'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '186.07' WHERE (`spawn_id` = '4766'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-22.613' WHERE (`spawn_id` = '4768'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-22.613' WHERE (`spawn_id` = '4768'); 
         -- Black Lotus Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.604' WHERE (`spawn_id` = '3998088'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.604' WHERE (`spawn_id` = '3998088'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '29.679' WHERE (`spawn_id` = '4799'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '29.679' WHERE (`spawn_id` = '4799'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '249.881' WHERE (`spawn_id` = '4802'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '249.881' WHERE (`spawn_id` = '4802'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '5.163' WHERE (`spawn_id` = '4807'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '5.163' WHERE (`spawn_id` = '4807'); 
         -- Black Lotus Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.561' WHERE (`spawn_id` = '3998085'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '6.561' WHERE (`spawn_id` = '3998085'); 
         -- Black Lotus Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '7.22' WHERE (`spawn_id` = '3998084'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '7.22' WHERE (`spawn_id` = '3998084'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.841' WHERE (`spawn_id` = '4824'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '26.841' WHERE (`spawn_id` = '4824'); 
         -- Black Lotus Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.976' WHERE (`spawn_id` = '3998081'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '4.976' WHERE (`spawn_id` = '3998081'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '106.417' WHERE (`spawn_id` = '4898'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '106.417' WHERE (`spawn_id` = '4898'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.014' WHERE (`spawn_id` = '4901'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.014' WHERE (`spawn_id` = '4901'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '52.078' WHERE (`spawn_id` = '4936'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '52.078' WHERE (`spawn_id` = '4936'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '4302.084', `spawn_positionY` = '943.749', `spawn_positionZ` = '52.078' WHERE (`spawn_id` = '4936'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '4302.084', `spawn_positionY` = '943.749', `spawn_positionZ` = '52.078' WHERE (`spawn_id` = '4936'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '46.039' WHERE (`spawn_id` = '5031'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '46.039' WHERE (`spawn_id` = '5031'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-13.056' WHERE (`spawn_id` = '5061'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-13.056' WHERE (`spawn_id` = '5061'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '6805.169', `spawn_positionY` = '-679.499', `spawn_positionZ` = '97.658' WHERE (`spawn_id` = '5066'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '6805.169', `spawn_positionY` = '-679.499', `spawn_positionZ` = '97.658' WHERE (`spawn_id` = '5066'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '20.473' WHERE (`spawn_id` = '5361'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '20.473' WHERE (`spawn_id` = '5361'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.049' WHERE (`spawn_id` = '5377'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.049' WHERE (`spawn_id` = '5377'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.399' WHERE (`spawn_id` = '5421'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '94.399' WHERE (`spawn_id` = '5421'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.118' WHERE (`spawn_id` = '5452'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '33.118' WHERE (`spawn_id` = '5452'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '106.626' WHERE (`spawn_id` = '5464'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '106.626' WHERE (`spawn_id` = '5464'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '45.543', `spawn_positionY` = '-1725.294', `spawn_positionZ` = '106.626' WHERE (`spawn_id` = '5464'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '45.543', `spawn_positionY` = '-1725.294', `spawn_positionZ` = '106.626' WHERE (`spawn_id` = '5464'); 
         -- Tin Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8918.297', `spawn_positionY` = '-1945.519', `spawn_positionZ` = '134.216' WHERE (`spawn_id` = '5511'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-8918.297', `spawn_positionY` = '-1945.519', `spawn_positionZ` = '134.216' WHERE (`spawn_id` = '5511'); 
         -- Tin Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-809.262', `spawn_positionY` = '133.229', `spawn_positionZ` = '18.607' WHERE (`spawn_id` = '5514'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-809.262', `spawn_positionY` = '133.229', `spawn_positionZ` = '18.607' WHERE (`spawn_id` = '5514'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.683' WHERE (`spawn_id` = '18887'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '36.683' WHERE (`spawn_id` = '18887'); 
         -- Tin Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '5.703' WHERE (`spawn_id` = '5559'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '5.703' WHERE (`spawn_id` = '5559'); 
         -- Tin Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.018' WHERE (`spawn_id` = '5561'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '38.018' WHERE (`spawn_id` = '5561'); 
         -- Tin Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '46.986' WHERE (`spawn_id` = '5633'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '46.986' WHERE (`spawn_id` = '5633'); 
         -- Tin Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8933.606', `spawn_positionY` = '-1977.563', `spawn_positionZ` = '133.189' WHERE (`spawn_id` = '5675'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-8933.606', `spawn_positionY` = '-1977.563', `spawn_positionZ` = '133.189' WHERE (`spawn_id` = '5675'); 
         -- Silver Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '164.403' WHERE (`spawn_id` = '5725'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '164.403' WHERE (`spawn_id` = '5725'); 
         -- Silver Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '158.827' WHERE (`spawn_id` = '5728'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '158.827' WHERE (`spawn_id` = '5728'); 
         -- Silver Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '18.83' WHERE (`spawn_id` = '5762'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '18.83' WHERE (`spawn_id` = '5762'); 
         -- Gold Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '65.865' WHERE (`spawn_id` = '5770'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '65.865' WHERE (`spawn_id` = '5770'); 
         -- Gold Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.513' WHERE (`spawn_id` = '5773'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.513' WHERE (`spawn_id` = '5773'); 
         -- Gold Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '1240.966', `spawn_positionY` = '-1257.593', `spawn_positionZ` = '43.924' WHERE (`spawn_id` = '5783'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '1240.966', `spawn_positionY` = '-1257.593', `spawn_positionZ` = '43.924' WHERE (`spawn_id` = '5783'); 
         -- Gold Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '5785'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '5785'); 
         -- Gold Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '140.666' WHERE (`spawn_id` = '5801'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '140.666' WHERE (`spawn_id` = '5801'); 
         -- Gold Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '46.276' WHERE (`spawn_id` = '5819'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '46.276' WHERE (`spawn_id` = '5819'); 
         -- Gold Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.676' WHERE (`spawn_id` = '5839'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '38.676' WHERE (`spawn_id` = '5839'); 
         -- Gold Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '73.703' WHERE (`spawn_id` = '5859'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '73.703' WHERE (`spawn_id` = '5859'); 
         -- Gold Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '50.96' WHERE (`spawn_id` = '5861'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '50.96' WHERE (`spawn_id` = '5861'); 
         -- Gold Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '1241.67', `spawn_positionY` = '-1272.324', `spawn_positionZ` = '43.074' WHERE (`spawn_id` = '5863'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '1241.67', `spawn_positionY` = '-1272.324', `spawn_positionZ` = '43.074' WHERE (`spawn_id` = '5863'); 
         -- Gold Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.716' WHERE (`spawn_id` = '5914'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '14.716' WHERE (`spawn_id` = '5914'); 
         -- Gold Vein ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '5959'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '5959'); 
         -- Gold Vein ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '5960'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '5960'); 
         -- Gold Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '5983'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '5983'); 
         -- Gold Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10969.125', `spawn_positionY` = '-3695.028', `spawn_positionZ` = '17.251' WHERE (`spawn_id` = '5995'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-10969.125', `spawn_positionY` = '-3695.028', `spawn_positionZ` = '17.251' WHERE (`spawn_id` = '5995'); 
         -- Gold Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '70.886' WHERE (`spawn_id` = '6000'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '70.886' WHERE (`spawn_id` = '6000'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.834' WHERE (`spawn_id` = '6002'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '10.834' WHERE (`spawn_id` = '6002'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '138.23' WHERE (`spawn_id` = '6019'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '138.23' WHERE (`spawn_id` = '6019'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '116.027' WHERE (`spawn_id` = '6061'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '116.027' WHERE (`spawn_id` = '6061'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '367.703' WHERE (`spawn_id` = '6076'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '367.703' WHERE (`spawn_id` = '6076'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '25.39' WHERE (`spawn_id` = '6107'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '25.39' WHERE (`spawn_id` = '6107'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '90.278' WHERE (`spawn_id` = '6127'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '90.278' WHERE (`spawn_id` = '6127'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '12.037' WHERE (`spawn_id` = '6128'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '12.037' WHERE (`spawn_id` = '6128'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '12.387' WHERE (`spawn_id` = '6147'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '12.387' WHERE (`spawn_id` = '6147'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-42.434' WHERE (`spawn_id` = '6155'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-42.434' WHERE (`spawn_id` = '6155'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-48.643' WHERE (`spawn_id` = '6157'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-48.643' WHERE (`spawn_id` = '6157'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '58.518' WHERE (`spawn_id` = '6197'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '58.518' WHERE (`spawn_id` = '6197'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5121.117', `spawn_positionY` = '1795.439', `spawn_positionZ` = '50.692' WHERE (`spawn_id` = '6199'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-5121.117', `spawn_positionY` = '1795.439', `spawn_positionZ` = '50.692' WHERE (`spawn_id` = '6199'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1452.101', `spawn_positionY` = '2943.731', `spawn_positionZ` = '136.712' WHERE (`spawn_id` = '6210'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1452.101', `spawn_positionY` = '2943.731', `spawn_positionZ` = '136.712' WHERE (`spawn_id` = '6210'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '144.217' WHERE (`spawn_id` = '6220'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '144.217' WHERE (`spawn_id` = '6220'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '6229'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '6229'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '131.359' WHERE (`spawn_id` = '6241'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '131.359' WHERE (`spawn_id` = '6241'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '113.478' WHERE (`spawn_id` = '6242'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '113.478' WHERE (`spawn_id` = '6242'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '176.463' WHERE (`spawn_id` = '6249'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '176.463' WHERE (`spawn_id` = '6249'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '6250'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '6250'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.387' WHERE (`spawn_id` = '6252'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '26.387' WHERE (`spawn_id` = '6252'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.092' WHERE (`spawn_id` = '6288'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '26.092' WHERE (`spawn_id` = '6288'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '79.7' WHERE (`spawn_id` = '6298'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '79.7' WHERE (`spawn_id` = '6298'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '68.58' WHERE (`spawn_id` = '6304'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '68.58' WHERE (`spawn_id` = '6304'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-58.749' WHERE (`spawn_id` = '6322'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-58.749' WHERE (`spawn_id` = '6322'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '178.669' WHERE (`spawn_id` = '6349'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '178.669' WHERE (`spawn_id` = '6349'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '101.954' WHERE (`spawn_id` = '6366'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '101.954' WHERE (`spawn_id` = '6366'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '90.481' WHERE (`spawn_id` = '6372'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '90.481' WHERE (`spawn_id` = '6372'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '87.957' WHERE (`spawn_id` = '6373'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '87.957' WHERE (`spawn_id` = '6373'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4992.803', `spawn_positionY` = '-2291.727', `spawn_positionZ` = '-61.709' WHERE (`spawn_id` = '6378'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4992.803', `spawn_positionY` = '-2291.727', `spawn_positionZ` = '-61.709' WHERE (`spawn_id` = '6378'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-814.5', `spawn_positionY` = '-3883.0', `spawn_positionZ` = '180.319' WHERE (`spawn_id` = '6414'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-814.5', `spawn_positionY` = '-3883.0', `spawn_positionZ` = '180.319' WHERE (`spawn_id` = '6414'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6643.518', `spawn_positionY` = '-3714.351', `spawn_positionZ` = '278.994' WHERE (`spawn_id` = '6449'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-6643.518', `spawn_positionY` = '-3714.351', `spawn_positionZ` = '278.994' WHERE (`spawn_id` = '6449'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '40.434' WHERE (`spawn_id` = '14954'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '40.434' WHERE (`spawn_id` = '14954'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '24.255' WHERE (`spawn_id` = '6485'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '24.255' WHERE (`spawn_id` = '6485'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10954.143', `spawn_positionY` = '-3706.594', `spawn_positionZ` = '18.849' WHERE (`spawn_id` = '6492'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-10954.143', `spawn_positionY` = '-3706.594', `spawn_positionZ` = '18.849' WHERE (`spawn_id` = '6492'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5099.394', `spawn_positionY` = '1781.258', `spawn_positionZ` = '51.33' WHERE (`spawn_id` = '6495'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-5099.394', `spawn_positionY` = '1781.258', `spawn_positionZ` = '51.33' WHERE (`spawn_id` = '6495'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '40.564' WHERE (`spawn_id` = '14953'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '40.564' WHERE (`spawn_id` = '14953'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6467.737', `spawn_positionY` = '-2480.182', `spawn_positionZ` = '326.823' WHERE (`spawn_id` = '6503'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-6467.737', `spawn_positionY` = '-2480.182', `spawn_positionZ` = '326.823' WHERE (`spawn_id` = '6503'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '40.467' WHERE (`spawn_id` = '14952'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '40.467' WHERE (`spawn_id` = '14952'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-13134.521', `spawn_positionY` = '-481.502', `spawn_positionZ` = '4.085' WHERE (`spawn_id` = '6521'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-13134.521', `spawn_positionY` = '-481.502', `spawn_positionZ` = '4.085' WHERE (`spawn_id` = '6521'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '40.3' WHERE (`spawn_id` = '14951'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '40.3' WHERE (`spawn_id` = '14951'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.921' WHERE (`spawn_id` = '14950'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '34.921' WHERE (`spawn_id` = '14950'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '90.485' WHERE (`spawn_id` = '6551'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '90.485' WHERE (`spawn_id` = '6551'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-7310.229', `spawn_positionY` = '-1956.119', `spawn_positionZ` = '308.881' WHERE (`spawn_id` = '6556'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-7310.229', `spawn_positionY` = '-1956.119', `spawn_positionZ` = '308.881' WHERE (`spawn_id` = '6556'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.005' WHERE (`spawn_id` = '14949'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '38.005' WHERE (`spawn_id` = '14949'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.002' WHERE (`spawn_id` = '14948'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '38.002' WHERE (`spawn_id` = '14948'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4982.301', `spawn_positionY` = '-2316.412', `spawn_positionZ` = '-56.926' WHERE (`spawn_id` = '6560'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4982.301', `spawn_positionY` = '-2316.412', `spawn_positionZ` = '-56.926' WHERE (`spawn_id` = '6560'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5016.368', `spawn_positionY` = '1794.606', `spawn_positionZ` = '65.902' WHERE (`spawn_id` = '6577'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-5016.368', `spawn_positionY` = '1794.606', `spawn_positionZ` = '65.902' WHERE (`spawn_id` = '6577'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.329' WHERE (`spawn_id` = '6587'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '61.329' WHERE (`spawn_id` = '6587'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5046.849', `spawn_positionY` = '1792.557', `spawn_positionZ` = '57.756' WHERE (`spawn_id` = '6588'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-5046.849', `spawn_positionY` = '1792.557', `spawn_positionZ` = '57.756' WHERE (`spawn_id` = '6588'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.695' WHERE (`spawn_id` = '6592'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.695' WHERE (`spawn_id` = '6592'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.181' WHERE (`spawn_id` = '14947'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '38.181' WHERE (`spawn_id` = '14947'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.168' WHERE (`spawn_id` = '14946'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '38.168' WHERE (`spawn_id` = '14946'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-884.0', `spawn_positionY` = '-3912.0', `spawn_positionZ` = '147.56' WHERE (`spawn_id` = '6614'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-884.0', `spawn_positionY` = '-3912.0', `spawn_positionZ` = '147.56' WHERE (`spawn_id` = '6614'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.677' WHERE (`spawn_id` = '6624'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '14.677' WHERE (`spawn_id` = '6624'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4944.349', `spawn_positionY` = '-2341.905', `spawn_positionZ` = '-57.6' WHERE (`spawn_id` = '6625'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4944.349', `spawn_positionY` = '-2341.905', `spawn_positionZ` = '-57.6' WHERE (`spawn_id` = '6625'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2975.015', `spawn_positionY` = '-3154.677', `spawn_positionZ` = '52.554' WHERE (`spawn_id` = '6639'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2975.015', `spawn_positionY` = '-3154.677', `spawn_positionZ` = '52.554' WHERE (`spawn_id` = '6639'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '15.414' WHERE (`spawn_id` = '6645'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '15.414' WHERE (`spawn_id` = '6645'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2024.515', `spawn_positionY` = '-3336.165', `spawn_positionZ` = '49.725' WHERE (`spawn_id` = '6651'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2024.515', `spawn_positionY` = '-3336.165', `spawn_positionZ` = '49.725' WHERE (`spawn_id` = '6651'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '86.288' WHERE (`spawn_id` = '6661'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '86.288' WHERE (`spawn_id` = '6661'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '90.169' WHERE (`spawn_id` = '6668'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '90.169' WHERE (`spawn_id` = '6668'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '6676'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '6676'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.112' WHERE (`spawn_id` = '6678'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '94.112' WHERE (`spawn_id` = '6678'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.206' WHERE (`spawn_id` = '6704'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '14.206' WHERE (`spawn_id` = '6704'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4937.387', `spawn_positionY` = '-2349.707', `spawn_positionZ` = '-48.827' WHERE (`spawn_id` = '6718'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4937.387', `spawn_positionY` = '-2349.707', `spawn_positionZ` = '-48.827' WHERE (`spawn_id` = '6718'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2038.625', `spawn_positionY` = '-3371.98', `spawn_positionZ` = '46.037' WHERE (`spawn_id` = '6729'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2038.625', `spawn_positionY` = '-3371.98', `spawn_positionZ` = '46.037' WHERE (`spawn_id` = '6729'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.511' WHERE (`spawn_id` = '6737'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.511' WHERE (`spawn_id` = '6737'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '29.002' WHERE (`spawn_id` = '6740'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '29.002' WHERE (`spawn_id` = '6740'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '146.556' WHERE (`spawn_id` = '6744'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '146.556' WHERE (`spawn_id` = '6744'); 
         -- TEMP Nearby Tubers Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '82.474' WHERE (`spawn_id` = '99868'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '82.474' WHERE (`spawn_id` = '99868'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-7829.0', `spawn_positionY` = '-5004.78', `spawn_positionZ` = '23.592' WHERE (`spawn_id` = '6751'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-7829.0', `spawn_positionY` = '-5004.78', `spawn_positionZ` = '23.592' WHERE (`spawn_id` = '6751'); 
         -- Open To Pass Your Rite. Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '183.149' WHERE (`spawn_id` = '29644'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '183.149' WHERE (`spawn_id` = '29644'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.493' WHERE (`spawn_id` = '34172'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '6.493' WHERE (`spawn_id` = '34172'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.676' WHERE (`spawn_id` = '34164'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.676' WHERE (`spawn_id` = '34164'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '34163'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '34163'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '34162'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '34162'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.319' WHERE (`spawn_id` = '34161'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '94.319' WHERE (`spawn_id` = '34161'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.019' WHERE (`spawn_id` = '34150'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '94.019' WHERE (`spawn_id` = '34150'); 
         -- Atal'ai Artifact Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-75.333' WHERE (`spawn_id` = '30559'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-75.333' WHERE (`spawn_id` = '30559'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '34077'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '34077'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '33911'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '33911'); 
         -- Dwarven Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '6836'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '6836'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '6839'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '6839'); 
         -- Tin Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-811.035', `spawn_positionY` = '155.677', `spawn_positionZ` = '2.727' WHERE (`spawn_id` = '21273'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-811.035', `spawn_positionY` = '155.677', `spawn_positionZ` = '2.727' WHERE (`spawn_id` = '21273'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '64.457' WHERE (`spawn_id` = '33555'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '64.457' WHERE (`spawn_id` = '33555'); 
         -- Dwarven Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '6872'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '6872'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '6874'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '6874'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '9.839' WHERE (`spawn_id` = '35551'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '9.839' WHERE (`spawn_id` = '35551'); 
         -- Tin Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-814.012', `spawn_positionY` = '164.024', `spawn_positionZ` = '0.648' WHERE (`spawn_id` = '21259'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-814.012', `spawn_positionY` = '164.024', `spawn_positionZ` = '0.648' WHERE (`spawn_id` = '21259'); 
         -- Tammra Gaea Sapling Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '33531'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '33531'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-28.823' WHERE (`spawn_id` = '21249'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-28.823' WHERE (`spawn_id` = '21249'); 
         -- Atal'ai Artifact Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '16.693' WHERE (`spawn_id` = '30383'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '16.693' WHERE (`spawn_id` = '30383'); 
         -- Campfire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '64.457' WHERE (`spawn_id` = '32863'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '64.457' WHERE (`spawn_id` = '32863'); 
         -- Atal'ai Artifact Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-25.613' WHERE (`spawn_id` = '30378'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-25.613' WHERE (`spawn_id` = '30378'); 
         -- Anvil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '32669'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '32669'); 
         -- Anvil ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '32667'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '32667'); 
         -- Meat Smoker ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '32659'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '32659'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '47.605' WHERE (`spawn_id` = '14930'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '47.605' WHERE (`spawn_id` = '14930'); 
         -- Campfire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '186.07' WHERE (`spawn_id` = '32654'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '186.07' WHERE (`spawn_id` = '32654'); 
         -- Tear of Theradras XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2351.913', `spawn_positionY` = '2413.787', `spawn_positionZ` = '61.14' WHERE (`spawn_id` = '32647'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2351.913', `spawn_positionY` = '2413.787', `spawn_positionZ` = '61.14' WHERE (`spawn_id` = '32647'); 
         -- Tear of Theradras XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2347.225', `spawn_positionY` = '2413.241', `spawn_positionZ` = '62.401' WHERE (`spawn_id` = '32647'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2347.225', `spawn_positionY` = '2413.241', `spawn_positionZ` = '62.401' WHERE (`spawn_id` = '32647'); 
         -- Tear of Theradras XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2399.662', `spawn_positionY` = '2420.426', `spawn_positionZ` = '58.416' WHERE (`spawn_id` = '32604'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2399.662', `spawn_positionY` = '2420.426', `spawn_positionZ` = '58.416' WHERE (`spawn_id` = '32604'); 
         -- Alliance Chest Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '54.189' WHERE (`spawn_id` = '20885'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '54.189' WHERE (`spawn_id` = '20885'); 
         -- Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '119.487' WHERE (`spawn_id` = '7070'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '119.487' WHERE (`spawn_id` = '7070'); 
         -- Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.102' WHERE (`spawn_id` = '7141'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '10.102' WHERE (`spawn_id` = '7141'); 
         -- Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '79.674' WHERE (`spawn_id` = '7146'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '79.674' WHERE (`spawn_id` = '7146'); 
         -- Mithril Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2067.0', `spawn_positionY` = '-3350.525', `spawn_positionZ` = '40.86' WHERE (`spawn_id` = '7177'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2067.0', `spawn_positionY` = '-3350.525', `spawn_positionZ` = '40.86' WHERE (`spawn_id` = '7177'); 
         -- Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '7.082' WHERE (`spawn_id` = '7199'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '7.082' WHERE (`spawn_id` = '7199'); 
         -- Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '90.748' WHERE (`spawn_id` = '7302'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '90.748' WHERE (`spawn_id` = '7302'); 
         -- Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '115.395' WHERE (`spawn_id` = '7315'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '115.395' WHERE (`spawn_id` = '7315'); 
         -- Liferoot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '13.363' WHERE (`spawn_id` = '7335'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '13.363' WHERE (`spawn_id` = '7335'); 
         -- Liferoot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '124.15' WHERE (`spawn_id` = '7538'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '124.15' WHERE (`spawn_id` = '7538'); 
         -- Liferoot Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.062' WHERE (`spawn_id` = '7545'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.062' WHERE (`spawn_id` = '7545'); 
         -- Fadeleaf Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '121.3' WHERE (`spawn_id` = '7577'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '121.3' WHERE (`spawn_id` = '7577'); 
         -- Fadeleaf Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '117.919' WHERE (`spawn_id` = '7579'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '117.919' WHERE (`spawn_id` = '7579'); 
         -- Fadeleaf Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '118.866' WHERE (`spawn_id` = '7660'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '118.866' WHERE (`spawn_id` = '7660'); 
         -- Khadgar's Whisker Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.715' WHERE (`spawn_id` = '14613'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '38.715' WHERE (`spawn_id` = '14613'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.405' WHERE (`spawn_id` = '14604'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '35.405' WHERE (`spawn_id` = '14604'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.006' WHERE (`spawn_id` = '13672'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '35.006' WHERE (`spawn_id` = '13672'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.853' WHERE (`spawn_id` = '13671'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '34.853' WHERE (`spawn_id` = '13671'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.834' WHERE (`spawn_id` = '13670'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '34.834' WHERE (`spawn_id` = '13670'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '12.188' WHERE (`spawn_id` = '13669'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '12.188' WHERE (`spawn_id` = '13669'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.248' WHERE (`spawn_id` = '13657'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '35.248' WHERE (`spawn_id` = '13657'); 
         -- Egg of Onyxia Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.207' WHERE (`spawn_id` = '13656'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '35.207' WHERE (`spawn_id` = '13656'); 
         -- Khadgar's Whisker Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '120.349' WHERE (`spawn_id` = '7935'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '120.349' WHERE (`spawn_id` = '7935'); 
         -- Khadgar's Whisker Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '15.518' WHERE (`spawn_id` = '7963'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '15.518' WHERE (`spawn_id` = '7963'); 
         -- Khadgar's Whisker Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.441' WHERE (`spawn_id` = '7966'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '6.441' WHERE (`spawn_id` = '7966'); 
         -- Khadgar's Whisker Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.142' WHERE (`spawn_id` = '8047'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.142' WHERE (`spawn_id` = '8047'); 
         -- Khadgar's Whisker Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '122.04' WHERE (`spawn_id` = '8119'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '122.04' WHERE (`spawn_id` = '8119'); 
         -- Khadgar's Whisker Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.448' WHERE (`spawn_id` = '8163'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '6.448' WHERE (`spawn_id` = '8163'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.824' WHERE (`spawn_id` = '8224'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-0.824' WHERE (`spawn_id` = '8224'); 
         -- Stranglekelp ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8234'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8234'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.635' WHERE (`spawn_id` = '8235'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.635' WHERE (`spawn_id` = '8235'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.678' WHERE (`spawn_id` = '8237'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.678' WHERE (`spawn_id` = '8237'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.618' WHERE (`spawn_id` = '8238'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.618' WHERE (`spawn_id` = '8238'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.333' WHERE (`spawn_id` = '8243'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '6.333' WHERE (`spawn_id` = '8243'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.599' WHERE (`spawn_id` = '8248'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.599' WHERE (`spawn_id` = '8248'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.302' WHERE (`spawn_id` = '8250'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '0.302' WHERE (`spawn_id` = '8250'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.56' WHERE (`spawn_id` = '8259'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.56' WHERE (`spawn_id` = '8259'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.528' WHERE (`spawn_id` = '8261'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.528' WHERE (`spawn_id` = '8261'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.147' WHERE (`spawn_id` = '8262'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '4.147' WHERE (`spawn_id` = '8262'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.808' WHERE (`spawn_id` = '8263'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '0.808' WHERE (`spawn_id` = '8263'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.844' WHERE (`spawn_id` = '8264'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '0.844' WHERE (`spawn_id` = '8264'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.659' WHERE (`spawn_id` = '8266'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.659' WHERE (`spawn_id` = '8266'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.637' WHERE (`spawn_id` = '8267'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.637' WHERE (`spawn_id` = '8267'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.459' WHERE (`spawn_id` = '8268'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-0.459' WHERE (`spawn_id` = '8268'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-3.279' WHERE (`spawn_id` = '8272'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-3.279' WHERE (`spawn_id` = '8272'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.555' WHERE (`spawn_id` = '8298'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.555' WHERE (`spawn_id` = '8298'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.091' WHERE (`spawn_id` = '8299'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.091' WHERE (`spawn_id` = '8299'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.231' WHERE (`spawn_id` = '8304'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.231' WHERE (`spawn_id` = '8304'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.386' WHERE (`spawn_id` = '8308'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.386' WHERE (`spawn_id` = '8308'); 
         -- Stranglekelp ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8311'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8311'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.147' WHERE (`spawn_id` = '8316'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.147' WHERE (`spawn_id` = '8316'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.556' WHERE (`spawn_id` = '8318'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.556' WHERE (`spawn_id` = '8318'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.972' WHERE (`spawn_id` = '8319'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.972' WHERE (`spawn_id` = '8319'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.729' WHERE (`spawn_id` = '8330'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.729' WHERE (`spawn_id` = '8330'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.64' WHERE (`spawn_id` = '8331'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.64' WHERE (`spawn_id` = '8331'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.574' WHERE (`spawn_id` = '8337'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.574' WHERE (`spawn_id` = '8337'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-2.104' WHERE (`spawn_id` = '8339'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-2.104' WHERE (`spawn_id` = '8339'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-4.136' WHERE (`spawn_id` = '8340'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-4.136' WHERE (`spawn_id` = '8340'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.625' WHERE (`spawn_id` = '8369'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.625' WHERE (`spawn_id` = '8369'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.859' WHERE (`spawn_id` = '8385'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.859' WHERE (`spawn_id` = '8385'); 
         -- Fadeleaf Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '39.598' WHERE (`spawn_id` = '13641'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '39.598' WHERE (`spawn_id` = '13641'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.527' WHERE (`spawn_id` = '8404'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.527' WHERE (`spawn_id` = '8404'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.857' WHERE (`spawn_id` = '8406'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.857' WHERE (`spawn_id` = '8406'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.681' WHERE (`spawn_id` = '8411'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-0.681' WHERE (`spawn_id` = '8411'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.039' WHERE (`spawn_id` = '8428'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.039' WHERE (`spawn_id` = '8428'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.188' WHERE (`spawn_id` = '8442'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.188' WHERE (`spawn_id` = '8442'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-4.566' WHERE (`spawn_id` = '8447'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-4.566' WHERE (`spawn_id` = '8447'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.087' WHERE (`spawn_id` = '8454'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-0.087' WHERE (`spawn_id` = '8454'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.651' WHERE (`spawn_id` = '8457'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.651' WHERE (`spawn_id` = '8457'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-2.548' WHERE (`spawn_id` = '8468'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-2.548' WHERE (`spawn_id` = '8468'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.568' WHERE (`spawn_id` = '8501'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.568' WHERE (`spawn_id` = '8501'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '12.563' WHERE (`spawn_id` = '8508'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '12.563' WHERE (`spawn_id` = '8508'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.412' WHERE (`spawn_id` = '8509'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.412' WHERE (`spawn_id` = '8509'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.821' WHERE (`spawn_id` = '8534'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.821' WHERE (`spawn_id` = '8534'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.648' WHERE (`spawn_id` = '8535'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.648' WHERE (`spawn_id` = '8535'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.676' WHERE (`spawn_id` = '8536'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.676' WHERE (`spawn_id` = '8536'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.523' WHERE (`spawn_id` = '8537'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.523' WHERE (`spawn_id` = '8537'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.24' WHERE (`spawn_id` = '8538'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.24' WHERE (`spawn_id` = '8538'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.432' WHERE (`spawn_id` = '8540'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.432' WHERE (`spawn_id` = '8540'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.697' WHERE (`spawn_id` = '8542'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.697' WHERE (`spawn_id` = '8542'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.701' WHERE (`spawn_id` = '8543'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.701' WHERE (`spawn_id` = '8543'); 
         -- Stranglekelp XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '2136.485', `spawn_positionY` = '-313.482', `spawn_positionZ` = '91.118' WHERE (`spawn_id` = '8545'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '2136.485', `spawn_positionY` = '-313.482', `spawn_positionZ` = '91.118' WHERE (`spawn_id` = '8545'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.441' WHERE (`spawn_id` = '8549'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '0.441' WHERE (`spawn_id` = '8549'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.754' WHERE (`spawn_id` = '8550'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.754' WHERE (`spawn_id` = '8550'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.58' WHERE (`spawn_id` = '8556'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '0.58' WHERE (`spawn_id` = '8556'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.598' WHERE (`spawn_id` = '8557'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.598' WHERE (`spawn_id` = '8557'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.075' WHERE (`spawn_id` = '8559'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.075' WHERE (`spawn_id` = '8559'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.398' WHERE (`spawn_id` = '8564'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '2.398' WHERE (`spawn_id` = '8564'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.636' WHERE (`spawn_id` = '8566'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.636' WHERE (`spawn_id` = '8566'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.621' WHERE (`spawn_id` = '8567'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '0.621' WHERE (`spawn_id` = '8567'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.003' WHERE (`spawn_id` = '8575'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.003' WHERE (`spawn_id` = '8575'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.088' WHERE (`spawn_id` = '8576'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.088' WHERE (`spawn_id` = '8576'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.732' WHERE (`spawn_id` = '8577'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '0.732' WHERE (`spawn_id` = '8577'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-2.278' WHERE (`spawn_id` = '8578'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-2.278' WHERE (`spawn_id` = '8578'); 
         -- Stranglekelp Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-12.684' WHERE (`spawn_id` = '8589'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-12.684' WHERE (`spawn_id` = '8589'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '27.452' WHERE (`spawn_id` = '8608'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '27.452' WHERE (`spawn_id` = '8608'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.832' WHERE (`spawn_id` = '8699'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '94.832' WHERE (`spawn_id` = '8699'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '118.894' WHERE (`spawn_id` = '8700'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '118.894' WHERE (`spawn_id` = '8700'); 
         -- Goldthorn XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '40.752', `spawn_positionY` = '-3667.576', `spawn_positionZ` = '121.721' WHERE (`spawn_id` = '8701'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '40.752', `spawn_positionY` = '-3667.576', `spawn_positionZ` = '121.721' WHERE (`spawn_id` = '8701'); 
         -- Crownroyal Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.379' WHERE (`spawn_id` = '12566'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '33.379' WHERE (`spawn_id` = '12566'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.936' WHERE (`spawn_id` = '8712'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.936' WHERE (`spawn_id` = '8712'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '32.887' WHERE (`spawn_id` = '11764'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '32.887' WHERE (`spawn_id` = '11764'); 
         -- Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '39.014' WHERE (`spawn_id` = '11762'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '39.014' WHERE (`spawn_id` = '11762'); 
         -- Khadgar's Whisker Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.589' WHERE (`spawn_id` = '11760'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '35.589' WHERE (`spawn_id` = '11760'); 
         -- Crownroyal Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '39.065' WHERE (`spawn_id` = '11756'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '39.065' WHERE (`spawn_id` = '11756'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '125.236' WHERE (`spawn_id` = '8868'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '125.236' WHERE (`spawn_id` = '8868'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '7.189' WHERE (`spawn_id` = '8889'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '7.189' WHERE (`spawn_id` = '8889'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-6.0' WHERE (`spawn_id` = '8904'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-6.0' WHERE (`spawn_id` = '8904'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.855' WHERE (`spawn_id` = '8906'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.855' WHERE (`spawn_id` = '8906'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '22.051' WHERE (`spawn_id` = '8913'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '22.051' WHERE (`spawn_id` = '8913'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-3.555' WHERE (`spawn_id` = '8948'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-3.555' WHERE (`spawn_id` = '8948'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.688' WHERE (`spawn_id` = '8959'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '21.688' WHERE (`spawn_id` = '8959'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.583' WHERE (`spawn_id` = '9005'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '4.583' WHERE (`spawn_id` = '9005'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-4.526' WHERE (`spawn_id` = '9013'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-4.526' WHERE (`spawn_id` = '9013'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '131.264' WHERE (`spawn_id` = '9039'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '131.264' WHERE (`spawn_id` = '9039'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '126.952' WHERE (`spawn_id` = '9053'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '126.952' WHERE (`spawn_id` = '9053'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '85.357' WHERE (`spawn_id` = '9092'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '85.357' WHERE (`spawn_id` = '9092'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '76.245' WHERE (`spawn_id` = '9201'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '76.245' WHERE (`spawn_id` = '9201'); 
         -- Goldthorn Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '81.763' WHERE (`spawn_id` = '9202'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '81.763' WHERE (`spawn_id` = '9202'); 
         -- Goldthorn XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '42.254', `spawn_positionY` = '-3664.0', `spawn_positionZ` = '120.138' WHERE (`spawn_id` = '9210'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '42.254', `spawn_positionY` = '-3664.0', `spawn_positionZ` = '120.138' WHERE (`spawn_id` = '9210'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '674.997' WHERE (`spawn_id` = '9232'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '674.997' WHERE (`spawn_id` = '9232'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.173' WHERE (`spawn_id` = '9237'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '26.173' WHERE (`spawn_id` = '9237'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '126.016' WHERE (`spawn_id` = '9246'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '126.016' WHERE (`spawn_id` = '9246'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.038' WHERE (`spawn_id` = '9266'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '33.038' WHERE (`spawn_id` = '9266'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '81.28' WHERE (`spawn_id` = '9271'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '81.28' WHERE (`spawn_id` = '9271'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-258.168' WHERE (`spawn_id` = '9275'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-258.168' WHERE (`spawn_id` = '9275'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '28.341' WHERE (`spawn_id` = '9345'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '28.341' WHERE (`spawn_id` = '9345'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '19.938' WHERE (`spawn_id` = '9347'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '19.938' WHERE (`spawn_id` = '9347'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-205.408', `spawn_positionY` = '-383.035', `spawn_positionZ` = '65.956' WHERE (`spawn_id` = '9350'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-205.408', `spawn_positionY` = '-383.035', `spawn_positionZ` = '65.956' WHERE (`spawn_id` = '9350'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '124.173' WHERE (`spawn_id` = '9364'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '124.173' WHERE (`spawn_id` = '9364'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.262' WHERE (`spawn_id` = '9390'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '14.262' WHERE (`spawn_id` = '9390'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '134.366' WHERE (`spawn_id` = '9397'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '134.366' WHERE (`spawn_id` = '9397'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '811.161' WHERE (`spawn_id` = '9398'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '811.161' WHERE (`spawn_id` = '9398'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-729.052', `spawn_positionY` = '-3695.72', `spawn_positionZ` = '195.584' WHERE (`spawn_id` = '9401'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-729.052', `spawn_positionY` = '-3695.72', `spawn_positionZ` = '195.584' WHERE (`spawn_id` = '9401'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-722.33', `spawn_positionY` = '-3692.587', `spawn_positionZ` = '196.207' WHERE (`spawn_id` = '9402'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-722.33', `spawn_positionY` = '-3692.587', `spawn_positionZ` = '196.207' WHERE (`spawn_id` = '9402'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '1334.458', `spawn_positionY` = '-1681.675', `spawn_positionZ` = '73.51' WHERE (`spawn_id` = '9403'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '1334.458', `spawn_positionY` = '-1681.675', `spawn_positionZ` = '73.51' WHERE (`spawn_id` = '9403'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '116.679' WHERE (`spawn_id` = '9418'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '116.679' WHERE (`spawn_id` = '9418'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-277.437', `spawn_positionY` = '-380.104', `spawn_positionZ` = '68.806' WHERE (`spawn_id` = '9420'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-277.437', `spawn_positionY` = '-380.104', `spawn_positionZ` = '68.806' WHERE (`spawn_id` = '9420'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '688.414' WHERE (`spawn_id` = '9423'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '688.414' WHERE (`spawn_id` = '9423'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2007.75', `spawn_positionY` = '-3290.647', `spawn_positionZ` = '59.618' WHERE (`spawn_id` = '9438'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2007.75', `spawn_positionY` = '-3290.647', `spawn_positionZ` = '59.618' WHERE (`spawn_id` = '9438'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '688.414' WHERE (`spawn_id` = '9445'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '688.414' WHERE (`spawn_id` = '9445'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '44.259' WHERE (`spawn_id` = '9446'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '44.259' WHERE (`spawn_id` = '9446'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.005' WHERE (`spawn_id` = '9455'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '2.005' WHERE (`spawn_id` = '9455'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.222' WHERE (`spawn_id` = '9455'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.222' WHERE (`spawn_id` = '9455'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-11158.411', `spawn_positionY` = '-1167.057', `spawn_positionZ` = '42.353' WHERE (`spawn_id` = '9457'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-11158.411', `spawn_positionY` = '-1167.057', `spawn_positionZ` = '42.353' WHERE (`spawn_id` = '9457'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '39.272' WHERE (`spawn_id` = '9468'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '39.272' WHERE (`spawn_id` = '9468'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5618.776', `spawn_positionY` = '3443.809', `spawn_positionZ` = '49.705' WHERE (`spawn_id` = '9481'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-5618.776', `spawn_positionY` = '3443.809', `spawn_positionZ` = '49.705' WHERE (`spawn_id` = '9481'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-209.05', `spawn_positionY` = '-384.295', `spawn_positionZ` = '65.214' WHERE (`spawn_id` = '9523'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-209.05', `spawn_positionY` = '-384.295', `spawn_positionZ` = '65.214' WHERE (`spawn_id` = '9523'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '118.97' WHERE (`spawn_id` = '9575'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '118.97' WHERE (`spawn_id` = '9575'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.382' WHERE (`spawn_id` = '9587'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.382' WHERE (`spawn_id` = '9587'); 
         -- Iron Deposit ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '9592'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '9592'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-672.413', `spawn_positionY` = '-3772.663', `spawn_positionZ` = '216.557' WHERE (`spawn_id` = '9605'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-672.413', `spawn_positionY` = '-3772.663', `spawn_positionZ` = '216.557' WHERE (`spawn_id` = '9605'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.964' WHERE (`spawn_id` = '9622'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.964' WHERE (`spawn_id` = '9622'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5640.168', `spawn_positionY` = '3531.055', `spawn_positionZ` = '44.682' WHERE (`spawn_id` = '9623'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-5640.168', `spawn_positionY` = '3531.055', `spawn_positionZ` = '44.682' WHERE (`spawn_id` = '9623'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '43.766' WHERE (`spawn_id` = '9623'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '43.766' WHERE (`spawn_id` = '9623'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '240.768' WHERE (`spawn_id` = '9633'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '240.768' WHERE (`spawn_id` = '9633'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-248.233', `spawn_positionY` = '-400.591', `spawn_positionZ` = '67.74' WHERE (`spawn_id` = '9636'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-248.233', `spawn_positionY` = '-400.591', `spawn_positionZ` = '67.74' WHERE (`spawn_id` = '9636'); 
         -- Tear of Theradras XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2358.7', `spawn_positionY` = '2502.176', `spawn_positionZ` = '75.21' WHERE (`spawn_id` = '32601'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2358.7', `spawn_positionY` = '2502.176', `spawn_positionZ` = '75.21' WHERE (`spawn_id` = '32601'); 
         -- Tear of Theradras XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2335.491', `spawn_positionY` = '2472.6', `spawn_positionZ` = '76.172' WHERE (`spawn_id` = '32600'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2335.491', `spawn_positionY` = '2472.6', `spawn_positionZ` = '76.172' WHERE (`spawn_id` = '32600'); 
         -- Tear of Theradras XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2345.112', `spawn_positionY` = '2453.43', `spawn_positionZ` = '67.707' WHERE (`spawn_id` = '32599'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2345.112', `spawn_positionY` = '2453.43', `spawn_positionZ` = '67.707' WHERE (`spawn_id` = '32599'); 
         -- Tear of Theradras Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '72.315' WHERE (`spawn_id` = '32598'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '72.315' WHERE (`spawn_id` = '32598'); 
         -- Tear of Theradras Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '58.188' WHERE (`spawn_id` = '32596'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '58.188' WHERE (`spawn_id` = '32596'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5550.423', `spawn_positionY` = '658.624', `spawn_positionZ` = '393.387' WHERE (`spawn_id` = '9938'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-5550.423', `spawn_positionY` = '658.624', `spawn_positionZ` = '393.387' WHERE (`spawn_id` = '9938'); 
         -- Vylestem Vine Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.523' WHERE (`spawn_id` = '32573'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.523' WHERE (`spawn_id` = '32573'); 
         -- Barrel of Melon Juice XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-498.822', `spawn_positionY` = '-1536.943', `spawn_positionZ` = '59.761' WHERE (`spawn_id` = '20856'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-498.822', `spawn_positionY` = '-1536.943', `spawn_positionZ` = '59.761' WHERE (`spawn_id` = '20856'); 
         -- Rise of the Horde Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '39.854' WHERE (`spawn_id` = '29688'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '39.854' WHERE (`spawn_id` = '29688'); 
         -- The Dark Portal and the Fall of Stormwind Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '20.962' WHERE (`spawn_id` = '29686'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '20.962' WHERE (`spawn_id` = '29686'); 
         -- The New Horde Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '39.855' WHERE (`spawn_id` = '29681'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '39.855' WHERE (`spawn_id` = '29681'); 
         -- Campfire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.867' WHERE (`spawn_id` = '32535'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '94.867' WHERE (`spawn_id` = '32535'); 
         -- Karnitol's Chest Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.121' WHERE (`spawn_id` = '32531'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.121' WHERE (`spawn_id` = '32531'); 
         -- MacGrann's Meat Locker Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '417.986' WHERE (`spawn_id` = '10027'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '417.986' WHERE (`spawn_id` = '10027'); 
         -- The Battle of Grim Batol XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1897.128', `spawn_positionY` = '352.391', `spawn_positionZ` = '107.661' WHERE (`spawn_id` = '32506'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1897.128', `spawn_positionY` = '352.391', `spawn_positionZ` = '107.661' WHERE (`spawn_id` = '32506'); 
         -- War of the Three Hammers XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1898.901', `spawn_positionY` = '336.872', `spawn_positionZ` = '105.117' WHERE (`spawn_id` = '32010'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1898.901', `spawn_positionY` = '336.872', `spawn_positionZ` = '105.117' WHERE (`spawn_id` = '32010'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.774' WHERE (`spawn_id` = '20817'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.774' WHERE (`spawn_id` = '20817'); 
         -- Ironforge - the Awakening of the Dwarves XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1896.912', `spawn_positionY` = '355.444', `spawn_positionZ` = '107.55' WHERE (`spawn_id` = '31909'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1896.912', `spawn_positionY` = '355.444', `spawn_positionZ` = '107.55' WHERE (`spawn_id` = '31909'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '386.112' WHERE (`spawn_id` = '10105'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '386.112' WHERE (`spawn_id` = '10105'); 
         -- Mighty Blaze Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '31346'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '31346'); 
         -- Fierce Blaze Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '31344'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '31344'); 
         -- Fierce Blaze Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '31342'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '31342'); 
         -- Fierce Blaze Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30952'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30952'); 
         -- Fierce Blaze Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30908'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30908'); 
         -- Fierce Blaze Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30907'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30907'); 
         -- Mighty Blaze Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30906'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30906'); 
         -- Fierce Blaze Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30905'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30905'); 
         -- Campfire XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2284.958', `spawn_positionY` = '2657.683', `spawn_positionZ` = '60.66' WHERE (`spawn_id` = '30904'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2284.958', `spawn_positionY` = '2657.683', `spawn_positionZ` = '60.66' WHERE (`spawn_id` = '30904'); 
         -- Caravan Chest Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.686' WHERE (`spawn_id` = '29362'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '21.686' WHERE (`spawn_id` = '29362'); 
         -- Locked ball and chain Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '51.226' WHERE (`spawn_id` = '20785'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '51.226' WHERE (`spawn_id` = '20785'); 
         -- Locked ball and chain Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '53.623' WHERE (`spawn_id` = '20784'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '53.623' WHERE (`spawn_id` = '20784'); 
         -- Alterac Granite XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-241.674', `spawn_positionY` = '-267.344', `spawn_positionZ` = '54.413' WHERE (`spawn_id` = '20782'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-241.674', `spawn_positionY` = '-267.344', `spawn_positionZ` = '54.413' WHERE (`spawn_id` = '20782'); 
         -- Alterac Granite XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-212.773', `spawn_positionY` = '-383.497', `spawn_positionZ` = '64.896' WHERE (`spawn_id` = '20781'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-212.773', `spawn_positionY` = '-383.497', `spawn_positionZ` = '64.896' WHERE (`spawn_id` = '20781'); 
         -- Flame of Veraz XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-210.968', `spawn_positionY` = '-308.329', `spawn_positionZ` = '49.109' WHERE (`spawn_id` = '20780'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-210.968', `spawn_positionY` = '-308.329', `spawn_positionZ` = '49.109' WHERE (`spawn_id` = '20780'); 
         -- Flame of Azel XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-211.04', `spawn_positionY` = '-378.924', `spawn_positionZ` = '65.852' WHERE (`spawn_id` = '20779'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-211.04', `spawn_positionY` = '-378.924', `spawn_positionZ` = '65.852' WHERE (`spawn_id` = '20779'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8943.978', `spawn_positionY` = '-2035.95', `spawn_positionZ` = '133.951' WHERE (`spawn_id` = '31124'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-8943.978', `spawn_positionY` = '-2035.95', `spawn_positionZ` = '133.951' WHERE (`spawn_id` = '31124'); 
         -- Tin Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8957.213', `spawn_positionY` = '-2000.348', `spawn_positionZ` = '134.091' WHERE (`spawn_id` = '31123'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-8957.213', `spawn_positionY` = '-2000.348', `spawn_positionZ` = '134.091' WHERE (`spawn_id` = '31123'); 
         -- Battered Chest XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8910.886', `spawn_positionY` = '-1962.685', `spawn_positionZ` = '130.836' WHERE (`spawn_id` = '31122'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-8910.886', `spawn_positionY` = '-1962.685', `spawn_positionZ` = '130.836' WHERE (`spawn_id` = '31122'); 
         -- Tin Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8946.009', `spawn_positionY` = '-1975.52', `spawn_positionZ` = '135.707' WHERE (`spawn_id` = '20883'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-8946.009', `spawn_positionY` = '-1975.52', `spawn_positionZ` = '135.707' WHERE (`spawn_id` = '20883'); 
         -- Tin Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8904.822', `spawn_positionY` = '-1918.278', `spawn_positionZ` = '133.83' WHERE (`spawn_id` = '20882'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-8904.822', `spawn_positionY` = '-1918.278', `spawn_positionZ` = '133.83' WHERE (`spawn_id` = '20882'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8867.052', `spawn_positionY` = '-1849.176', `spawn_positionZ` = '120.721' WHERE (`spawn_id` = '20454'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-8867.052', `spawn_positionY` = '-1849.176', `spawn_positionZ` = '120.721' WHERE (`spawn_id` = '20454'); 
         -- Water Barrel Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '358.872' WHERE (`spawn_id` = '10847'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '358.872' WHERE (`spawn_id` = '10847'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5704.192', `spawn_positionY` = '-1684.101', `spawn_positionZ` = '358.417' WHERE (`spawn_id` = '10853'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-5704.192', `spawn_positionY` = '-1684.101', `spawn_positionZ` = '358.417' WHERE (`spawn_id` = '10853'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5615.457', `spawn_positionY` = '-1648.702', `spawn_positionZ` = '354.348' WHERE (`spawn_id` = '10855'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-5615.457', `spawn_positionY` = '-1648.702', `spawn_positionZ` = '354.348' WHERE (`spawn_id` = '10855'); 
         -- Battered Chest XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5559.417', `spawn_positionY` = '-1607.08', `spawn_positionZ` = '353.305' WHERE (`spawn_id` = '10856'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-5559.417', `spawn_positionY` = '-1607.08', `spawn_positionZ` = '353.305' WHERE (`spawn_id` = '10856'); 
         -- Ironband's Strongbox Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '408.592' WHERE (`spawn_id` = '10868'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '408.592' WHERE (`spawn_id` = '10868'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-322.092', `spawn_positionY` = '931.233', `spawn_positionZ` = '131.866' WHERE (`spawn_id` = '35444'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-322.092', `spawn_positionY` = '931.233', `spawn_positionZ` = '131.866' WHERE (`spawn_id` = '35444'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8747.848', `spawn_positionY` = '-2246.65', `spawn_positionZ` = '153.659' WHERE (`spawn_id` = '18679'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-8747.848', `spawn_positionY` = '-2246.65', `spawn_positionZ` = '153.659' WHERE (`spawn_id` = '18679'); 
         -- Solid Chest Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.926' WHERE (`spawn_id` = '9096'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.926' WHERE (`spawn_id` = '9096'); 
         -- Onyxia's Gate Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.097' WHERE (`spawn_id` = '9091'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '34.097' WHERE (`spawn_id` = '9091'); 
         -- Wooden Chair XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4088.002', `spawn_positionY` = '-4537.01', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9087'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4088.002', `spawn_positionY` = '-4537.01', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9087'); 
         -- Wooden Chair XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4089.954', `spawn_positionY` = '-4530.919', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9082'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4089.954', `spawn_positionY` = '-4530.919', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9082'); 
         -- Wooden Chair XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-820.755', `spawn_positionY` = '-563.622', `spawn_positionZ` = '16.408' WHERE (`spawn_id` = '18819'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-820.755', `spawn_positionY` = '-563.622', `spawn_positionZ` = '16.408' WHERE (`spawn_id` = '18819'); 
         -- Shaman Shrine Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.29' WHERE (`spawn_id` = '35418'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '6.29' WHERE (`spawn_id` = '35418'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.643' WHERE (`spawn_id` = '17994'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '182.643' WHERE (`spawn_id` = '17994'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.909' WHERE (`spawn_id` = '17993'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '182.909' WHERE (`spawn_id` = '17993'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '186.92' WHERE (`spawn_id` = '17991'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '186.92' WHERE (`spawn_id` = '17991'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.883' WHERE (`spawn_id` = '17988'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '182.883' WHERE (`spawn_id` = '17988'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.764' WHERE (`spawn_id` = '17986'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '182.764' WHERE (`spawn_id` = '17986'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.375' WHERE (`spawn_id` = '17984'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '182.375' WHERE (`spawn_id` = '17984'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.297' WHERE (`spawn_id` = '17982'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '182.297' WHERE (`spawn_id` = '17982'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '186.743' WHERE (`spawn_id` = '17980'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '186.743' WHERE (`spawn_id` = '17980'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.607' WHERE (`spawn_id` = '17979'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '182.607' WHERE (`spawn_id` = '17979'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.638' WHERE (`spawn_id` = '17977'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '182.638' WHERE (`spawn_id` = '17977'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.764' WHERE (`spawn_id` = '17976'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '182.764' WHERE (`spawn_id` = '17976'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.542' WHERE (`spawn_id` = '17974'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '182.542' WHERE (`spawn_id` = '17974'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.629' WHERE (`spawn_id` = '17973'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '182.629' WHERE (`spawn_id` = '17973'); 
         -- Wooden Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '181.718' WHERE (`spawn_id` = '17966'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '181.718' WHERE (`spawn_id` = '17966'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1818.535', `spawn_positionY` = '-1160.698', `spawn_positionZ` = '84.396' WHERE (`spawn_id` = '20722'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1818.535', `spawn_positionY` = '-1160.698', `spawn_positionZ` = '84.396' WHERE (`spawn_id` = '20722'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1796.07', `spawn_positionY` = '-1133.676', `spawn_positionZ` = '89.368' WHERE (`spawn_id` = '20721'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1796.07', `spawn_positionY` = '-1133.676', `spawn_positionZ` = '89.368' WHERE (`spawn_id` = '20721'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2414.816', `spawn_positionY` = '352.55', `spawn_positionZ` = '71.249' WHERE (`spawn_id` = '20717'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2414.816', `spawn_positionY` = '352.55', `spawn_positionZ` = '71.249' WHERE (`spawn_id` = '20717'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2355.516', `spawn_positionY` = '374.086', `spawn_positionZ` = '71.101' WHERE (`spawn_id` = '20716'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2355.516', `spawn_positionY` = '374.086', `spawn_positionZ` = '71.101' WHERE (`spawn_id` = '20716'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1729.654', `spawn_positionY` = '-1183.665', `spawn_positionZ` = '83.191' WHERE (`spawn_id` = '20672'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1729.654', `spawn_positionY` = '-1183.665', `spawn_positionZ` = '83.191' WHERE (`spawn_id` = '20672'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2409.372', `spawn_positionY` = '392.377', `spawn_positionZ` = '65.291' WHERE (`spawn_id` = '20667'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2409.372', `spawn_positionY` = '392.377', `spawn_positionZ` = '65.291' WHERE (`spawn_id` = '20667'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1803.327', `spawn_positionY` = '-1145.089', `spawn_positionZ` = '86.233' WHERE (`spawn_id` = '20648'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1803.327', `spawn_positionY` = '-1145.089', `spawn_positionZ` = '86.233' WHERE (`spawn_id` = '20648'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1786.272', `spawn_positionY` = '-995.415', `spawn_positionZ` = '86.124' WHERE (`spawn_id` = '20644'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1786.272', `spawn_positionY` = '-995.415', `spawn_positionZ` = '86.124' WHERE (`spawn_id` = '20644'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '85.098' WHERE (`spawn_id` = '20644'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '85.098' WHERE (`spawn_id` = '20644'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1457.337', `spawn_positionY` = '-920.6', `spawn_positionZ` = '51.495' WHERE (`spawn_id` = '20642'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1457.337', `spawn_positionY` = '-920.6', `spawn_positionZ` = '51.495' WHERE (`spawn_id` = '20642'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '50.769' WHERE (`spawn_id` = '20642'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '50.769' WHERE (`spawn_id` = '20642'); 
 		        -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '72.494' WHERE (`spawn_id` = '42512'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '72.494' WHERE (`spawn_id` = '42512'); 
         -- Campfire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '72.495' WHERE (`spawn_id` = '42511'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '72.495' WHERE (`spawn_id` = '42511'); 
         -- Wooden Chair XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4087.813', `spawn_positionY` = '-4538.993', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9079'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4087.813', `spawn_positionY` = '-4538.993', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9079'); 
         -- Wooden Chair XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4090.135', `spawn_positionY` = '-4528.345', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9077'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4090.135', `spawn_positionY` = '-4528.345', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9077'); 
         -- Wooden Chair XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4092.054', `spawn_positionY` = '-4542.481', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9063'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4092.054', `spawn_positionY` = '-4542.481', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9063'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '9062'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '9062'); 
         -- Wooden Chair XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4093.94', `spawn_positionY` = '-4534.429', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9056'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4093.94', `spawn_positionY` = '-4534.429', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9056'); 
         -- Wooden Chair XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4080.577', `spawn_positionY` = '-4537.296', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9038'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4080.577', `spawn_positionY` = '-4537.296', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9038'); 
         -- Wooden Chair XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4090.338', `spawn_positionY` = '-4535.015', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9037'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4090.338', `spawn_positionY` = '-4535.015', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9037'); 
         -- Wooden Chair XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3979.879', `spawn_positionY` = '-4594.738', `spawn_positionZ` = '0.077' WHERE (`spawn_id` = '9034'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-3979.879', `spawn_positionY` = '-4594.738', `spawn_positionZ` = '0.077' WHERE (`spawn_id` = '9034'); 
         -- Wooden Chair XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3994.309', `spawn_positionY` = '-4594.834', `spawn_positionZ` = '0.077' WHERE (`spawn_id` = '9032'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-3994.309', `spawn_positionY` = '-4594.834', `spawn_positionZ` = '0.077' WHERE (`spawn_id` = '9032'); 
         -- Wooden Chair XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3992.362', `spawn_positionY` = '-4590.767', `spawn_positionZ` = '0.077' WHERE (`spawn_id` = '9024'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-3992.362', `spawn_positionY` = '-4590.767', `spawn_positionZ` = '0.077' WHERE (`spawn_id` = '9024'); 
         -- Wooden Chair XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3997.958', `spawn_positionY` = '-4611.022', `spawn_positionZ` = '7.394' WHERE (`spawn_id` = '9006'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-3997.958', `spawn_positionY` = '-4611.022', `spawn_positionZ` = '7.394' WHERE (`spawn_id` = '9006'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '9001'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '9001'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '9000'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '9000'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8996'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8996'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8996'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8996'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8979'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8979'); 
         -- Anvil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '86.522' WHERE (`spawn_id` = '20560'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '86.522' WHERE (`spawn_id` = '20560'); 
         -- Bonfire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '163.335' WHERE (`spawn_id` = '20556'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '163.335' WHERE (`spawn_id` = '20556'); 
         -- Food Crate XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1925.28', `spawn_positionY` = '417.42', `spawn_positionZ` = '186.07' WHERE (`spawn_id` = '20528'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1925.28', `spawn_positionY` = '417.42', `spawn_positionZ` = '186.07' WHERE (`spawn_id` = '20528'); 
         -- Food Crate XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1948.225', `spawn_positionY` = '377.8', `spawn_positionZ` = '133.381' WHERE (`spawn_id` = '20528'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1948.225', `spawn_positionY` = '377.8', `spawn_positionZ` = '133.381' WHERE (`spawn_id` = '20528'); 
         -- Food Crate XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1886.202', `spawn_positionY` = '-1098.123', `spawn_positionZ` = '87.3' WHERE (`spawn_id` = '20526'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1886.202', `spawn_positionY` = '-1098.123', `spawn_positionZ` = '87.3' WHERE (`spawn_id` = '20526'); 
         -- Food Crate XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1826.478', `spawn_positionY` = '-1124.856', `spawn_positionZ` = '84.674' WHERE (`spawn_id` = '20525'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1826.478', `spawn_positionY` = '-1124.856', `spawn_positionZ` = '84.674' WHERE (`spawn_id` = '20525'); 
         -- Solid Chest XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-877.876', `spawn_positionY` = '-3873.885', `spawn_positionZ` = '159.727' WHERE (`spawn_id` = '16977'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-877.876', `spawn_positionY` = '-3873.885', `spawn_positionZ` = '159.727' WHERE (`spawn_id` = '16977'); 
         -- Mithril Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2022.357', `spawn_positionY` = '-3371.005', `spawn_positionZ` = '52.244' WHERE (`spawn_id` = '16974'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2022.357', `spawn_positionY` = '-3371.005', `spawn_positionZ` = '52.244' WHERE (`spawn_id` = '16974'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2012.945', `spawn_positionY` = '-3312.173', `spawn_positionZ` = '52.082' WHERE (`spawn_id` = '16973'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2012.945', `spawn_positionY` = '-3312.173', `spawn_positionZ` = '52.082' WHERE (`spawn_id` = '16973'); 
         -- Lesser Bloodstone Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-870.385', `spawn_positionY` = '-3821.466', `spawn_positionZ` = '145.192' WHERE (`spawn_id` = '11993'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-870.385', `spawn_positionY` = '-3821.466', `spawn_positionZ` = '145.192' WHERE (`spawn_id` = '11993'); 
         -- Lesser Bloodstone Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '143.782' WHERE (`spawn_id` = '11993'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '143.782' WHERE (`spawn_id` = '11993'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-873.807', `spawn_positionY` = '-3840.334', `spawn_positionZ` = '149.58' WHERE (`spawn_id` = '11995'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-873.807', `spawn_positionY` = '-3840.334', `spawn_positionZ` = '149.58' WHERE (`spawn_id` = '11995'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '148.947' WHERE (`spawn_id` = '11995'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '148.947' WHERE (`spawn_id` = '11995'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-797.869', `spawn_positionY` = '-3808.113', `spawn_positionZ` = '144.85' WHERE (`spawn_id` = '11997'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-797.869', `spawn_positionY` = '-3808.113', `spawn_positionZ` = '144.85' WHERE (`spawn_id` = '11997'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '143.062' WHERE (`spawn_id` = '11997'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '143.062' WHERE (`spawn_id` = '11997'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-942.759', `spawn_positionY` = '-3857.444', `spawn_positionZ` = '147.871' WHERE (`spawn_id` = '11999'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-942.759', `spawn_positionY` = '-3857.444', `spawn_positionZ` = '147.871' WHERE (`spawn_id` = '11999'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '147.196' WHERE (`spawn_id` = '11999'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '147.196' WHERE (`spawn_id` = '11999'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-803.337', `spawn_positionY` = '-3838.042', `spawn_positionZ` = '140.398' WHERE (`spawn_id` = '12001'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-803.337', `spawn_positionY` = '-3838.042', `spawn_positionZ` = '140.398' WHERE (`spawn_id` = '12001'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '137.824' WHERE (`spawn_id` = '12001'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '137.824' WHERE (`spawn_id` = '12001'); 
         -- Lesser Bloodstone Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-834.981', `spawn_positionY` = '-3903.662', `spawn_positionZ` = '153.738' WHERE (`spawn_id` = '12002'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-834.981', `spawn_positionY` = '-3903.662', `spawn_positionZ` = '153.738' WHERE (`spawn_id` = '12002'); 
         -- Lesser Bloodstone Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '153.38' WHERE (`spawn_id` = '12002'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '153.38' WHERE (`spawn_id` = '12002'); 
         -- Lesser Bloodstone Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-852.325', `spawn_positionY` = '-3896.017', `spawn_positionZ` = '155.17' WHERE (`spawn_id` = '12005'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-852.325', `spawn_positionY` = '-3896.017', `spawn_positionZ` = '155.17' WHERE (`spawn_id` = '12005'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-887.304', `spawn_positionY` = '-3083.02', `spawn_positionZ` = '80.638' WHERE (`spawn_id` = '16965'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-887.304', `spawn_positionY` = '-3083.02', `spawn_positionZ` = '80.638' WHERE (`spawn_id` = '16965'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '77.763' WHERE (`spawn_id` = '16965'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '77.763' WHERE (`spawn_id` = '16965'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '153.873' WHERE (`spawn_id` = '16964'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '153.873' WHERE (`spawn_id` = '16964'); 
         -- Lesser Bloodstone Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-984.15', `spawn_positionY` = '-3845.262', `spawn_positionZ` = '144.812' WHERE (`spawn_id` = '16958'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-984.15', `spawn_positionY` = '-3845.262', `spawn_positionZ` = '144.812' WHERE (`spawn_id` = '16958'); 
         -- Lesser Bloodstone Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '143.037' WHERE (`spawn_id` = '16958'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '143.037' WHERE (`spawn_id` = '16958'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-900.728', `spawn_positionY` = '-3824.991', `spawn_positionZ` = '146.628' WHERE (`spawn_id` = '16954'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-900.728', `spawn_positionY` = '-3824.991', `spawn_positionZ` = '146.628' WHERE (`spawn_id` = '16954'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '146.283' WHERE (`spawn_id` = '16954'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '146.283' WHERE (`spawn_id` = '16954'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2061.016', `spawn_positionY` = '-3354.228', `spawn_positionZ` = '42.784' WHERE (`spawn_id` = '16931'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2061.016', `spawn_positionY` = '-3354.228', `spawn_positionZ` = '42.784' WHERE (`spawn_id` = '16931'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '41.178' WHERE (`spawn_id` = '16931'); 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-7.673' WHERE (`spawn_id` = '20420'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '41.178' WHERE (`spawn_id` = '16931'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-7.673' WHERE (`spawn_id` = '20420'); 
         -- Smoke Emitter 02 Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.722' WHERE (`spawn_id` = '16771'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.722' WHERE (`spawn_id` = '16771'); 
         -- Small Barracks Flame Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.164' WHERE (`spawn_id` = '14779'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '92.164' WHERE (`spawn_id` = '14779'); 
         -- Smoke Emitter 02 Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.901' WHERE (`spawn_id` = '16770'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.901' WHERE (`spawn_id` = '16770'); 
         -- Big Barracks Flame Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.905' WHERE (`spawn_id` = '14776'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.905' WHERE (`spawn_id` = '14776'); 
         -- Small Barracks Flame Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.683' WHERE (`spawn_id` = '14780'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.683' WHERE (`spawn_id` = '14780'); 
         -- Small Barracks Flame Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.9' WHERE (`spawn_id` = '14777'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.9' WHERE (`spawn_id` = '14777'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-983.377', `spawn_positionY` = '-3879.499', `spawn_positionZ` = '142.401' WHERE (`spawn_id` = '16906'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-983.377', `spawn_positionY` = '-3879.499', `spawn_positionZ` = '142.401' WHERE (`spawn_id` = '16906'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '141.518' WHERE (`spawn_id` = '16906'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '141.518' WHERE (`spawn_id` = '16906'); 
         -- Firebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '11.493' WHERE (`spawn_id` = '12242'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '11.493' WHERE (`spawn_id` = '12242'); 
         -- Firebloom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-7262.0', `spawn_positionY` = '-864.0', `spawn_positionZ` = '289.955' WHERE (`spawn_id` = '12243'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-7262.0', `spawn_positionY` = '-864.0', `spawn_positionZ` = '289.955' WHERE (`spawn_id` = '12243'); 
         -- Firebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.623' WHERE (`spawn_id` = '12250'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '4.623' WHERE (`spawn_id` = '12250'); 
         -- Firebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.319' WHERE (`spawn_id` = '12274'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '10.319' WHERE (`spawn_id` = '12274'); 
         -- Forge XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1938.896', `spawn_positionY` = '383.6', `spawn_positionZ` = '133.448' WHERE (`spawn_id` = '30166'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1938.896', `spawn_positionY` = '383.6', `spawn_positionZ` = '133.448' WHERE (`spawn_id` = '30166'); 
         -- Anvil XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1946.268', `spawn_positionY` = '379.568', `spawn_positionZ` = '133.412' WHERE (`spawn_id` = '30168'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1946.268', `spawn_positionY` = '379.568', `spawn_positionZ` = '133.412' WHERE (`spawn_id` = '30168'); 
         -- Firebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '13.28' WHERE (`spawn_id` = '12327'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '13.28' WHERE (`spawn_id` = '12327'); 
         -- Peacebloom Flower Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-14.139' WHERE (`spawn_id` = '18551'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-14.139' WHERE (`spawn_id` = '18551'); 
         -- Battered Chest ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18447'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18447'); 
         -- Battered Chest ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18445'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18445'); 
         -- Water Barrel ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18305'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18305'); 
         -- Water Barrel ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18303'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18303'); 
         -- Water Barrel ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18302'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18302'); 
         -- Campfire ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18167'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18167'); 
         -- Thunder Bluff Forge XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1241.988', `spawn_positionY` = '95.77', `spawn_positionZ` = '130.43' WHERE (`spawn_id` = '18126'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1241.988', `spawn_positionY` = '95.77', `spawn_positionZ` = '130.43' WHERE (`spawn_id` = '18126'); 
         -- Bonfire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '100.889' WHERE (`spawn_id` = '18116'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '100.889' WHERE (`spawn_id` = '18116'); 
         -- Bonfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '100.889' WHERE (`spawn_id` = '18112'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '100.889' WHERE (`spawn_id` = '18112'); 
         -- Solid Chest Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.597' WHERE (`spawn_id` = '16648'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '38.597' WHERE (`spawn_id` = '16648'); 
         -- Solid Chest Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '51.004' WHERE (`spawn_id` = '15672'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '51.004' WHERE (`spawn_id` = '15672'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.867' WHERE (`spawn_id` = '18045'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '94.867' WHERE (`spawn_id` = '18045'); 
         -- Iridescent Shards Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '153.348' WHERE (`spawn_id` = '16635'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '153.348' WHERE (`spawn_id` = '16635'); 
         -- Rise of the Blood Elves Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '83.769' WHERE (`spawn_id` = '16609'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '83.769' WHERE (`spawn_id` = '16609'); 
         -- Sargeras and the Betrayal Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '75.614' WHERE (`spawn_id` = '16608'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '75.614' WHERE (`spawn_id` = '16608'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.566' WHERE (`spawn_id` = '18025'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.566' WHERE (`spawn_id` = '18025'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18024'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18024'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18017'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18017'); 
         -- Mouthpiece Mount Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '179.327' WHERE (`spawn_id` = '18013'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '179.327' WHERE (`spawn_id` = '18013'); 
         -- HornCover Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '161.313' WHERE (`spawn_id` = '17228'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '161.313' WHERE (`spawn_id` = '17228'); 
         -- Small Thorium Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6353.775', `spawn_positionY` = '-1884.256', `spawn_positionZ` = '-259.576' WHERE (`spawn_id` = '17593'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-6353.775', `spawn_positionY` = '-1884.256', `spawn_positionZ` = '-259.576' WHERE (`spawn_id` = '17593'); 
         -- Small Thorium Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6317.152', `spawn_positionY` = '-1846.192', `spawn_positionZ` = '-257.155' WHERE (`spawn_id` = '17592'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-6317.152', `spawn_positionY` = '-1846.192', `spawn_positionZ` = '-257.155' WHERE (`spawn_id` = '17592'); 
         -- Solid Chest XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3853.528', `spawn_positionY` = '-2540.012', `spawn_positionZ` = '42.331' WHERE (`spawn_id` = '15212'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-3853.528', `spawn_positionY` = '-2540.012', `spawn_positionZ` = '42.331' WHERE (`spawn_id` = '15212'); 
         -- Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.575' WHERE (`spawn_id` = '17484'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '6.575' WHERE (`spawn_id` = '17484'); 
         -- Egg-O-Matic Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '8.828' WHERE (`spawn_id` = '17475'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '8.828' WHERE (`spawn_id` = '17475'); 
         -- Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17463'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17463'); 
         -- Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17462'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17462'); 
         -- Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17461'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17461'); 
         -- Stove Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '9.214' WHERE (`spawn_id` = '17445'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '9.214' WHERE (`spawn_id` = '17445'); 
         -- Gahz'ridian Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '27.36' WHERE (`spawn_id` = '17409'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '27.36' WHERE (`spawn_id` = '17409'); 
         -- Gahz'ridian Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '60.208' WHERE (`spawn_id` = '17406'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '60.208' WHERE (`spawn_id` = '17406'); 
         -- Gahz'ridian Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '9.273' WHERE (`spawn_id` = '17395'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '9.273' WHERE (`spawn_id` = '17395'); 
         -- Gahz'ridian Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '16.819' WHERE (`spawn_id` = '17386'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '16.819' WHERE (`spawn_id` = '17386'); 
         -- Stove Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.167' WHERE (`spawn_id` = '17354'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.167' WHERE (`spawn_id` = '17354'); 
         -- Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.081' WHERE (`spawn_id` = '17351'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.081' WHERE (`spawn_id` = '17351'); 
         -- Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.455' WHERE (`spawn_id` = '17350'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '2.455' WHERE (`spawn_id` = '17350'); 
         -- Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.014' WHERE (`spawn_id` = '17349'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.014' WHERE (`spawn_id` = '17349'); 
         -- Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.324' WHERE (`spawn_id` = '17348'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.324' WHERE (`spawn_id` = '17348'); 
         -- Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.621' WHERE (`spawn_id` = '17347'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.621' WHERE (`spawn_id` = '17347'); 
         -- Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.468' WHERE (`spawn_id` = '17346'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.468' WHERE (`spawn_id` = '17346'); 
         -- Stove Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.527' WHERE (`spawn_id` = '17345'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.527' WHERE (`spawn_id` = '17345'); 
         -- Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.762' WHERE (`spawn_id` = '17344'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '2.762' WHERE (`spawn_id` = '17344'); 
         -- Chair Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.388' WHERE (`spawn_id` = '17343'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '2.388' WHERE (`spawn_id` = '17343'); 
         -- Old Hatreds - The Colonization of Kalimdor Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.88' WHERE (`spawn_id` = '17342'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '10.88' WHERE (`spawn_id` = '17342'); 
         -- Food Crate Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.224' WHERE (`spawn_id` = '15194'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-0.224' WHERE (`spawn_id` = '15194'); 
         -- Tin Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3906.052', `spawn_positionY` = '-2520.028', `spawn_positionZ` = '45.379' WHERE (`spawn_id` = '15182'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-3906.052', `spawn_positionY` = '-2520.028', `spawn_positionZ` = '45.379' WHERE (`spawn_id` = '15182'); 
         -- Tin Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '44.098' WHERE (`spawn_id` = '15182'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '44.098' WHERE (`spawn_id` = '15182'); 
         -- Tin Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3870.382', `spawn_positionY` = '-2415.092', `spawn_positionZ` = '47.584' WHERE (`spawn_id` = '15181'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-3870.382', `spawn_positionY` = '-2415.092', `spawn_positionZ` = '47.584' WHERE (`spawn_id` = '15181'); 
         -- Tin Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '47.402' WHERE (`spawn_id` = '15181'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '47.402' WHERE (`spawn_id` = '15181'); 
         -- Tin Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3918.919', `spawn_positionY` = '-2441.717', `spawn_positionZ` = '41.335' WHERE (`spawn_id` = '15180'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-3918.919', `spawn_positionY` = '-2441.717', `spawn_positionZ` = '41.335' WHERE (`spawn_id` = '15180'); 
         -- Tin Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '42.127' WHERE (`spawn_id` = '15180'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '42.127' WHERE (`spawn_id` = '15180'); 
         -- Incendicite Mineral Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3871.993', `spawn_positionY` = '-2533.822', `spawn_positionZ` = '45.258' WHERE (`spawn_id` = '15179'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-3871.993', `spawn_positionY` = '-2533.822', `spawn_positionZ` = '45.258' WHERE (`spawn_id` = '15179'); 
         -- Incendicite Mineral Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '43.881' WHERE (`spawn_id` = '15179'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '43.881' WHERE (`spawn_id` = '15179'); 
         -- Doodad_GeneralMedChair03 ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14174'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14174'); 
         -- Doodad_GeneralMedChair04 ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14173'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14173'); 
         -- Doodad_GeneralMedChair02 ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14172'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14172'); 
         -- Solid Chest ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17329'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17329'); 
         -- Moon Well Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.062' WHERE (`spawn_id` = '17328'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '14.062' WHERE (`spawn_id` = '17328'); 
         -- Captain's Chest ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17327'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17327'); 
         -- Stolen Cargo Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.514' WHERE (`spawn_id` = '17326'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.514' WHERE (`spawn_id` = '17326'); 
         -- Stolen Cargo Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.896' WHERE (`spawn_id` = '17324'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.896' WHERE (`spawn_id` = '17324'); 
         -- Stolen Cargo Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.441' WHERE (`spawn_id` = '17326'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.441' WHERE (`spawn_id` = '17326'); 
         -- Stolen Cargo Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.503' WHERE (`spawn_id` = '17325'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.503' WHERE (`spawn_id` = '17325'); 
         -- Stolen Cargo Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.51' WHERE (`spawn_id` = '17324'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '2.51' WHERE (`spawn_id` = '17324'); 
         -- Stolen Cargo Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.838' WHERE (`spawn_id` = '17323'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.838' WHERE (`spawn_id` = '17323'); 
         -- Stolen Cargo Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.658' WHERE (`spawn_id` = '17322'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.658' WHERE (`spawn_id` = '17322'); 
         -- Bench Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.002' WHERE (`spawn_id` = '17321'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '10.002' WHERE (`spawn_id` = '17321'); 
         -- Bench Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.587' WHERE (`spawn_id` = '17320'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '10.587' WHERE (`spawn_id` = '17320'); 
         -- Bench Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.541' WHERE (`spawn_id` = '17319'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '10.541' WHERE (`spawn_id` = '17319'); 
         -- Bench Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.326' WHERE (`spawn_id` = '17318'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '10.326' WHERE (`spawn_id` = '17318'); 
         -- Couch Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '16.507' WHERE (`spawn_id` = '17317'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '16.507' WHERE (`spawn_id` = '17317'); 
         -- Book "Soothsaying for Dummies" Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '16.827' WHERE (`spawn_id` = '17316'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '16.827' WHERE (`spawn_id` = '17316'); 
         -- Barrel of Melon Juice Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-10.782' WHERE (`spawn_id` = '14890'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-10.782' WHERE (`spawn_id` = '14890'); 
         -- Wanted Poster Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '9.962' WHERE (`spawn_id` = '17282'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '9.962' WHERE (`spawn_id` = '17282'); 
         -- Pew ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14047'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14047'); 
         -- Pew Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '52.643' WHERE (`spawn_id` = '14046'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '52.643' WHERE (`spawn_id` = '14046'); 
         -- Pew ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14046'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14046'); 
         -- Pew ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14045'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14045'); 
         -- Pew ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14044'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14044'); 
         -- Pew ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14043'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14043'); 
         -- Pew ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14042'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14042'); 
         -- Gate ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14040'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14040'); 
         -- Door ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14039'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14039'); 
         -- Gate ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14038'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14038'); 
         -- Door ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14036'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14036'); 
         -- Door ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14035'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14035'); 
         -- Door ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14034'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14034'); 
         -- Door ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14033'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14033'); 
         -- Gate ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14032'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14032'); 
         -- Portcullis XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2757.28', `spawn_positionY` = '-5036.39', `spawn_positionZ` = '-1.69' WHERE (`spawn_id` = '7636'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2757.28', `spawn_positionY` = '-5036.39', `spawn_positionZ` = '-1.69' WHERE (`spawn_id` = '7636'); 
         -- Portcullis Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.655' WHERE (`spawn_id` = '7635'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.655' WHERE (`spawn_id` = '7635'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.142' WHERE (`spawn_id` = '7634'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '33.142' WHERE (`spawn_id` = '7634'); 
         -- Doodad_PortcullisActive02 ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14030'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14030'); 
         -- Doodad_PortcullisActive06 ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14029'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14029'); 
         -- Anvil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '11.009' WHERE (`spawn_id` = '17243'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '11.009' WHERE (`spawn_id` = '17243'); 
         -- Food Crate Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '7.236' WHERE (`spawn_id` = '14857'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '7.236' WHERE (`spawn_id` = '14857'); 
         -- Food Crate Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.098' WHERE (`spawn_id` = '14853'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-0.098' WHERE (`spawn_id` = '14853'); 
         -- Doodad_WroughtIronDoor01 ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14014'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14014'); 
         -- Forge Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.936' WHERE (`spawn_id` = '17240'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '10.936' WHERE (`spawn_id` = '17240'); 
         -- Doodad_PortcullisActive07 ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14013'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14013'); 
         -- Doodad_WroughtIronDoor03 ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14011'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14011'); 
         -- Uldum Pedestal Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '9.323' WHERE (`spawn_id` = '17230'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '9.323' WHERE (`spawn_id` = '17230'); 
         -- Tin Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3013.538', `spawn_positionY` = '-3293.8', `spawn_positionZ` = '65.469' WHERE (`spawn_id` = '14665'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-3013.538', `spawn_positionY` = '-3293.8', `spawn_positionZ` = '65.469' WHERE (`spawn_id` = '14665'); 
         -- Tin Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '65.179' WHERE (`spawn_id` = '14665'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '65.179' WHERE (`spawn_id` = '14665'); 
         -- Iron Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '49.327' WHERE (`spawn_id` = '14664'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '49.327' WHERE (`spawn_id` = '14664'); 
         -- Silver Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2996.575', `spawn_positionY` = '-3302.436', `spawn_positionZ` = '65.892' WHERE (`spawn_id` = '14663'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2996.575', `spawn_positionY` = '-3302.436', `spawn_positionZ` = '65.892' WHERE (`spawn_id` = '14663'); 
         -- Solid Chest XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2948.437', `spawn_positionY` = '-3202.636', `spawn_positionZ` = '59.875' WHERE (`spawn_id` = '14660'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2948.437', `spawn_positionY` = '-3202.636', `spawn_positionZ` = '59.875' WHERE (`spawn_id` = '14660'); 
         -- Doodad_WroughtIronDoor04 ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14010'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14010'); 
         -- Doodad_PortcullisActive05 ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14009'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14009'); 
         -- Doodad_WroughtIronDoor02 ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14005'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14005'); 
         -- Bonfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13992'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13992'); 
         -- Bonfire ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13991'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13991'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13990'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13990'); 
         -- Campfire ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13989'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13989'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13988'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13988'); 
         -- Cauldron ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13987'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13987'); 
         -- Turn Back! ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13985'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13985'); 
         -- Bonfire ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13983'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13983'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13982'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13982'); 
         -- Cauldron ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13981'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13981'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10945.107', `spawn_positionY` = '-3546.316', `spawn_positionZ` = '30.528' WHERE (`spawn_id` = '16582'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-10945.107', `spawn_positionY` = '-3546.316', `spawn_positionZ` = '30.528' WHERE (`spawn_id` = '16582'); 
         -- Mithril Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10996.399', `spawn_positionY` = '-3539.051', `spawn_positionZ` = '30.997' WHERE (`spawn_id` = '32135'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-10996.399', `spawn_positionY` = '-3539.051', `spawn_positionZ` = '30.997' WHERE (`spawn_id` = '32135'); 
         -- Truesilver Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10672.617', `spawn_positionY` = '-3564.864', `spawn_positionZ` = '50.989' WHERE (`spawn_id` = '42459'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-10672.617', `spawn_positionY` = '-3564.864', `spawn_positionZ` = '50.989' WHERE (`spawn_id` = '42459'); 
         -- Truesilver Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '49.995' WHERE (`spawn_id` = '42459'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '49.995' WHERE (`spawn_id` = '42459'); 
         -- Mithril Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10652.375', `spawn_positionY` = '-3586.477', `spawn_positionZ` = '29.141' WHERE (`spawn_id` = '42458'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-10652.375', `spawn_positionY` = '-3586.477', `spawn_positionZ` = '29.141' WHERE (`spawn_id` = '42458'); 
         -- Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '27.309' WHERE (`spawn_id` = '42458'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '27.309' WHERE (`spawn_id` = '42458'); 
         -- Beyond the Dark Portal ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '42443'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '42443'); 
         -- Burning Embers ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17209'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17209'); 
         -- Document Chest ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17199'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17199'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '42.709' WHERE (`spawn_id` = '7568'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '42.709' WHERE (`spawn_id` = '7568'); 
         -- Brazier of Everfount ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '33417'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '33417'); 
         -- The Dark Portal and the Fall of Stormwind ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '42442'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '42442'); 
         -- Aftermath of the Second War ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '42441'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '42441'); 
         -- House 2 ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '3996095'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '3996095'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.775' WHERE (`spawn_id` = '7400'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '6.775' WHERE (`spawn_id` = '7400'); 
         -- Signal Torch Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.213' WHERE (`spawn_id` = '6992'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '35.213' WHERE (`spawn_id` = '6992'); 
         -- Mithril Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10637.499', `spawn_positionY` = '-3546.715', `spawn_positionZ` = '32.412' WHERE (`spawn_id` = '42436'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-10637.499', `spawn_positionY` = '-3546.715', `spawn_positionZ` = '32.412' WHERE (`spawn_id` = '42436'); 
         -- Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '31.394' WHERE (`spawn_id` = '42436'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '31.394' WHERE (`spawn_id` = '42436'); 
         -- Iron Deposit XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5036.521', `spawn_positionY` = '-2401.981', `spawn_positionZ` = '-55.601' WHERE (`spawn_id` = '17194'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-5036.521', `spawn_positionY` = '-2401.981', `spawn_positionZ` = '-55.601' WHERE (`spawn_id` = '17194'); 
         -- Small Thorium Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10926.867', `spawn_positionY` = '-3526.492', `spawn_positionZ` = '47.292' WHERE (`spawn_id` = '40005'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-10926.867', `spawn_positionY` = '-3526.492', `spawn_positionZ` = '47.292' WHERE (`spawn_id` = '40005'); 
         -- Shaman Shrine ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '33369'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '33369'); 
         -- Solid Chest XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10860.763', `spawn_positionY` = '-3629.552', `spawn_positionZ` = '24.561' WHERE (`spawn_id` = '13978'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-10860.763', `spawn_positionY` = '-3629.552', `spawn_positionZ` = '24.561' WHERE (`spawn_id` = '13978'); 
         -- The Kaldorei and the Well of Eternity Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '17.073' WHERE (`spawn_id` = '14566'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '17.073' WHERE (`spawn_id` = '14566'); 
         -- Ooze Covered Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.949' WHERE (`spawn_id` = '15431'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '35.949' WHERE (`spawn_id` = '15431'); 
         -- Ooze Covered Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.364' WHERE (`spawn_id` = '15433'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '35.364' WHERE (`spawn_id` = '15433'); 
         -- Ooze Covered Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '42.721' WHERE (`spawn_id` = '15438'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '42.721' WHERE (`spawn_id` = '15438'); 
         -- Ooze Covered Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.375' WHERE (`spawn_id` = '15439'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '35.375' WHERE (`spawn_id` = '15439'); 
         -- Ooze Covered Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '31.316' WHERE (`spawn_id` = '15440'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '31.316' WHERE (`spawn_id` = '15440'); 
         -- Ooze Covered Mithril Deposit Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.569' WHERE (`spawn_id` = '15442'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '35.569' WHERE (`spawn_id` = '15442'); 
         -- Ooze Covered Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-328.398' WHERE (`spawn_id` = '15470'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-328.398' WHERE (`spawn_id` = '15470'); 
         -- Ooze Covered Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-323.104' WHERE (`spawn_id` = '15472'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-323.104' WHERE (`spawn_id` = '15472'); 
         -- Gorishi Hive Hatchery Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-329.91' WHERE (`spawn_id` = '50381'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-329.91' WHERE (`spawn_id` = '50381'); 
         -- Incendia Agave Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-41.855' WHERE (`spawn_id` = '16757'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-41.855' WHERE (`spawn_id` = '16757'); 
         -- Incendia Agave Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-52.562' WHERE (`spawn_id` = '16756'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-52.562' WHERE (`spawn_id` = '16756'); 
         -- Incendia Agave Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-36.947' WHERE (`spawn_id` = '16755'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-36.947' WHERE (`spawn_id` = '16755'); 
         -- Incendia Agave Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-52.341' WHERE (`spawn_id` = '16749'); 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.612' WHERE (`spawn_id` = '15866'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-52.341' WHERE (`spawn_id` = '16749'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '2.612' WHERE (`spawn_id` = '15866'); 
         -- Purple Lotus Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '115.526' WHERE (`spawn_id` = '15871'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '115.526' WHERE (`spawn_id` = '15871'); 
         -- Purple Lotus Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '109.631' WHERE (`spawn_id` = '15880'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '109.631' WHERE (`spawn_id` = '15880'); 
         -- Purple Lotus Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '154.385' WHERE (`spawn_id` = '15905'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '154.385' WHERE (`spawn_id` = '15905'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '71.571' WHERE (`spawn_id` = '15950'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '71.571' WHERE (`spawn_id` = '15950'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '64.133' WHERE (`spawn_id` = '15951'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '64.133' WHERE (`spawn_id` = '15951'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '64.789' WHERE (`spawn_id` = '15963'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '64.789' WHERE (`spawn_id` = '15963'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.439' WHERE (`spawn_id` = '15966'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '61.439' WHERE (`spawn_id` = '15966'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '57.21' WHERE (`spawn_id` = '15967'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '57.21' WHERE (`spawn_id` = '15967'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '78.472' WHERE (`spawn_id` = '15968'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '78.472' WHERE (`spawn_id` = '15968'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '64.125' WHERE (`spawn_id` = '15971'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '64.125' WHERE (`spawn_id` = '15971'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '63.122' WHERE (`spawn_id` = '15975'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '63.122' WHERE (`spawn_id` = '15975'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '64.415' WHERE (`spawn_id` = '15980'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '64.415' WHERE (`spawn_id` = '15980'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '63.338' WHERE (`spawn_id` = '15987'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '63.338' WHERE (`spawn_id` = '15987'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '63.555' WHERE (`spawn_id` = '15990'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '63.555' WHERE (`spawn_id` = '15990'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '59.306' WHERE (`spawn_id` = '15992'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '59.306' WHERE (`spawn_id` = '15992'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '59.683' WHERE (`spawn_id` = '15994'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '59.683' WHERE (`spawn_id` = '15994'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '72.59' WHERE (`spawn_id` = '16007'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '72.59' WHERE (`spawn_id` = '16007'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '62.882' WHERE (`spawn_id` = '16019'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '62.882' WHERE (`spawn_id` = '16019'); 
         -- Arthas' Tears Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '71.456' WHERE (`spawn_id` = '16022'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '71.456' WHERE (`spawn_id` = '16022'); 
         -- Sungrass Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '60.102' WHERE (`spawn_id` = '16063'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '60.102' WHERE (`spawn_id` = '16063'); 
         -- Sungrass Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '120.1' WHERE (`spawn_id` = '16087'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '120.1' WHERE (`spawn_id` = '16087'); 
         -- Sungrass Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '120.834' WHERE (`spawn_id` = '16079'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '120.834' WHERE (`spawn_id` = '16079'); 
         -- Sungrass Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-2.065' WHERE (`spawn_id` = '16098'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-2.065' WHERE (`spawn_id` = '16098'); 
         -- Sungrass Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.145' WHERE (`spawn_id` = '16098'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-1.145' WHERE (`spawn_id` = '16098'); 
         -- Sungrass Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '119.111' WHERE (`spawn_id` = '16109'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '119.111' WHERE (`spawn_id` = '16109'); 
         -- Sungrass Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '117.854' WHERE (`spawn_id` = '16116'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '117.854' WHERE (`spawn_id` = '16116'); 
         -- Sungrass Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '124.133' WHERE (`spawn_id` = '16121'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '124.133' WHERE (`spawn_id` = '16121'); 
         -- Sungrass Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '122.78' WHERE (`spawn_id` = '16125'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '122.78' WHERE (`spawn_id` = '16125'); 
         -- Sungrass Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '122.385' WHERE (`spawn_id` = '16144'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '122.385' WHERE (`spawn_id` = '16144'); 
         -- Sungrass Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '71.551' WHERE (`spawn_id` = '16205'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '71.551' WHERE (`spawn_id` = '16205'); 
         -- Ghost Mushroom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '153.402' WHERE (`spawn_id` = '16417'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '153.402' WHERE (`spawn_id` = '16417'); 
         -- Ghost Mushroom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '355.608', `spawn_positionY` = '-3752.967', `spawn_positionZ` = '135.822' WHERE (`spawn_id` = '16418'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '355.608', `spawn_positionY` = '-3752.967', `spawn_positionZ` = '135.822' WHERE (`spawn_id` = '16418'); 
         -- Ghost Mushroom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '329.565', `spawn_positionY` = '-3821.0', `spawn_positionZ` = '142.901' WHERE (`spawn_id` = '16419'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '329.565', `spawn_positionY` = '-3821.0', `spawn_positionZ` = '142.901' WHERE (`spawn_id` = '16419'); 
         -- Ghost Mushroom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '126.081' WHERE (`spawn_id` = '16421'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '126.081' WHERE (`spawn_id` = '16421'); 
         -- Ghost Mushroom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '353.627', `spawn_positionY` = '-3779.0', `spawn_positionZ` = '148.453' WHERE (`spawn_id` = '16422'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '353.627', `spawn_positionY` = '-3779.0', `spawn_positionZ` = '148.453' WHERE (`spawn_id` = '16422'); 
         -- Ghost Mushroom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '378.796', `spawn_positionY` = '-3797.707', `spawn_positionZ` = '154.722' WHERE (`spawn_id` = '16423'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '378.796', `spawn_positionY` = '-3797.707', `spawn_positionZ` = '154.722' WHERE (`spawn_id` = '16423'); 
         -- Ghost Mushroom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '312.829', `spawn_positionY` = '-3810.0', `spawn_positionZ` = '137.854' WHERE (`spawn_id` = '16424'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '312.829', `spawn_positionY` = '-3810.0', `spawn_positionZ` = '137.854' WHERE (`spawn_id` = '16424'); 
         -- Ghost Mushroom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '388.011', `spawn_positionY` = '-3733.0', `spawn_positionZ` = '126.703' WHERE (`spawn_id` = '16426'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '388.011', `spawn_positionY` = '-3733.0', `spawn_positionZ` = '126.703' WHERE (`spawn_id` = '16426'); 
         -- Ghost Mushroom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '363.497', `spawn_positionY` = '-3722.528', `spawn_positionZ` = '123.33' WHERE (`spawn_id` = '16430'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '363.497', `spawn_positionY` = '-3722.528', `spawn_positionZ` = '123.33' WHERE (`spawn_id` = '16430'); 
         -- Ghost Mushroom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '337.574', `spawn_positionY` = '-3889.219', `spawn_positionZ` = '119.72' WHERE (`spawn_id` = '16431'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '337.574', `spawn_positionY` = '-3889.219', `spawn_positionZ` = '119.72' WHERE (`spawn_id` = '16431'); 
         -- Ghost Mushroom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '373.483', `spawn_positionY` = '-3757.0', `spawn_positionZ` = '148.096' WHERE (`spawn_id` = '16433'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '373.483', `spawn_positionY` = '-3757.0', `spawn_positionZ` = '148.096' WHERE (`spawn_id` = '16433'); 
         -- Ghost Mushroom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '405.255', `spawn_positionY` = '-3744.617', `spawn_positionZ` = '116.589' WHERE (`spawn_id` = '16434'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '405.255', `spawn_positionY` = '-3744.617', `spawn_positionZ` = '116.589' WHERE (`spawn_id` = '16434'); 
         -- Ghost Mushroom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '432.341', `spawn_positionY` = '-3800.962', `spawn_positionZ` = '114.644' WHERE (`spawn_id` = '16437'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '432.341', `spawn_positionY` = '-3800.962', `spawn_positionZ` = '114.644' WHERE (`spawn_id` = '16437'); 
         -- Ghost Mushroom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '352.612', `spawn_positionY` = '-3820.737', `spawn_positionZ` = '104.034' WHERE (`spawn_id` = '16438'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '352.612', `spawn_positionY` = '-3820.737', `spawn_positionZ` = '104.034' WHERE (`spawn_id` = '16438'); 
         -- Ghost Mushroom XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '372.982', `spawn_positionY` = '-3784.0', `spawn_positionZ` = '154.539' WHERE (`spawn_id` = '16442'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '372.982', `spawn_positionY` = '-3784.0', `spawn_positionZ` = '154.539' WHERE (`spawn_id` = '16442'); 
         -- Ghost Mushroom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '121.689' WHERE (`spawn_id` = '16448'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '121.689' WHERE (`spawn_id` = '16448'); 
         -- Gromsblood Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.918' WHERE (`spawn_id` = '16454'); 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '5.042' WHERE (`spawn_id` = '16541'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '61.918' WHERE (`spawn_id` = '16454'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '5.042' WHERE (`spawn_id` = '16541'); 
         -- Gromsblood Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '567.981' WHERE (`spawn_id` = '16543'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '567.981' WHERE (`spawn_id` = '16543'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14344'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14344'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14345'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14345'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14343'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14343'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14342'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14342'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14341'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14341'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14340'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14340'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14339'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14339'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14338'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14338'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14337'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14337'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '16614'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '16614'); 
         -- Stranglekelp ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15761'); 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '23.918' WHERE (`spawn_id` = '15753'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15761'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '23.918' WHERE (`spawn_id` = '15753'); 
         --  Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '96.532' WHERE (`spawn_id` = '15725'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '96.532' WHERE (`spawn_id` = '15725'); 
         --  Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '62.411' WHERE (`spawn_id` = '15723'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '62.411' WHERE (`spawn_id` = '15723'); 
         -- The Punisher (DND) ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15705'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15705'); 
         -- Buccaneer's Strongbox ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15702'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15702'); 
         -- Tin Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.305' WHERE (`spawn_id` = '15688'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '94.305' WHERE (`spawn_id` = '15688'); 
         -- Grim Batol Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '19.059' WHERE (`spawn_id` = '13764'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '19.059' WHERE (`spawn_id` = '13764'); 
         -- Buccaneer's Strongbox ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15683'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15683'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '96.629' WHERE (`spawn_id` = '15676'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '96.629' WHERE (`spawn_id` = '15676'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1975.0', `spawn_positionY` = '-3290.534', `spawn_positionZ` = '70.921' WHERE (`spawn_id` = '15675'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1975.0', `spawn_positionY` = '-3290.534', `spawn_positionZ` = '70.921' WHERE (`spawn_id` = '15675'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '69.406' WHERE (`spawn_id` = '15675'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '69.406' WHERE (`spawn_id` = '15675'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1348.71', `spawn_positionY` = '-2963.96', `spawn_positionZ` = '101.549' WHERE (`spawn_id` = '15496'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-1348.71', `spawn_positionY` = '-2963.96', `spawn_positionZ` = '101.549' WHERE (`spawn_id` = '15496'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '100.936' WHERE (`spawn_id` = '15496'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '100.936' WHERE (`spawn_id` = '15496'); 
         -- Copper Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2041.03', `spawn_positionY` = '-3471.56', `spawn_positionZ` = '35.338' WHERE (`spawn_id` = '15495'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-2041.03', `spawn_positionY` = '-3471.56', `spawn_positionZ` = '35.338' WHERE (`spawn_id` = '15495'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.748' WHERE (`spawn_id` = '15495'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '34.748' WHERE (`spawn_id` = '15495'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '15150'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '15150'); 
         -- Buccaneer's Strongbox ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15145'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15145'); 
         -- Copper Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '60.775' WHERE (`spawn_id` = '15135'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '60.775' WHERE (`spawn_id` = '15135'); 
         -- Buccaneer's Strongbox ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15125'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15125'); 
         -- Buccaneer's Strongbox ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15123'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15123'); 
         -- Buccaneer's Strongbox ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15122'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15122'); 
         -- Buccaneer's Strongbox ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15121'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15121'); 
         -- Buccaneer's Strongbox ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15120'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15120'); 
         -- Buccaneer's Strongbox ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15119'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15119'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13184'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13184'); 
         -- Fiery Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13141'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13141'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13138'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13138'); 
         -- Fiery Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13129'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13129'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13128'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13128'); 
         -- Fiery Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13126'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13126'); 
         -- High Back Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13125'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13125'); 
         -- High Back Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13124'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13124'); 
         -- Campfire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.994' WHERE (`spawn_id` = '14846'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.994' WHERE (`spawn_id` = '14846'); 
         -- Anvil ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14774'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14774'); 
         --  ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14681'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14681'); 
         -- Cauldron ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14678'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14678'); 
         --  ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14677'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14677'); 
         --  ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14642'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14642'); 
         --  ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14639'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14639'); 
         --  ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14637'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14637'); 
         -- Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14598'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14598'); 
         -- Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14596'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14596'); 
         -- Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14594'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14594'); 
         -- Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14542'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14542'); 
         -- Stove ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14519'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14519'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14197'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14197'); 
         -- Archimonde's Return and the Flight to Kalimdor Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.557' WHERE (`spawn_id` = '13594'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '4.557' WHERE (`spawn_id` = '13594'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13592'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13592'); 
         -- Miblon's Door Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.847' WHERE (`spawn_id` = '17428'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '36.847' WHERE (`spawn_id` = '17428'); 
         -- The New Horde Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.492' WHERE (`spawn_id` = '13538'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '33.492' WHERE (`spawn_id` = '13538'); 
         -- Lethargy of the Orcs Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '32.751' WHERE (`spawn_id` = '13535'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '32.751' WHERE (`spawn_id` = '13535'); 
         -- Master Control Program Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.572' WHERE (`spawn_id` = '13531'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '2.572' WHERE (`spawn_id` = '13531'); 
         -- Bonfire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '45.576' WHERE (`spawn_id` = '13526'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '45.576' WHERE (`spawn_id` = '13526'); 
         -- War of the Three Hammers Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '108.909' WHERE (`spawn_id` = '13514'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '108.909' WHERE (`spawn_id` = '13514'); 
         -- Fierce Blaze Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.956' WHERE (`spawn_id` = '13512'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '93.956' WHERE (`spawn_id` = '13512'); 
         -- Barrel of Milk Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '13510'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '13510'); 
         -- Barrel of Milk Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.02' WHERE (`spawn_id` = '13501'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '92.02' WHERE (`spawn_id` = '13501'); 
         -- Ironforge - the Awakening of the Dwarves Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '118.077' WHERE (`spawn_id` = '13496'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '118.077' WHERE (`spawn_id` = '13496'); 
         -- Crude Brazier Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '98.811' WHERE (`spawn_id` = '13491'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '98.811' WHERE (`spawn_id` = '13491'); 
         -- Burning Embers Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.411' WHERE (`spawn_id` = '13475'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '92.411' WHERE (`spawn_id` = '13475'); 
         -- Crude Brazier Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '135.031' WHERE (`spawn_id` = '13474'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '135.031' WHERE (`spawn_id` = '13474'); 
         -- Campfire ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13473'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13473'); 
         -- Crude Brazier XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-595.49', `spawn_positionY` = '-3170.718', `spawn_positionZ` = '92.897' WHERE (`spawn_id` = '13470'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-595.49', `spawn_positionY` = '-3170.718', `spawn_positionZ` = '92.897' WHERE (`spawn_id` = '13470'); 
         -- Campfire ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13469'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13469'); 
         -- Exile of the High Elves Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '24.83' WHERE (`spawn_id` = '13468'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '24.83' WHERE (`spawn_id` = '13468'); 
         -- Crude Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13465'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13465'); 
         -- Crude Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13463'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13463'); 
         -- Crude Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13459'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13459'); 
         -- Crude Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13456'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13456'); 
         -- Crude Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13453'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13453'); 
         -- Crude Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13450'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13450'); 
         -- Food Crate XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '1247.18', `spawn_positionY` = '-3604.149', `spawn_positionZ` = '114.297' WHERE (`spawn_id` = '13448'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '1247.18', `spawn_positionY` = '-3604.149', `spawn_positionZ` = '114.297' WHERE (`spawn_id` = '13448'); 
         -- Gallywix's Lockbox Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '13434'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '13434'); 
         -- Bench Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '27.43' WHERE (`spawn_id` = '13406'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '27.43' WHERE (`spawn_id` = '13406'); 
         -- Stolen Silver ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13405'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13405'); 
         -- Bench Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '27.45' WHERE (`spawn_id` = '13399'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '27.45' WHERE (`spawn_id` = '13399'); 
         -- Bench Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.696' WHERE (`spawn_id` = '13397'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.696' WHERE (`spawn_id` = '13397'); 
         -- Bench Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.79' WHERE (`spawn_id` = '13394'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.79' WHERE (`spawn_id` = '13394'); 
         -- Wild Steelbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.683' WHERE (`spawn_id` = '13366'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '36.683' WHERE (`spawn_id` = '13366'); 
         -- Forge Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.129' WHERE (`spawn_id` = '13360'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '14.129' WHERE (`spawn_id` = '13360'); 
         -- Common Magebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '65.684' WHERE (`spawn_id` = '13358'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '65.684' WHERE (`spawn_id` = '13358'); 
         -- Anvil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '13.37' WHERE (`spawn_id` = '13356'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '13.37' WHERE (`spawn_id` = '13356'); 
         -- Nijel's Point Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '89.49' WHERE (`spawn_id` = '30226'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '89.49' WHERE (`spawn_id` = '30226'); 
         -- Anvil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '13.679' WHERE (`spawn_id` = '13354'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '13.679' WHERE (`spawn_id` = '13354'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13353'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13353'); 
         -- Anvil ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13352'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13352'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13351'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13351'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13350'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13350'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.129' WHERE (`spawn_id` = '13344'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '26.129' WHERE (`spawn_id` = '13344'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '16.967' WHERE (`spawn_id` = '13343'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '16.967' WHERE (`spawn_id` = '13343'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '65.368' WHERE (`spawn_id` = '13342'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '65.368' WHERE (`spawn_id` = '13342'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '69.855' WHERE (`spawn_id` = '13341'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '69.855' WHERE (`spawn_id` = '13341'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '49.643' WHERE (`spawn_id` = '13340'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '49.643' WHERE (`spawn_id` = '13340'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '40.758' WHERE (`spawn_id` = '13337'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '40.758' WHERE (`spawn_id` = '13337'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.134' WHERE (`spawn_id` = '13336'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '21.134' WHERE (`spawn_id` = '13336'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '75.836' WHERE (`spawn_id` = '13335'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '75.836' WHERE (`spawn_id` = '13335'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '57.878' WHERE (`spawn_id` = '13334'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '57.878' WHERE (`spawn_id` = '13334'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '66.371' WHERE (`spawn_id` = '13333'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '66.371' WHERE (`spawn_id` = '13333'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.526' WHERE (`spawn_id` = '13332'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '26.526' WHERE (`spawn_id` = '13332'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '51.573' WHERE (`spawn_id` = '13331'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '51.573' WHERE (`spawn_id` = '13331'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '51.012' WHERE (`spawn_id` = '13330'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '51.012' WHERE (`spawn_id` = '13330'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '43.784' WHERE (`spawn_id` = '13329'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '43.784' WHERE (`spawn_id` = '13329'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '22.152' WHERE (`spawn_id` = '13328'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '22.152' WHERE (`spawn_id` = '13328'); 
         -- Burning Embers Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '13326'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '13326'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13325'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13325'); 
         -- Food Crate ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13319'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13319'); 
         -- Gallywix's Lockbox Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '13316'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '13316'); 
         -- Warm Fire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.836' WHERE (`spawn_id` = '13313'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.836' WHERE (`spawn_id` = '13313'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13312'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13312'); 
         -- Warm Fire Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.683' WHERE (`spawn_id` = '13308'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.683' WHERE (`spawn_id` = '13308'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13307'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13307'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13302'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13302'); 
         -- Anvil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.229' WHERE (`spawn_id` = '13301'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '92.229' WHERE (`spawn_id` = '13301'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13299'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13299'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13294'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13294'); 
         -- The Jewel of the Southsea ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13293'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13293'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.129' WHERE (`spawn_id` = '13290'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '26.129' WHERE (`spawn_id` = '13290'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '16.967' WHERE (`spawn_id` = '13277'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '16.967' WHERE (`spawn_id` = '13277'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '65.368' WHERE (`spawn_id` = '13276'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '65.368' WHERE (`spawn_id` = '13276'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '69.747' WHERE (`spawn_id` = '13275'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '69.747' WHERE (`spawn_id` = '13275'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '49.643' WHERE (`spawn_id` = '13274'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '49.643' WHERE (`spawn_id` = '13274'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '40.758' WHERE (`spawn_id` = '13273'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '40.758' WHERE (`spawn_id` = '13273'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.134' WHERE (`spawn_id` = '13272'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '21.134' WHERE (`spawn_id` = '13272'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '75.836' WHERE (`spawn_id` = '13271'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '75.836' WHERE (`spawn_id` = '13271'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '57.878' WHERE (`spawn_id` = '13270'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '57.878' WHERE (`spawn_id` = '13270'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '66.371' WHERE (`spawn_id` = '13269'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '66.371' WHERE (`spawn_id` = '13269'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.526' WHERE (`spawn_id` = '13268'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '26.526' WHERE (`spawn_id` = '13268'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '51.573' WHERE (`spawn_id` = '13267'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '51.573' WHERE (`spawn_id` = '13267'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '51.011' WHERE (`spawn_id` = '13266'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '51.011' WHERE (`spawn_id` = '13266'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '43.784' WHERE (`spawn_id` = '13265'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '43.784' WHERE (`spawn_id` = '13265'); 
         -- Serpentbloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '22.152' WHERE (`spawn_id` = '13264'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '22.152' WHERE (`spawn_id` = '13264'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13262'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13262'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13258'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13258'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13257'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13257'); 
         -- Kolkars' Booty ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13253'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13253'); 
         -- Laden Mushroom ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13198'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13198'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13183'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13183'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13172'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13172'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13169'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13169'); 
         -- Kolkar's Booty ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13162'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13162'); 
         -- Cannon ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13153'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13153'); 
         -- Cannon ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13149'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13149'); 
         -- Cannon ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13130'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13130'); 
         -- Battered Chest XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6008.708', `spawn_positionY` = '-2972.425', `spawn_positionZ` = '402.824' WHERE (`spawn_id` = '13209'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-6008.708', `spawn_positionY` = '-2972.425', `spawn_positionZ` = '402.824' WHERE (`spawn_id` = '13209'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13122'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13122'); 
         -- Tin Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6048.852', `spawn_positionY` = '-2798.129', `spawn_positionZ` = '392.479' WHERE (`spawn_id` = '12860'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-6048.852', `spawn_positionY` = '-2798.129', `spawn_positionZ` = '392.479' WHERE (`spawn_id` = '12860'); 
         -- Tin Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '391.79' WHERE (`spawn_id` = '12860'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '391.79' WHERE (`spawn_id` = '12860'); 
         -- Barrel of Milk XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6024.201', `spawn_positionY` = '-2801.919', `spawn_positionZ` = '386.121' WHERE (`spawn_id` = '12801'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-6024.201', `spawn_positionY` = '-2801.919', `spawn_positionZ` = '386.121' WHERE (`spawn_id` = '12801'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13123'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13123'); 
         -- Cannon ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13082'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13082'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13081'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13081'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13065'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13065'); 
         -- Kolkar's Booty Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '97.756' WHERE (`spawn_id` = '13061'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '97.756' WHERE (`spawn_id` = '13061'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13039'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13039'); 
         -- Stonetalon Mountains Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '89.488' WHERE (`spawn_id` = '30232'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '89.488' WHERE (`spawn_id` = '30232'); 
         -- Bonfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12961'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12961'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12945'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12945'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '12940'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '12940'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.836' WHERE (`spawn_id` = '12939'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.836' WHERE (`spawn_id` = '12939'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.683' WHERE (`spawn_id` = '12938'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '91.683' WHERE (`spawn_id` = '12938'); 
         -- Campfire Damage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.411' WHERE (`spawn_id` = '12937'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '92.411' WHERE (`spawn_id` = '12937'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12933'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12933'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12931'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12931'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12930'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12930'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12928'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12928'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12857'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12857'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12854'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12854'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12853'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12853'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12852'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12852'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12850'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12850'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12849'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12849'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12835'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12835'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12711'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12711'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12710'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12710'); 
         -- Ironzar's Imported Weaponry ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12708'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12708'); 
         -- Anvil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.297' WHERE (`spawn_id` = '12705'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '14.297' WHERE (`spawn_id` = '12705'); 
         -- Jazzik's General Goods ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12704'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12704'); 
         -- Damaged Chest XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4926.41', `spawn_positionY` = '-2345.391', `spawn_positionZ` = '-49.869' WHERE (`spawn_id` = '12699'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4926.41', `spawn_positionY` = '-2345.391', `spawn_positionZ` = '-49.869' WHERE (`spawn_id` = '12699'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12691'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12691'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12669'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12669'); 
         -- Taillasher Eggs Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.932' WHERE (`spawn_id` = '12623'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '3.932' WHERE (`spawn_id` = '12623'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13072'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13072'); 
         -- Rich Thorium Vein ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18384'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18384'); 
         -- Rich Thorium Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-223.106' WHERE (`spawn_id` = '18424'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-223.106' WHERE (`spawn_id` = '18424'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13070'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13070'); 
         -- Gold Vein XYZ placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-236.393', `spawn_positionY` = '-370.875', `spawn_positionZ` = '69.721' WHERE (`spawn_id` = '33196'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-236.393', `spawn_positionY` = '-370.875', `spawn_positionZ` = '69.721' WHERE (`spawn_id` = '33196'); 
         -- Gold Vein Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '68.876' WHERE (`spawn_id` = '33196'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '68.876' WHERE (`spawn_id` = '33196'); 
         -- Fiery Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13069'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13069'); 
         -- Water Barrel Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.252' WHERE (`spawn_id` = '12498'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '1.252' WHERE (`spawn_id` = '12498'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13025'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13025'); 
         -- Fiery Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13023'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13023'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13021'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13021'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13020'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13020'); 
         -- Fiery Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13018'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13018'); 
         -- High Back Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13013'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13013'); 
         -- Potbelly Stove ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13009'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13009'); 
         -- High Back Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13007'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13007'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13004'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13004'); 
         -- Campfire Damage ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13001'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13001'); 
         -- Fiery Brazier ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13000'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13000'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12997');         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12996'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12997');         -- Wooden Chair ignored, out of reach. 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12996'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12988'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12988'); 
         -- High Back Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12925'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12925'); 
         -- High Back Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12924'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12924'); 
         -- High Back Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12922'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12922'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12912'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12912'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12911'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12911'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12908'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12908'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12907'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12907'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12897'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12897'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12896'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12896'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12895'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12895'); 
         -- Gnomish Toolbox Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-14.262' WHERE (`spawn_id` = '12422'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '-14.262' WHERE (`spawn_id` = '12422'); 
         -- Food Crate Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.854' WHERE (`spawn_id` = '12392');         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12889'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '26.854' WHERE (`spawn_id` = '12392');         -- Wooden Chair ignored, out of reach. 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12889'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12886'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12886'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12884'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12884'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12881'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12881'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12879'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12879'); 
         -- Wooden Chair ignored, out of reach. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12878'); 
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12878'); 
         -- Golden Sansam Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.8' WHERE (`spawn_id` = '18972'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '0.8' WHERE (`spawn_id` = '18972'); 
         -- Golden Sansam Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.886' WHERE (`spawn_id` = '19004'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '2.886' WHERE (`spawn_id` = '19004'); 
         -- Golden Sansam Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.886' WHERE (`spawn_id` = '19004'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '2.886' WHERE (`spawn_id` = '19004'); 
         -- Golden Sansam Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '117.873' WHERE (`spawn_id` = '19093'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '117.873' WHERE (`spawn_id` = '19093'); 
         -- Golden Sansam Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '65.504' WHERE (`spawn_id` = '19173'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '65.504' WHERE (`spawn_id` = '19173'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '118.658' WHERE (`spawn_id` = '19287'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '118.658' WHERE (`spawn_id` = '19287'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '60.256' WHERE (`spawn_id` = '19311'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '60.256' WHERE (`spawn_id` = '19311'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '64.248' WHERE (`spawn_id` = '19332'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '64.248' WHERE (`spawn_id` = '19332'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.076' WHERE (`spawn_id` = '19333'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '61.076' WHERE (`spawn_id` = '19333'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '63.923' WHERE (`spawn_id` = '19359'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '63.923' WHERE (`spawn_id` = '19359'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '128.284' WHERE (`spawn_id` = '19363'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '128.284' WHERE (`spawn_id` = '19363'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '128.454' WHERE (`spawn_id` = '19364'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '128.454' WHERE (`spawn_id` = '19364'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '62.483' WHERE (`spawn_id` = '19489'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '62.483' WHERE (`spawn_id` = '19489'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '60.426' WHERE (`spawn_id` = '19490'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '60.426' WHERE (`spawn_id` = '19490'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.284' WHERE (`spawn_id` = '19560'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '0.284' WHERE (`spawn_id` = '19560'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.801' WHERE (`spawn_id` = '19592'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '0.801' WHERE (`spawn_id` = '19592'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.201' WHERE (`spawn_id` = '19608'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '0.201' WHERE (`spawn_id` = '19608'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.781' WHERE (`spawn_id` = '19612'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '61.781' WHERE (`spawn_id` = '19612'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '63.534' WHERE (`spawn_id` = '19632'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '63.534' WHERE (`spawn_id` = '19632'); 
         -- Dreamfoil Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.085' WHERE (`spawn_id` = '19656'); 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '106.304' WHERE (`spawn_id` = '19713'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '4.085' WHERE (`spawn_id` = '19656'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '106.304' WHERE (`spawn_id` = '19713'); 
         -- Mountain Silversage Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '140.878' WHERE (`spawn_id` = '19736'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '140.878' WHERE (`spawn_id` = '19736'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '80.112' WHERE (`spawn_id` = '19882'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '80.112' WHERE (`spawn_id` = '19882'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '84.089' WHERE (`spawn_id` = '19883'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '84.089' WHERE (`spawn_id` = '19883'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '82.082' WHERE (`spawn_id` = '19884'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '82.082' WHERE (`spawn_id` = '19884'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '129.702' WHERE (`spawn_id` = '19893'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '129.702' WHERE (`spawn_id` = '19893'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.77' WHERE (`spawn_id` = '19895'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '61.77' WHERE (`spawn_id` = '19895'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '63.511' WHERE (`spawn_id` = '19911'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '63.511' WHERE (`spawn_id` = '19911'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '81.348' WHERE (`spawn_id` = '19912'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '81.348' WHERE (`spawn_id` = '19912'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '83.893' WHERE (`spawn_id` = '19913'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '83.893' WHERE (`spawn_id` = '19913'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '62.793' WHERE (`spawn_id` = '19916'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '62.793' WHERE (`spawn_id` = '19916'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '102.343' WHERE (`spawn_id` = '19920'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '102.343' WHERE (`spawn_id` = '19920'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.37' WHERE (`spawn_id` = '19940'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '61.37' WHERE (`spawn_id` = '19940'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '78.101' WHERE (`spawn_id` = '19942'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '78.101' WHERE (`spawn_id` = '19942'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.924' WHERE (`spawn_id` = '19944'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '61.924' WHERE (`spawn_id` = '19944'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '66.533' WHERE (`spawn_id` = '19975'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '66.533' WHERE (`spawn_id` = '19975'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '102.31' WHERE (`spawn_id` = '19996'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '102.31' WHERE (`spawn_id` = '19996'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.002' WHERE (`spawn_id` = '19999'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '61.002' WHERE (`spawn_id` = '19999'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '60.707' WHERE (`spawn_id` = '20001'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '60.707' WHERE (`spawn_id` = '20001'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '62.044' WHERE (`spawn_id` = '20002'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '62.044' WHERE (`spawn_id` = '20002'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '137.031' WHERE (`spawn_id` = '20004'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '137.031' WHERE (`spawn_id` = '20004'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '80.968' WHERE (`spawn_id` = '20028'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '80.968' WHERE (`spawn_id` = '20028'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '129.097' WHERE (`spawn_id` = '20031'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '129.097' WHERE (`spawn_id` = '20031'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '101.295' WHERE (`spawn_id` = '20035'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '101.295' WHERE (`spawn_id` = '20035'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '126.042' WHERE (`spawn_id` = '20045'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '126.042' WHERE (`spawn_id` = '20045'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '129.752' WHERE (`spawn_id` = '20062'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '129.752' WHERE (`spawn_id` = '20062'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '136.219' WHERE (`spawn_id` = '20094'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '136.219' WHERE (`spawn_id` = '20094'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '82.372' WHERE (`spawn_id` = '20108'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '82.372' WHERE (`spawn_id` = '20108'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '135.51' WHERE (`spawn_id` = '20124'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '135.51' WHERE (`spawn_id` = '20124'); 
         -- Plaguebloom Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '103.504' WHERE (`spawn_id` = '20133'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '103.504' WHERE (`spawn_id` = '20133'); 
         -- Khadgar's Whisker Z placement. 
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '120.328' WHERE (`spawn_id` = '34961'); 
+        UPDATE `spawns_gameobjects` SET `spawn_positionZ` = '120.328' WHERE (`spawn_id` = '34961'); 
 
         insert into applied_updates values ('190120221');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -17,13 +17,63 @@ begin not atomic
 	
     -- 19/01/2022 1
     if (select count(*) from applied_updates where id='190120221') = 0 then
+        -- Webwood Eggs proper placement.
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10874.13', `spawn_positionY` = '923.626', `spawn_positionZ` = '1317.481' WHERE (`spawn_id` = '49589');
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10874.27', `spawn_positionY` = '917.391', `spawn_positionZ` = '1317.544' WHERE (`spawn_id` = '49590');
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10881.17', `spawn_positionY` = '914.299', `spawn_positionZ` = '1317.358' WHERE (`spawn_id` = '49591');
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10896.01', `spawn_positionY` = '920.324', `spawn_positionZ` = '1319.054' WHERE (`spawn_id` = '49593');
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10900.56', `spawn_positionY` = '920.812', `spawn_positionZ` = '1319.237' WHERE (`spawn_id` = '49595');
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10903.92', `spawn_positionY` = '927.207', `spawn_positionZ` = '1319.866' WHERE (`spawn_id` = '49596');
-		
+	
+        -- Fix Webwood Spiders wrong Z.
+        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1334.94' WHERE (`spawn_id` = '47061');
+        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1335.55' WHERE (`spawn_id` = '47249');
+        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1335.60' WHERE (`spawn_id` = '47003');
+        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1336.16' WHERE (`spawn_id` = '47002');
+        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1332.67' WHERE (`spawn_id` = '47017');
+        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1326.44' WHERE (`spawn_id` = '47018');
+        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1321.23' WHERE (`spawn_id` = '47023');
+        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1319.51' WHERE (`spawn_id` = '47056');
+
+        -- Ignore Webwood Spiders that have wrong placement in 0.5.3. (Out of reach)
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46958');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46971');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46972');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46974');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46981');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46997');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46998');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46999');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47000');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47001');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47004');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47006');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47008');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47009');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47010');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47012');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47016');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47021');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47029');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47030');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47031');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47037');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47038');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47039');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47052');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47053');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47054');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47055');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47057');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47060');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47062');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47208');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47262');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47263');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47266');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47267');
+        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47268');
+
         insert into applied_updates values ('190120221');
     end if;
 end $

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -624,7 +624,7 @@ begin not atomic
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-55.438' WHERE (`spawn_id` = '3587'); 
         -- Bruiseweed Z placement. 
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '17.642' WHERE (`spawn_id` = '3597'); 
-		        -- Ruins of Stardust Fountain Z placement. 
+		-- Ruins of Stardust Fountain Z placement. 
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '97.061' WHERE (`spawn_id` = '99862'); 
         -- Atal'ai Artifact XYZ placement. 
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10525.458', `spawn_positionY` = '-3870.514', `spawn_positionZ` = '-17.858' WHERE (`spawn_id` = '30744'); 
@@ -844,7 +844,6 @@ begin not atomic
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '144.217' WHERE (`spawn_id` = '6220'); 
         -- Iron Deposit Z placement. 
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '6229'); 
-
         -- Iron Deposit Z placement. 
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '131.359' WHERE (`spawn_id` = '6241'); 
         -- Iron Deposit Z placement. 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -14,5 +14,17 @@ begin not atomic
 
         insert into applied_updates values ('270920211');
     end if;
+	
+    -- 19/01/2022 1
+    if (select count(*) from applied_updates where id='190120221') = 0 then
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10874.13', `spawn_positionY` = '923.626', `spawn_positionZ` = '1317.481' WHERE (`spawn_id` = '49589');
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10874.27', `spawn_positionY` = '917.391', `spawn_positionZ` = '1317.544' WHERE (`spawn_id` = '49590');
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10881.17', `spawn_positionY` = '914.299', `spawn_positionZ` = '1317.358' WHERE (`spawn_id` = '49591');
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10896.01', `spawn_positionY` = '920.324', `spawn_positionZ` = '1319.054' WHERE (`spawn_id` = '49593');
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10900.56', `spawn_positionY` = '920.812', `spawn_positionZ` = '1319.237' WHERE (`spawn_id` = '49595');
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '10903.92', `spawn_positionY` = '927.207', `spawn_positionZ` = '1319.866' WHERE (`spawn_id` = '49596');
+		
+        insert into applied_updates values ('190120221');
+    end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -624,6 +624,226 @@ begin not atomic
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-55.438' WHERE (`spawn_id` = '3587'); 
         -- Bruiseweed Z placement. 
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '17.642' WHERE (`spawn_id` = '3597'); 
+		        -- Ruins of Stardust Fountain Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '97.061' WHERE (`spawn_id` = '99862'); 
+        -- Atal'ai Artifact XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10525.458', `spawn_positionY` = '-3870.514', `spawn_positionZ` = '-17.858' WHERE (`spawn_id` = '30744'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '113.891' WHERE (`spawn_id` = '3665'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.934' WHERE (`spawn_id` = '3692'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.548' WHERE (`spawn_id` = '3732'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '17.187' WHERE (`spawn_id` = '3739'); 
+        -- Bruiseweed ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '3741'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-37.248' WHERE (`spawn_id` = '3787'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '23.175' WHERE (`spawn_id` = '3793'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.898' WHERE (`spawn_id` = '3854'); 
+        -- Wild Steelbloom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4286.811', `spawn_positionY` = '-2070.202', `spawn_positionZ` = '88.609' WHERE (`spawn_id` = '3923'); 
+        -- Wild Steelbloom ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '3968'); 
+        -- Wild Steelbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '98.374' WHERE (`spawn_id` = '3969'); 
+        -- Wild Steelbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '255.354' WHERE (`spawn_id` = '4005'); 
+        -- Wild Steelbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '18.871' WHERE (`spawn_id` = '4024'); 
+        -- Wild Steelbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '253.799' WHERE (`spawn_id` = '4025'); 
+        -- Wild Steelbloom ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '4045'); 
+        -- Wild Steelbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-20.385' WHERE (`spawn_id` = '4050'); 
+        -- Wild Steelbloom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3600.042', `spawn_positionY` = '-1762.24', `spawn_positionZ` = '139.489' WHERE (`spawn_id` = '4065'); 
+        -- Wild Steelbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '72.52' WHERE (`spawn_id` = '4090'); 
+        -- Wild Steelbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.071' WHERE (`spawn_id` = '4095'); 
+        -- Wild Steelbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '253.317' WHERE (`spawn_id` = '4216'); 
+        -- Wild Steelbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '95.741' WHERE (`spawn_id` = '4267'); 
+        -- Wild Steelbloom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2639.203', `spawn_positionY` = '-2318.273', `spawn_positionZ` = '91.608' WHERE (`spawn_id` = '4268'); 
+        -- Crownroyal Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '56.356' WHERE (`spawn_id` = '4294'); 
+        -- Crownroyal Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.98' WHERE (`spawn_id` = '4311'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.389' WHERE (`spawn_id` = '28518'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.116' WHERE (`spawn_id` = '18909'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.625' WHERE (`spawn_id` = '18890'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.81' WHERE (`spawn_id` = '18889'); 
+        -- Thornroot Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.744' WHERE (`spawn_id` = '44642'); 
+        -- Burning Embers Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '40718'); 
+        -- Warm Fire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '40716'); 
+        -- Warm Fire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.677' WHERE (`spawn_id` = '40715'); 
+        -- Campfire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '86.9' WHERE (`spawn_id` = '40714'); 
+        -- Bruiseweed Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '117.836' WHERE (`spawn_id` = '29658'); 
+        -- Alliance Chest Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.586' WHERE (`spawn_id` = '29650'); 
+        -- DANGER! Do Not Open! Move Along! Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.99' WHERE (`spawn_id` = '29645'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '32.669' WHERE (`spawn_id` = '4652'); 
+        -- Ironforge Main Gate ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '4691'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '4699'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '20.049' WHERE (`spawn_id` = '4711'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-55.161' WHERE (`spawn_id` = '4728'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.822' WHERE (`spawn_id` = '18888'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-46.288' WHERE (`spawn_id` = '4762'); 
+        -- Black Lotus Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '53.845' WHERE (`spawn_id` = '3998089'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '186.07' WHERE (`spawn_id` = '4766'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-22.613' WHERE (`spawn_id` = '4768'); 
+        -- Black Lotus Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.604' WHERE (`spawn_id` = '3998088'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '29.679' WHERE (`spawn_id` = '4799'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '249.881' WHERE (`spawn_id` = '4802'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '5.163' WHERE (`spawn_id` = '4807'); 
+        -- Black Lotus Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.561' WHERE (`spawn_id` = '3998085'); 
+        -- Black Lotus Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '7.22' WHERE (`spawn_id` = '3998084'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.841' WHERE (`spawn_id` = '4824'); 
+        -- Black Lotus Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.976' WHERE (`spawn_id` = '3998081'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '106.417' WHERE (`spawn_id` = '4898'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.014' WHERE (`spawn_id` = '4901'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '52.078' WHERE (`spawn_id` = '4936'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '4302.084', `spawn_positionY` = '943.749', `spawn_positionZ` = '52.078' WHERE (`spawn_id` = '4936'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '46.039' WHERE (`spawn_id` = '5031'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-13.056' WHERE (`spawn_id` = '5061'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '6805.169', `spawn_positionY` = '-679.499', `spawn_positionZ` = '97.658' WHERE (`spawn_id` = '5066'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '20.473' WHERE (`spawn_id` = '5361'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.049' WHERE (`spawn_id` = '5377'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.399' WHERE (`spawn_id` = '5421'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.118' WHERE (`spawn_id` = '5452'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '106.626' WHERE (`spawn_id` = '5464'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '45.543', `spawn_positionY` = '-1725.294', `spawn_positionZ` = '106.626' WHERE (`spawn_id` = '5464'); 
+        -- Tin Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8918.297', `spawn_positionY` = '-1945.519', `spawn_positionZ` = '134.216' WHERE (`spawn_id` = '5511'); 
+        -- Tin Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-809.262', `spawn_positionY` = '133.229', `spawn_positionZ` = '18.607' WHERE (`spawn_id` = '5514'); 
+        -- Egg of Onyxia Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.683' WHERE (`spawn_id` = '18887'); 
+        -- Tin Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '5.703' WHERE (`spawn_id` = '5559'); 
+        -- Tin Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.018' WHERE (`spawn_id` = '5561'); 
+        -- Tin Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '46.986' WHERE (`spawn_id` = '5633'); 
+        -- Tin Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8933.606', `spawn_positionY` = '-1977.563', `spawn_positionZ` = '133.189' WHERE (`spawn_id` = '5675'); 
+        -- Silver Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '164.403' WHERE (`spawn_id` = '5725'); 
+        -- Silver Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '158.827' WHERE (`spawn_id` = '5728'); 
+        -- Silver Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '18.83' WHERE (`spawn_id` = '5762'); 
+        -- Gold Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '65.865' WHERE (`spawn_id` = '5770'); 
+        -- Gold Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.513' WHERE (`spawn_id` = '5773'); 
+        -- Gold Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '1240.966', `spawn_positionY` = '-1257.593', `spawn_positionZ` = '43.924' WHERE (`spawn_id` = '5783'); 
+        -- Gold Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '5785'); 
+        -- Gold Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '140.666' WHERE (`spawn_id` = '5801'); 
+        -- Gold Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '46.276' WHERE (`spawn_id` = '5819'); 
+        -- Gold Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.676' WHERE (`spawn_id` = '5839'); 
+        -- Gold Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '73.703' WHERE (`spawn_id` = '5859'); 
+        -- Gold Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '50.96' WHERE (`spawn_id` = '5861'); 
+        -- Gold Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '1241.67', `spawn_positionY` = '-1272.324', `spawn_positionZ` = '43.074' WHERE (`spawn_id` = '5863'); 
+        -- Gold Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.716' WHERE (`spawn_id` = '5914'); 
+        -- Gold Vein ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '5959'); 
+        -- Gold Vein ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '5960'); 
+        -- Gold Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '5983'); 
+        -- Gold Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10969.125', `spawn_positionY` = '-3695.028', `spawn_positionZ` = '17.251' WHERE (`spawn_id` = '5995'); 
+        -- Gold Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '70.886' WHERE (`spawn_id` = '6000'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.834' WHERE (`spawn_id` = '6002'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '138.23' WHERE (`spawn_id` = '6019'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '116.027' WHERE (`spawn_id` = '6061'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '367.703' WHERE (`spawn_id` = '6076'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '25.39' WHERE (`spawn_id` = '6107'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '90.278' WHERE (`spawn_id` = '6127'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '12.037' WHERE (`spawn_id` = '6128'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '12.387' WHERE (`spawn_id` = '6147'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-42.434' WHERE (`spawn_id` = '6155'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-48.643' WHERE (`spawn_id` = '6157'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '58.518' WHERE (`spawn_id` = '6197'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5121.117', `spawn_positionY` = '1795.439', `spawn_positionZ` = '50.692' WHERE (`spawn_id` = '6199'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1452.101', `spawn_positionY` = '2943.731', `spawn_positionZ` = '136.712' WHERE (`spawn_id` = '6210'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '144.217' WHERE (`spawn_id` = '6220'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-58.75' WHERE (`spawn_id` = '6229'); 
 
         insert into applied_updates values ('190120221');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -73,6 +73,304 @@ begin not atomic
         UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47266');
         UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47267');
         UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47268');
+	
+        -- Small Thorium Vein ignored, out of reach.
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '132');
+        -- Small Thorium Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '53.964', `spawn_positionY` = '-4194.94', `spawn_positionZ` = '119.66' WHERE (`spawn_id` = '131');
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.767' WHERE (`spawn_id` = '136');
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.132' WHERE (`spawn_id` = '141');
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '480.185' WHERE (`spawn_id` = '144');
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '15.19' WHERE (`spawn_id` = '148');
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.39' WHERE (`spawn_id` = '152');
+        -- Quilboar Watering Hole placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '99864'); 
+        -- Alliance Chest ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '47590'); 
+        -- Alliance Chest ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '47589'); 
+        -- Dwarven Brazier Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.878' WHERE (`spawn_id` = '19'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.878' WHERE (`spawn_id` = '20'); 
+        -- Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '25.874' WHERE (`spawn_id` = '30737'); 
+        -- Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.126' WHERE (`spawn_id` = '30646'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '46'); 
+        -- No object template, set ignored.
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '52'); 
+        -- Dwarven Brazier Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '423.01' WHERE (`spawn_id` = '58'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '423.01' WHERE (`spawn_id` = '59'); 
+        -- Forge ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '47586'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '22.465' WHERE (`spawn_id` = '30591'); 
+        -- Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '20.76' WHERE (`spawn_id` = '30589'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '93'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '155.184' WHERE (`spawn_id` = '30035'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.14' WHERE (`spawn_id` = '136'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '65.924' WHERE (`spawn_id` = '156'); 
+        -- Small Thorium Vein ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '157'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-27.0' WHERE (`spawn_id` = '163'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '70.317' WHERE (`spawn_id` = '165'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '700.815' WHERE (`spawn_id` = '166'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '697.121' WHERE (`spawn_id` = '167'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.955' WHERE (`spawn_id` = '171'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '55.253' WHERE (`spawn_id` = '173'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '57.667' WHERE (`spawn_id` = '174'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '240.779' WHERE (`spawn_id` = '175'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '693.624' WHERE (`spawn_id` = '185'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '594.675' WHERE (`spawn_id` = '191'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '153.33' WHERE (`spawn_id` = '194'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.598' WHERE (`spawn_id` = '195'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '110.99' WHERE (`spawn_id` = '201'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '7.772' WHERE (`spawn_id` = '204'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-215.479' WHERE (`spawn_id` = '209'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '934.929' WHERE (`spawn_id` = '210'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.213' WHERE (`spawn_id` = '214'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '692.923' WHERE (`spawn_id` = '220'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '9.668' WHERE (`spawn_id` = '221'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '5.86' WHERE (`spawn_id` = '222'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '66.006' WHERE (`spawn_id` = '226'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '74.424' WHERE (`spawn_id` = '227'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '461.16' WHERE (`spawn_id` = '228'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '42.558' WHERE (`spawn_id` = '230'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '161.934' WHERE (`spawn_id` = '233'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '906.364' WHERE (`spawn_id` = '238'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '940.785' WHERE (`spawn_id` = '239'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '882.397' WHERE (`spawn_id` = '246'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '424.27' WHERE (`spawn_id` = '251'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.77' WHERE (`spawn_id` = '254'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '70.562' WHERE (`spawn_id` = '255'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.585' WHERE (`spawn_id` = '257'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '242.406' WHERE (`spawn_id` = '258'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '67.875' WHERE (`spawn_id` = '260'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '336.134' WHERE (`spawn_id` = '263'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.657' WHERE (`spawn_id` = '266'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '604.286' WHERE (`spawn_id` = '269'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.938' WHERE (`spawn_id` = '273'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '565.656' WHERE (`spawn_id` = '278'); 
+        -- Small Thorium Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6354.948', `spawn_positionY` = '-1878.964', `spawn_positionZ` = '-196.699' WHERE (`spawn_id` = '280'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-258.303' WHERE (`spawn_id` = '282'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '944.186' WHERE (`spawn_id` = '287'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.265' WHERE (`spawn_id` = '288'); 
+        -- Small Thorium Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '6417.55', `spawn_positionY` = '-4285.0', `spawn_positionZ` = '627.528' WHERE (`spawn_id` = '292'); 
+        -- Small Thorium Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '6417.55', `spawn_positionY` = '-4285.0', `spawn_positionZ` = '699.082' WHERE (`spawn_id` = '292'); 
+        -- Small Thorium Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '5765.252', `spawn_positionY` = '-4931.604', `spawn_positionZ` = '762.81' WHERE (`spawn_id` = '293'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-31.202' WHERE (`spawn_id` = '294'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '66.178' WHERE (`spawn_id` = '295'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '85.641' WHERE (`spawn_id` = '298'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-257.122' WHERE (`spawn_id` = '299'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '28.691' WHERE (`spawn_id` = '302'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '67.088' WHERE (`spawn_id` = '307'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '19.638' WHERE (`spawn_id` = '310'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '15.455' WHERE (`spawn_id` = '312'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '454.778' WHERE (`spawn_id` = '314'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-260.0' WHERE (`spawn_id` = '315'); 
+        -- Small Thorium Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-7212.61', `spawn_positionY` = '-2299.323', `spawn_positionZ` = '-253.81' WHERE (`spawn_id` = '317'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '75.38' WHERE (`spawn_id` = '328'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.836' WHERE (`spawn_id` = '335'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-264.636' WHERE (`spawn_id` = '338'); 
+        -- Small Thorium Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-7976.028', `spawn_positionY` = '-2348.022', `spawn_positionZ` = '-24.016' WHERE (`spawn_id` = '339'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '911.426' WHERE (`spawn_id` = '340'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.373' WHERE (`spawn_id` = '343'); 
+        -- Small Thorium Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10604.152', `spawn_positionY` = '-3387.443', `spawn_positionZ` = '39.09' WHERE (`spawn_id` = '344'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '941.338' WHERE (`spawn_id` = '348'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-243.0' WHERE (`spawn_id` = '353'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '792.443' WHERE (`spawn_id` = '358'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '144.124' WHERE (`spawn_id` = '361'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-244.884' WHERE (`spawn_id` = '367'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '71.464' WHERE (`spawn_id` = '368'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-269.5' WHERE (`spawn_id` = '374'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-205.952' WHERE (`spawn_id` = '377'); 
+        -- Small Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '789.403' WHERE (`spawn_id` = '384'); 
+        -- Solid Chest Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '52.58' WHERE (`spawn_id` = '30018'); 
+        -- Anvil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.676' WHERE (`spawn_id` = '47584'); 
+        -- Greatwood Vale Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '311.76' WHERE (`spawn_id` = '47583'); 
+        -- Campfire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.676' WHERE (`spawn_id` = '47582'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '63.369' WHERE (`spawn_id` = '29993'); 
+        -- Campfire XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '817.833', `spawn_positionY` = '945.833', `spawn_positionZ` = '94.343' WHERE (`spawn_id` = '47580'); 
+        -- TEMP Shadra'Alor Altar Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '87.223' WHERE (`spawn_id` = '99875'); 
+        -- Musty Tome Trap Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '71.66' WHERE (`spawn_id` = '12342'); 
+        -- Incendicite Mineral Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '168.787' WHERE (`spawn_id` = '443'); 
+        -- Incendicite Mineral Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '166.461' WHERE (`spawn_id` = '444'); 
+        -- Incendicite Mineral Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '172.447' WHERE (`spawn_id` = '449'); 
+        -- Incendicite Mineral Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '160.752' WHERE (`spawn_id` = '450'); 
+        -- Incendicite Mineral Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '170.525' WHERE (`spawn_id` = '452'); 
+        -- Incendicite Mineral Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '168.753' WHERE (`spawn_id` = '454'); 
+        -- Incendicite Mineral Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '165.485' WHERE (`spawn_id` = '455'); 
+        -- Dwarven Brazier Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.887' WHERE (`spawn_id` = '512'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.888' WHERE (`spawn_id` = '513'); 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.887' WHERE (`spawn_id` = '516'); 
+        -- Silverleaf Bush Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.575' WHERE (`spawn_id` = '522'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '528.499' WHERE (`spawn_id` = '524'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '520.165' WHERE (`spawn_id` = '526'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.887' WHERE (`spawn_id` = '544'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '590'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '592'); 
+        -- Dwarven Brazier Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.876' WHERE (`spawn_id` = '596'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '519.876' WHERE (`spawn_id` = '601'); 
+        -- Dwarven Brazier Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '523.496' WHERE (`spawn_id` = '603'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '523.496' WHERE (`spawn_id` = '610'); 
+        -- Dwarven Brazier Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '523.496' WHERE (`spawn_id` = '611'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '523.496' WHERE (`spawn_id` = '612'); 
+        -- Dwarven Brazier Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '525.949' WHERE (`spawn_id` = '613'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '525.949' WHERE (`spawn_id` = '617'); 
+        -- Silverleaf Bush Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-5.602' WHERE (`spawn_id` = '631'); 
+        -- Silverleaf Bush Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '28.038' WHERE (`spawn_id` = '687'); 
+        -- Silverleaf Bush Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '30.138' WHERE (`spawn_id` = '764'); 
+        -- Barrel of Milk Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.852' WHERE (`spawn_id` = '47558'); 
+        -- Dwarven High Back Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '780'); 
+        -- Barrel of Milk Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.873' WHERE (`spawn_id` = '47557'); 
+        -- Barrel of Milk ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '47552'); 
+        -- Dwarven High Back Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '804'); 
+        -- Silverleaf Bush Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '53.714' WHERE (`spawn_id` = '955'); 
+        -- Silverleaf Bush Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-3.627' WHERE (`spawn_id` = '974'); 
+        -- Silverleaf Bush Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.649' WHERE (`spawn_id` = '1004'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '495.26' WHERE (`spawn_id` = '1009'); 
+        -- Silverleaf Bush XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1173.445', `spawn_positionY` = '-3001.554', `spawn_positionZ` = '99.832' WHERE (`spawn_id` = '1078'); 
+        -- Silverleaf Bush Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.03' WHERE (`spawn_id` = '1146'); 
+        -- Campfire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '407.117' WHERE (`spawn_id` = '1173'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '407.117' WHERE (`spawn_id` = '1174'); 
+        -- Silverleaf Bush XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5935.646', `spawn_positionY` = '-2903.753', `spawn_positionZ` = '369.238' WHERE (`spawn_id` = '1183'); 
+        -- Burning Embers Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '7.126' WHERE (`spawn_id` = '47504'); 
 
         insert into applied_updates values ('190120221');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1163,6 +1163,332 @@ begin not atomic
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '12.563' WHERE (`spawn_id` = '8508'); 
         -- Stranglekelp Z placement. 
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.412' WHERE (`spawn_id` = '8509'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.821' WHERE (`spawn_id` = '8534'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.648' WHERE (`spawn_id` = '8535'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.676' WHERE (`spawn_id` = '8536'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.523' WHERE (`spawn_id` = '8537'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.24' WHERE (`spawn_id` = '8538'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.432' WHERE (`spawn_id` = '8540'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.697' WHERE (`spawn_id` = '8542'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.701' WHERE (`spawn_id` = '8543'); 
+        -- Stranglekelp XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '2136.485', `spawn_positionY` = '-313.482', `spawn_positionZ` = '91.118' WHERE (`spawn_id` = '8545'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.441' WHERE (`spawn_id` = '8549'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.754' WHERE (`spawn_id` = '8550'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.58' WHERE (`spawn_id` = '8556'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.598' WHERE (`spawn_id` = '8557'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.075' WHERE (`spawn_id` = '8559'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.398' WHERE (`spawn_id` = '8564'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.636' WHERE (`spawn_id` = '8566'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.621' WHERE (`spawn_id` = '8567'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.003' WHERE (`spawn_id` = '8575'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.088' WHERE (`spawn_id` = '8576'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.732' WHERE (`spawn_id` = '8577'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-2.278' WHERE (`spawn_id` = '8578'); 
+        -- Stranglekelp Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-12.684' WHERE (`spawn_id` = '8589'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '27.452' WHERE (`spawn_id` = '8608'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.832' WHERE (`spawn_id` = '8699'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '118.894' WHERE (`spawn_id` = '8700'); 
+        -- Goldthorn XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '40.752', `spawn_positionY` = '-3667.576', `spawn_positionZ` = '121.721' WHERE (`spawn_id` = '8701'); 
+        -- Crownroyal Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.379' WHERE (`spawn_id` = '12566'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.936' WHERE (`spawn_id` = '8712'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '32.887' WHERE (`spawn_id` = '11764'); 
+        -- Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '39.014' WHERE (`spawn_id` = '11762'); 
+        -- Khadgar's Whisker Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.589' WHERE (`spawn_id` = '11760'); 
+        -- Crownroyal Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '39.065' WHERE (`spawn_id` = '11756'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '125.236' WHERE (`spawn_id` = '8868'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '7.189' WHERE (`spawn_id` = '8889'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-6.0' WHERE (`spawn_id` = '8904'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.855' WHERE (`spawn_id` = '8906'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '22.051' WHERE (`spawn_id` = '8913'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-3.555' WHERE (`spawn_id` = '8948'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.688' WHERE (`spawn_id` = '8959'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.583' WHERE (`spawn_id` = '9005'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-4.526' WHERE (`spawn_id` = '9013'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '131.264' WHERE (`spawn_id` = '9039'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '126.952' WHERE (`spawn_id` = '9053'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '85.357' WHERE (`spawn_id` = '9092'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '76.245' WHERE (`spawn_id` = '9201'); 
+        -- Goldthorn Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '81.763' WHERE (`spawn_id` = '9202'); 
+        -- Goldthorn XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '42.254', `spawn_positionY` = '-3664.0', `spawn_positionZ` = '120.138' WHERE (`spawn_id` = '9210'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '674.997' WHERE (`spawn_id` = '9232'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.173' WHERE (`spawn_id` = '9237'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '126.016' WHERE (`spawn_id` = '9246'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.038' WHERE (`spawn_id` = '9266'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '81.28' WHERE (`spawn_id` = '9271'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-258.168' WHERE (`spawn_id` = '9275'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '28.341' WHERE (`spawn_id` = '9345'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '19.938' WHERE (`spawn_id` = '9347'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-205.408', `spawn_positionY` = '-383.035', `spawn_positionZ` = '65.956' WHERE (`spawn_id` = '9350'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '124.173' WHERE (`spawn_id` = '9364'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.262' WHERE (`spawn_id` = '9390'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '134.366' WHERE (`spawn_id` = '9397'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '811.161' WHERE (`spawn_id` = '9398'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-729.052', `spawn_positionY` = '-3695.72', `spawn_positionZ` = '195.584' WHERE (`spawn_id` = '9401'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-722.33', `spawn_positionY` = '-3692.587', `spawn_positionZ` = '196.207' WHERE (`spawn_id` = '9402'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '1334.458', `spawn_positionY` = '-1681.675', `spawn_positionZ` = '73.51' WHERE (`spawn_id` = '9403'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '116.679' WHERE (`spawn_id` = '9418'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-277.437', `spawn_positionY` = '-380.104', `spawn_positionZ` = '68.806' WHERE (`spawn_id` = '9420'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '688.414' WHERE (`spawn_id` = '9423'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2007.75', `spawn_positionY` = '-3290.647', `spawn_positionZ` = '59.618' WHERE (`spawn_id` = '9438'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '688.414' WHERE (`spawn_id` = '9445'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '44.259' WHERE (`spawn_id` = '9446'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.005' WHERE (`spawn_id` = '9455'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.222' WHERE (`spawn_id` = '9455'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-11158.411', `spawn_positionY` = '-1167.057', `spawn_positionZ` = '42.353' WHERE (`spawn_id` = '9457'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '39.272' WHERE (`spawn_id` = '9468'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5618.776', `spawn_positionY` = '3443.809', `spawn_positionZ` = '49.705' WHERE (`spawn_id` = '9481'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-209.05', `spawn_positionY` = '-384.295', `spawn_positionZ` = '65.214' WHERE (`spawn_id` = '9523'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '118.97' WHERE (`spawn_id` = '9575'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.382' WHERE (`spawn_id` = '9587'); 
+        -- Iron Deposit ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '9592'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-672.413', `spawn_positionY` = '-3772.663', `spawn_positionZ` = '216.557' WHERE (`spawn_id` = '9605'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.964' WHERE (`spawn_id` = '9622'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5640.168', `spawn_positionY` = '3531.055', `spawn_positionZ` = '44.682' WHERE (`spawn_id` = '9623'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '43.766' WHERE (`spawn_id` = '9623'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '240.768' WHERE (`spawn_id` = '9633'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-248.233', `spawn_positionY` = '-400.591', `spawn_positionZ` = '67.74' WHERE (`spawn_id` = '9636'); 
+        -- Tear of Theradras XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2358.7', `spawn_positionY` = '2502.176', `spawn_positionZ` = '75.21' WHERE (`spawn_id` = '32601'); 
+        -- Tear of Theradras XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2335.491', `spawn_positionY` = '2472.6', `spawn_positionZ` = '76.172' WHERE (`spawn_id` = '32600'); 
+        -- Tear of Theradras XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2345.112', `spawn_positionY` = '2453.43', `spawn_positionZ` = '67.707' WHERE (`spawn_id` = '32599'); 
+        -- Tear of Theradras Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '72.315' WHERE (`spawn_id` = '32598'); 
+        -- Tear of Theradras Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '58.188' WHERE (`spawn_id` = '32596'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5550.423', `spawn_positionY` = '658.624', `spawn_positionZ` = '393.387' WHERE (`spawn_id` = '9938'); 
+        -- Vylestem Vine Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.523' WHERE (`spawn_id` = '32573'); 
+        -- Barrel of Melon Juice XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-498.822', `spawn_positionY` = '-1536.943', `spawn_positionZ` = '59.761' WHERE (`spawn_id` = '20856'); 
+        -- Rise of the Horde Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '39.854' WHERE (`spawn_id` = '29688'); 
+        -- The Dark Portal and the Fall of Stormwind Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '20.962' WHERE (`spawn_id` = '29686'); 
+        -- The New Horde Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '39.855' WHERE (`spawn_id` = '29681'); 
+        -- Campfire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.867' WHERE (`spawn_id` = '32535'); 
+        -- Karnitol's Chest Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.121' WHERE (`spawn_id` = '32531'); 
+        -- MacGrann's Meat Locker Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '417.986' WHERE (`spawn_id` = '10027'); 
+        -- The Battle of Grim Batol XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1897.128', `spawn_positionY` = '352.391', `spawn_positionZ` = '107.661' WHERE (`spawn_id` = '32506'); 
+        -- War of the Three Hammers XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1898.901', `spawn_positionY` = '336.872', `spawn_positionZ` = '105.117' WHERE (`spawn_id` = '32010'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.774' WHERE (`spawn_id` = '20817'); 
+        -- Ironforge - the Awakening of the Dwarves XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1896.912', `spawn_positionY` = '355.444', `spawn_positionZ` = '107.55' WHERE (`spawn_id` = '31909'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '386.112' WHERE (`spawn_id` = '10105'); 
+        -- Mighty Blaze Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '31346'); 
+        -- Fierce Blaze Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '31344'); 
+        -- Fierce Blaze Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '31342'); 
+        -- Fierce Blaze Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30952'); 
+        -- Fierce Blaze Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30908'); 
+        -- Fierce Blaze Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30907'); 
+        -- Mighty Blaze Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30906'); 
+        -- Fierce Blaze Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '30905'); 
+        -- Campfire XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2284.958', `spawn_positionY` = '2657.683', `spawn_positionZ` = '60.66' WHERE (`spawn_id` = '30904'); 
+        -- Caravan Chest Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.686' WHERE (`spawn_id` = '29362'); 
+        -- Locked ball and chain Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '51.226' WHERE (`spawn_id` = '20785'); 
+        -- Locked ball and chain Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '53.623' WHERE (`spawn_id` = '20784'); 
+        -- Alterac Granite XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-241.674', `spawn_positionY` = '-267.344', `spawn_positionZ` = '54.413' WHERE (`spawn_id` = '20782'); 
+        -- Alterac Granite XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-212.773', `spawn_positionY` = '-383.497', `spawn_positionZ` = '64.896' WHERE (`spawn_id` = '20781'); 
+        -- Flame of Veraz XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-210.968', `spawn_positionY` = '-308.329', `spawn_positionZ` = '49.109' WHERE (`spawn_id` = '20780'); 
+        -- Flame of Azel XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-211.04', `spawn_positionY` = '-378.924', `spawn_positionZ` = '65.852' WHERE (`spawn_id` = '20779'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8943.978', `spawn_positionY` = '-2035.95', `spawn_positionZ` = '133.951' WHERE (`spawn_id` = '31124'); 
+        -- Tin Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8957.213', `spawn_positionY` = '-2000.348', `spawn_positionZ` = '134.091' WHERE (`spawn_id` = '31123'); 
+        -- Battered Chest XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8910.886', `spawn_positionY` = '-1962.685', `spawn_positionZ` = '130.836' WHERE (`spawn_id` = '31122'); 
+        -- Tin Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8946.009', `spawn_positionY` = '-1975.52', `spawn_positionZ` = '135.707' WHERE (`spawn_id` = '20883'); 
+        -- Tin Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8904.822', `spawn_positionY` = '-1918.278', `spawn_positionZ` = '133.83' WHERE (`spawn_id` = '20882'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8867.052', `spawn_positionY` = '-1849.176', `spawn_positionZ` = '120.721' WHERE (`spawn_id` = '20454'); 
+        -- Water Barrel Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '358.872' WHERE (`spawn_id` = '10847'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5704.192', `spawn_positionY` = '-1684.101', `spawn_positionZ` = '358.417' WHERE (`spawn_id` = '10853'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5615.457', `spawn_positionY` = '-1648.702', `spawn_positionZ` = '354.348' WHERE (`spawn_id` = '10855'); 
+        -- Battered Chest XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5559.417', `spawn_positionY` = '-1607.08', `spawn_positionZ` = '353.305' WHERE (`spawn_id` = '10856'); 
+        -- Ironband's Strongbox Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '408.592' WHERE (`spawn_id` = '10868'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-322.092', `spawn_positionY` = '931.233', `spawn_positionZ` = '131.866' WHERE (`spawn_id` = '35444'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-8747.848', `spawn_positionY` = '-2246.65', `spawn_positionZ` = '153.659' WHERE (`spawn_id` = '18679'); 
+        -- Solid Chest Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.926' WHERE (`spawn_id` = '9096'); 
+        -- Onyxia's Gate Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.097' WHERE (`spawn_id` = '9091'); 
+        -- Wooden Chair XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4088.002', `spawn_positionY` = '-4537.01', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9087'); 
+        -- Wooden Chair XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4089.954', `spawn_positionY` = '-4530.919', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9082'); 
+        -- Wooden Chair XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-820.755', `spawn_positionY` = '-563.622', `spawn_positionZ` = '16.408' WHERE (`spawn_id` = '18819'); 
+        -- Shaman Shrine Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.29' WHERE (`spawn_id` = '35418'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.643' WHERE (`spawn_id` = '17994'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.909' WHERE (`spawn_id` = '17993'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '186.92' WHERE (`spawn_id` = '17991'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.883' WHERE (`spawn_id` = '17988'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.764' WHERE (`spawn_id` = '17986'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.375' WHERE (`spawn_id` = '17984'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.297' WHERE (`spawn_id` = '17982'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '186.743' WHERE (`spawn_id` = '17980'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.607' WHERE (`spawn_id` = '17979'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.638' WHERE (`spawn_id` = '17977'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.764' WHERE (`spawn_id` = '17976'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.542' WHERE (`spawn_id` = '17974'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '182.629' WHERE (`spawn_id` = '17973'); 
+        -- Wooden Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '181.718' WHERE (`spawn_id` = '17966'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1818.535', `spawn_positionY` = '-1160.698', `spawn_positionZ` = '84.396' WHERE (`spawn_id` = '20722'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1796.07', `spawn_positionY` = '-1133.676', `spawn_positionZ` = '89.368' WHERE (`spawn_id` = '20721'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2414.816', `spawn_positionY` = '352.55', `spawn_positionZ` = '71.249' WHERE (`spawn_id` = '20717'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2355.516', `spawn_positionY` = '374.086', `spawn_positionZ` = '71.101' WHERE (`spawn_id` = '20716'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1729.654', `spawn_positionY` = '-1183.665', `spawn_positionZ` = '83.191' WHERE (`spawn_id` = '20672'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2409.372', `spawn_positionY` = '392.377', `spawn_positionZ` = '65.291' WHERE (`spawn_id` = '20667'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1803.327', `spawn_positionY` = '-1145.089', `spawn_positionZ` = '86.233' WHERE (`spawn_id` = '20648'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1786.272', `spawn_positionY` = '-995.415', `spawn_positionZ` = '86.124' WHERE (`spawn_id` = '20644'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '85.098' WHERE (`spawn_id` = '20644'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1457.337', `spawn_positionY` = '-920.6', `spawn_positionZ` = '51.495' WHERE (`spawn_id` = '20642'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '50.769' WHERE (`spawn_id` = '20642'); 
 
         insert into applied_updates values ('190120221');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1449,6 +1449,1109 @@ begin not atomic
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1457.337', `spawn_positionY` = '-920.6', `spawn_positionZ` = '51.495' WHERE (`spawn_id` = '20642'); 
         -- Copper Vein Z placement. 
         UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '50.769' WHERE (`spawn_id` = '20642'); 
+		        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '72.494' WHERE (`spawn_id` = '42512'); 
+        -- Campfire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '72.495' WHERE (`spawn_id` = '42511'); 
+        -- Wooden Chair XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4087.813', `spawn_positionY` = '-4538.993', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9079'); 
+        -- Wooden Chair XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4090.135', `spawn_positionY` = '-4528.345', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9077'); 
+        -- Wooden Chair XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4092.054', `spawn_positionY` = '-4542.481', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9063'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '9062'); 
+        -- Wooden Chair XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4093.94', `spawn_positionY` = '-4534.429', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9056'); 
+        -- Wooden Chair XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4080.577', `spawn_positionY` = '-4537.296', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9038'); 
+        -- Wooden Chair XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4090.338', `spawn_positionY` = '-4535.015', `spawn_positionZ` = '0.006' WHERE (`spawn_id` = '9037'); 
+        -- Wooden Chair XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3979.879', `spawn_positionY` = '-4594.738', `spawn_positionZ` = '0.077' WHERE (`spawn_id` = '9034'); 
+        -- Wooden Chair XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3994.309', `spawn_positionY` = '-4594.834', `spawn_positionZ` = '0.077' WHERE (`spawn_id` = '9032'); 
+        -- Wooden Chair XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3992.362', `spawn_positionY` = '-4590.767', `spawn_positionZ` = '0.077' WHERE (`spawn_id` = '9024'); 
+        -- Wooden Chair XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3997.958', `spawn_positionY` = '-4611.022', `spawn_positionZ` = '7.394' WHERE (`spawn_id` = '9006'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '9001'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '9000'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8996'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8996'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '8979'); 
+        -- Anvil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '86.522' WHERE (`spawn_id` = '20560'); 
+        -- Bonfire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '163.335' WHERE (`spawn_id` = '20556'); 
+        -- Food Crate XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1925.28', `spawn_positionY` = '417.42', `spawn_positionZ` = '186.07' WHERE (`spawn_id` = '20528'); 
+        -- Food Crate XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1948.225', `spawn_positionY` = '377.8', `spawn_positionZ` = '133.381' WHERE (`spawn_id` = '20528'); 
+        -- Food Crate XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1886.202', `spawn_positionY` = '-1098.123', `spawn_positionZ` = '87.3' WHERE (`spawn_id` = '20526'); 
+        -- Food Crate XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1826.478', `spawn_positionY` = '-1124.856', `spawn_positionZ` = '84.674' WHERE (`spawn_id` = '20525'); 
+        -- Solid Chest XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-877.876', `spawn_positionY` = '-3873.885', `spawn_positionZ` = '159.727' WHERE (`spawn_id` = '16977'); 
+        -- Mithril Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2022.357', `spawn_positionY` = '-3371.005', `spawn_positionZ` = '52.244' WHERE (`spawn_id` = '16974'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2012.945', `spawn_positionY` = '-3312.173', `spawn_positionZ` = '52.082' WHERE (`spawn_id` = '16973'); 
+        -- Lesser Bloodstone Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-870.385', `spawn_positionY` = '-3821.466', `spawn_positionZ` = '145.192' WHERE (`spawn_id` = '11993'); 
+        -- Lesser Bloodstone Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '143.782' WHERE (`spawn_id` = '11993'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-873.807', `spawn_positionY` = '-3840.334', `spawn_positionZ` = '149.58' WHERE (`spawn_id` = '11995'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '148.947' WHERE (`spawn_id` = '11995'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-797.869', `spawn_positionY` = '-3808.113', `spawn_positionZ` = '144.85' WHERE (`spawn_id` = '11997'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '143.062' WHERE (`spawn_id` = '11997'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-942.759', `spawn_positionY` = '-3857.444', `spawn_positionZ` = '147.871' WHERE (`spawn_id` = '11999'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '147.196' WHERE (`spawn_id` = '11999'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-803.337', `spawn_positionY` = '-3838.042', `spawn_positionZ` = '140.398' WHERE (`spawn_id` = '12001'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '137.824' WHERE (`spawn_id` = '12001'); 
+        -- Lesser Bloodstone Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-834.981', `spawn_positionY` = '-3903.662', `spawn_positionZ` = '153.738' WHERE (`spawn_id` = '12002'); 
+        -- Lesser Bloodstone Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '153.38' WHERE (`spawn_id` = '12002'); 
+        -- Lesser Bloodstone Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-852.325', `spawn_positionY` = '-3896.017', `spawn_positionZ` = '155.17' WHERE (`spawn_id` = '12005'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-887.304', `spawn_positionY` = '-3083.02', `spawn_positionZ` = '80.638' WHERE (`spawn_id` = '16965'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '77.763' WHERE (`spawn_id` = '16965'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '153.873' WHERE (`spawn_id` = '16964'); 
+        -- Lesser Bloodstone Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-984.15', `spawn_positionY` = '-3845.262', `spawn_positionZ` = '144.812' WHERE (`spawn_id` = '16958'); 
+        -- Lesser Bloodstone Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '143.037' WHERE (`spawn_id` = '16958'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-900.728', `spawn_positionY` = '-3824.991', `spawn_positionZ` = '146.628' WHERE (`spawn_id` = '16954'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '146.283' WHERE (`spawn_id` = '16954'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2061.016', `spawn_positionY` = '-3354.228', `spawn_positionZ` = '42.784' WHERE (`spawn_id` = '16931'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '41.178' WHERE (`spawn_id` = '16931'); 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-7.673' WHERE (`spawn_id` = '20420'); 
+        -- Smoke Emitter 02 Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.722' WHERE (`spawn_id` = '16771'); 
+        -- Small Barracks Flame Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.164' WHERE (`spawn_id` = '14779'); 
+        -- Smoke Emitter 02 Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.901' WHERE (`spawn_id` = '16770'); 
+        -- Big Barracks Flame Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.905' WHERE (`spawn_id` = '14776'); 
+        -- Small Barracks Flame Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.683' WHERE (`spawn_id` = '14780'); 
+        -- Small Barracks Flame Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.9' WHERE (`spawn_id` = '14777'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-983.377', `spawn_positionY` = '-3879.499', `spawn_positionZ` = '142.401' WHERE (`spawn_id` = '16906'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '141.518' WHERE (`spawn_id` = '16906'); 
+        -- Firebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '11.493' WHERE (`spawn_id` = '12242'); 
+        -- Firebloom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-7262.0', `spawn_positionY` = '-864.0', `spawn_positionZ` = '289.955' WHERE (`spawn_id` = '12243'); 
+        -- Firebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.623' WHERE (`spawn_id` = '12250'); 
+        -- Firebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.319' WHERE (`spawn_id` = '12274'); 
+        -- Forge XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1938.896', `spawn_positionY` = '383.6', `spawn_positionZ` = '133.448' WHERE (`spawn_id` = '30166'); 
+        -- Anvil XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1946.268', `spawn_positionY` = '379.568', `spawn_positionZ` = '133.412' WHERE (`spawn_id` = '30168'); 
+        -- Firebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '13.28' WHERE (`spawn_id` = '12327'); 
+        -- Peacebloom Flower Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-14.139' WHERE (`spawn_id` = '18551'); 
+        -- Battered Chest ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18447'); 
+        -- Battered Chest ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18445'); 
+        -- Water Barrel ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18305'); 
+        -- Water Barrel ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18303'); 
+        -- Water Barrel ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18302'); 
+        -- Campfire ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18167'); 
+        -- Thunder Bluff Forge XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1241.988', `spawn_positionY` = '95.77', `spawn_positionZ` = '130.43' WHERE (`spawn_id` = '18126'); 
+        -- Bonfire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '100.889' WHERE (`spawn_id` = '18116'); 
+        -- Bonfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '100.889' WHERE (`spawn_id` = '18112'); 
+        -- Solid Chest Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '38.597' WHERE (`spawn_id` = '16648'); 
+        -- Solid Chest Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '51.004' WHERE (`spawn_id` = '15672'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.867' WHERE (`spawn_id` = '18045'); 
+        -- Iridescent Shards Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '153.348' WHERE (`spawn_id` = '16635'); 
+        -- Rise of the Blood Elves Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '83.769' WHERE (`spawn_id` = '16609'); 
+        -- Sargeras and the Betrayal Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '75.614' WHERE (`spawn_id` = '16608'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.566' WHERE (`spawn_id` = '18025'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18024'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18017'); 
+        -- Mouthpiece Mount Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '179.327' WHERE (`spawn_id` = '18013'); 
+        -- HornCover Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '161.313' WHERE (`spawn_id` = '17228'); 
+        -- Small Thorium Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6353.775', `spawn_positionY` = '-1884.256', `spawn_positionZ` = '-259.576' WHERE (`spawn_id` = '17593'); 
+        -- Small Thorium Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6317.152', `spawn_positionY` = '-1846.192', `spawn_positionZ` = '-257.155' WHERE (`spawn_id` = '17592'); 
+        -- Solid Chest XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3853.528', `spawn_positionY` = '-2540.012', `spawn_positionZ` = '42.331' WHERE (`spawn_id` = '15212'); 
+        -- Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.575' WHERE (`spawn_id` = '17484'); 
+        -- Egg-O-Matic Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '8.828' WHERE (`spawn_id` = '17475'); 
+        -- Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17463'); 
+        -- Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17462'); 
+        -- Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17461'); 
+        -- Stove Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '9.214' WHERE (`spawn_id` = '17445'); 
+        -- Gahz'ridian Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '27.36' WHERE (`spawn_id` = '17409'); 
+        -- Gahz'ridian Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '60.208' WHERE (`spawn_id` = '17406'); 
+        -- Gahz'ridian Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '9.273' WHERE (`spawn_id` = '17395'); 
+        -- Gahz'ridian Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '16.819' WHERE (`spawn_id` = '17386'); 
+        -- Stove Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.167' WHERE (`spawn_id` = '17354'); 
+        -- Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.081' WHERE (`spawn_id` = '17351'); 
+        -- Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.455' WHERE (`spawn_id` = '17350'); 
+        -- Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.014' WHERE (`spawn_id` = '17349'); 
+        -- Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.324' WHERE (`spawn_id` = '17348'); 
+        -- Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.621' WHERE (`spawn_id` = '17347'); 
+        -- Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.468' WHERE (`spawn_id` = '17346'); 
+        -- Stove Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.527' WHERE (`spawn_id` = '17345'); 
+        -- Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.762' WHERE (`spawn_id` = '17344'); 
+        -- Chair Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.388' WHERE (`spawn_id` = '17343'); 
+        -- Old Hatreds - The Colonization of Kalimdor Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.88' WHERE (`spawn_id` = '17342'); 
+        -- Food Crate Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.224' WHERE (`spawn_id` = '15194'); 
+        -- Tin Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3906.052', `spawn_positionY` = '-2520.028', `spawn_positionZ` = '45.379' WHERE (`spawn_id` = '15182'); 
+        -- Tin Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '44.098' WHERE (`spawn_id` = '15182'); 
+        -- Tin Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3870.382', `spawn_positionY` = '-2415.092', `spawn_positionZ` = '47.584' WHERE (`spawn_id` = '15181'); 
+        -- Tin Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '47.402' WHERE (`spawn_id` = '15181'); 
+        -- Tin Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3918.919', `spawn_positionY` = '-2441.717', `spawn_positionZ` = '41.335' WHERE (`spawn_id` = '15180'); 
+        -- Tin Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '42.127' WHERE (`spawn_id` = '15180'); 
+        -- Incendicite Mineral Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3871.993', `spawn_positionY` = '-2533.822', `spawn_positionZ` = '45.258' WHERE (`spawn_id` = '15179'); 
+        -- Incendicite Mineral Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '43.881' WHERE (`spawn_id` = '15179'); 
+        -- Doodad_GeneralMedChair03 ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14174'); 
+        -- Doodad_GeneralMedChair04 ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14173'); 
+        -- Doodad_GeneralMedChair02 ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14172'); 
+        -- Solid Chest ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17329'); 
+        -- Moon Well Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.062' WHERE (`spawn_id` = '17328'); 
+        -- Captain's Chest ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17327'); 
+        -- Stolen Cargo Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.514' WHERE (`spawn_id` = '17326'); 
+        -- Stolen Cargo Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.896' WHERE (`spawn_id` = '17324'); 
+        -- Stolen Cargo Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.441' WHERE (`spawn_id` = '17326'); 
+        -- Stolen Cargo Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.503' WHERE (`spawn_id` = '17325'); 
+        -- Stolen Cargo Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.51' WHERE (`spawn_id` = '17324'); 
+        -- Stolen Cargo Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.838' WHERE (`spawn_id` = '17323'); 
+        -- Stolen Cargo Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.658' WHERE (`spawn_id` = '17322'); 
+        -- Bench Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.002' WHERE (`spawn_id` = '17321'); 
+        -- Bench Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.587' WHERE (`spawn_id` = '17320'); 
+        -- Bench Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.541' WHERE (`spawn_id` = '17319'); 
+        -- Bench Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.326' WHERE (`spawn_id` = '17318'); 
+        -- Couch Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '16.507' WHERE (`spawn_id` = '17317'); 
+        -- Book "Soothsaying for Dummies" Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '16.827' WHERE (`spawn_id` = '17316'); 
+        -- Barrel of Melon Juice Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-10.782' WHERE (`spawn_id` = '14890'); 
+        -- Wanted Poster Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '9.962' WHERE (`spawn_id` = '17282'); 
+        -- Pew ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14047'); 
+        -- Pew Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '52.643' WHERE (`spawn_id` = '14046'); 
+        -- Pew ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14046'); 
+        -- Pew ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14045'); 
+        -- Pew ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14044'); 
+        -- Pew ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14043'); 
+        -- Pew ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14042'); 
+        -- Gate ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14040'); 
+        -- Door ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14039'); 
+        -- Gate ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14038'); 
+        -- Door ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14036'); 
+        -- Door ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14035'); 
+        -- Door ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14034'); 
+        -- Door ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14033'); 
+        -- Gate ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14032'); 
+        -- Portcullis XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2757.28', `spawn_positionY` = '-5036.39', `spawn_positionZ` = '-1.69' WHERE (`spawn_id` = '7636'); 
+        -- Portcullis Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.655' WHERE (`spawn_id` = '7635'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.142' WHERE (`spawn_id` = '7634'); 
+        -- Doodad_PortcullisActive02 ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14030'); 
+        -- Doodad_PortcullisActive06 ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14029'); 
+        -- Anvil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '11.009' WHERE (`spawn_id` = '17243'); 
+        -- Food Crate Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '7.236' WHERE (`spawn_id` = '14857'); 
+        -- Food Crate Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-0.098' WHERE (`spawn_id` = '14853'); 
+        -- Doodad_WroughtIronDoor01 ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14014'); 
+        -- Forge Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '10.936' WHERE (`spawn_id` = '17240'); 
+        -- Doodad_PortcullisActive07 ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14013'); 
+        -- Doodad_WroughtIronDoor03 ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14011'); 
+        -- Uldum Pedestal Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '9.323' WHERE (`spawn_id` = '17230'); 
+        -- Tin Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-3013.538', `spawn_positionY` = '-3293.8', `spawn_positionZ` = '65.469' WHERE (`spawn_id` = '14665'); 
+        -- Tin Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '65.179' WHERE (`spawn_id` = '14665'); 
+        -- Iron Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '49.327' WHERE (`spawn_id` = '14664'); 
+        -- Silver Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2996.575', `spawn_positionY` = '-3302.436', `spawn_positionZ` = '65.892' WHERE (`spawn_id` = '14663'); 
+        -- Solid Chest XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2948.437', `spawn_positionY` = '-3202.636', `spawn_positionZ` = '59.875' WHERE (`spawn_id` = '14660'); 
+        -- Doodad_WroughtIronDoor04 ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14010'); 
+        -- Doodad_PortcullisActive05 ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14009'); 
+        -- Doodad_WroughtIronDoor02 ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14005'); 
+        -- Bonfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13992'); 
+        -- Bonfire ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13991'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13990'); 
+        -- Campfire ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13989'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13988'); 
+        -- Cauldron ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13987'); 
+        -- Turn Back! ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13985'); 
+        -- Bonfire ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13983'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13982'); 
+        -- Cauldron ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13981'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10945.107', `spawn_positionY` = '-3546.316', `spawn_positionZ` = '30.528' WHERE (`spawn_id` = '16582'); 
+        -- Mithril Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10996.399', `spawn_positionY` = '-3539.051', `spawn_positionZ` = '30.997' WHERE (`spawn_id` = '32135'); 
+        -- Truesilver Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10672.617', `spawn_positionY` = '-3564.864', `spawn_positionZ` = '50.989' WHERE (`spawn_id` = '42459'); 
+        -- Truesilver Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '49.995' WHERE (`spawn_id` = '42459'); 
+        -- Mithril Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10652.375', `spawn_positionY` = '-3586.477', `spawn_positionZ` = '29.141' WHERE (`spawn_id` = '42458'); 
+        -- Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '27.309' WHERE (`spawn_id` = '42458'); 
+        -- Beyond the Dark Portal ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '42443'); 
+        -- Burning Embers ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17209'); 
+        -- Document Chest ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '17199'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '42.709' WHERE (`spawn_id` = '7568'); 
+        -- Brazier of Everfount ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '33417'); 
+        -- The Dark Portal and the Fall of Stormwind ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '42442'); 
+        -- Aftermath of the Second War ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '42441'); 
+        -- House 2 ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '3996095'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '6.775' WHERE (`spawn_id` = '7400'); 
+        -- Signal Torch Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.213' WHERE (`spawn_id` = '6992'); 
+        -- Mithril Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10637.499', `spawn_positionY` = '-3546.715', `spawn_positionZ` = '32.412' WHERE (`spawn_id` = '42436'); 
+        -- Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '31.394' WHERE (`spawn_id` = '42436'); 
+        -- Iron Deposit XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-5036.521', `spawn_positionY` = '-2401.981', `spawn_positionZ` = '-55.601' WHERE (`spawn_id` = '17194'); 
+        -- Small Thorium Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10926.867', `spawn_positionY` = '-3526.492', `spawn_positionZ` = '47.292' WHERE (`spawn_id` = '40005'); 
+        -- Shaman Shrine ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '33369'); 
+        -- Solid Chest XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-10860.763', `spawn_positionY` = '-3629.552', `spawn_positionZ` = '24.561' WHERE (`spawn_id` = '13978'); 
+        -- The Kaldorei and the Well of Eternity Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '17.073' WHERE (`spawn_id` = '14566'); 
+        -- Ooze Covered Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.949' WHERE (`spawn_id` = '15431'); 
+        -- Ooze Covered Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.364' WHERE (`spawn_id` = '15433'); 
+        -- Ooze Covered Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '42.721' WHERE (`spawn_id` = '15438'); 
+        -- Ooze Covered Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.375' WHERE (`spawn_id` = '15439'); 
+        -- Ooze Covered Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '31.316' WHERE (`spawn_id` = '15440'); 
+        -- Ooze Covered Mithril Deposit Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '35.569' WHERE (`spawn_id` = '15442'); 
+        -- Ooze Covered Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-328.398' WHERE (`spawn_id` = '15470'); 
+        -- Ooze Covered Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-323.104' WHERE (`spawn_id` = '15472'); 
+        -- Gorishi Hive Hatchery Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-329.91' WHERE (`spawn_id` = '50381'); 
+        -- Incendia Agave Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-41.855' WHERE (`spawn_id` = '16757'); 
+        -- Incendia Agave Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-52.562' WHERE (`spawn_id` = '16756'); 
+        -- Incendia Agave Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-36.947' WHERE (`spawn_id` = '16755'); 
+        -- Incendia Agave Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-52.341' WHERE (`spawn_id` = '16749'); 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.612' WHERE (`spawn_id` = '15866'); 
+        -- Purple Lotus Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '115.526' WHERE (`spawn_id` = '15871'); 
+        -- Purple Lotus Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '109.631' WHERE (`spawn_id` = '15880'); 
+        -- Purple Lotus Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '154.385' WHERE (`spawn_id` = '15905'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '71.571' WHERE (`spawn_id` = '15950'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '64.133' WHERE (`spawn_id` = '15951'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '64.789' WHERE (`spawn_id` = '15963'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.439' WHERE (`spawn_id` = '15966'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '57.21' WHERE (`spawn_id` = '15967'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '78.472' WHERE (`spawn_id` = '15968'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '64.125' WHERE (`spawn_id` = '15971'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '63.122' WHERE (`spawn_id` = '15975'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '64.415' WHERE (`spawn_id` = '15980'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '63.338' WHERE (`spawn_id` = '15987'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '63.555' WHERE (`spawn_id` = '15990'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '59.306' WHERE (`spawn_id` = '15992'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '59.683' WHERE (`spawn_id` = '15994'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '72.59' WHERE (`spawn_id` = '16007'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '62.882' WHERE (`spawn_id` = '16019'); 
+        -- Arthas' Tears Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '71.456' WHERE (`spawn_id` = '16022'); 
+        -- Sungrass Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '60.102' WHERE (`spawn_id` = '16063'); 
+        -- Sungrass Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '120.1' WHERE (`spawn_id` = '16087'); 
+        -- Sungrass Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '120.834' WHERE (`spawn_id` = '16079'); 
+        -- Sungrass Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-2.065' WHERE (`spawn_id` = '16098'); 
+        -- Sungrass Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-1.145' WHERE (`spawn_id` = '16098'); 
+        -- Sungrass Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '119.111' WHERE (`spawn_id` = '16109'); 
+        -- Sungrass Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '117.854' WHERE (`spawn_id` = '16116'); 
+        -- Sungrass Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '124.133' WHERE (`spawn_id` = '16121'); 
+        -- Sungrass Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '122.78' WHERE (`spawn_id` = '16125'); 
+        -- Sungrass Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '122.385' WHERE (`spawn_id` = '16144'); 
+        -- Sungrass Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '71.551' WHERE (`spawn_id` = '16205'); 
+        -- Ghost Mushroom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '153.402' WHERE (`spawn_id` = '16417'); 
+        -- Ghost Mushroom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '355.608', `spawn_positionY` = '-3752.967', `spawn_positionZ` = '135.822' WHERE (`spawn_id` = '16418'); 
+        -- Ghost Mushroom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '329.565', `spawn_positionY` = '-3821.0', `spawn_positionZ` = '142.901' WHERE (`spawn_id` = '16419'); 
+        -- Ghost Mushroom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '126.081' WHERE (`spawn_id` = '16421'); 
+        -- Ghost Mushroom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '353.627', `spawn_positionY` = '-3779.0', `spawn_positionZ` = '148.453' WHERE (`spawn_id` = '16422'); 
+        -- Ghost Mushroom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '378.796', `spawn_positionY` = '-3797.707', `spawn_positionZ` = '154.722' WHERE (`spawn_id` = '16423'); 
+        -- Ghost Mushroom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '312.829', `spawn_positionY` = '-3810.0', `spawn_positionZ` = '137.854' WHERE (`spawn_id` = '16424'); 
+        -- Ghost Mushroom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '388.011', `spawn_positionY` = '-3733.0', `spawn_positionZ` = '126.703' WHERE (`spawn_id` = '16426'); 
+        -- Ghost Mushroom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '363.497', `spawn_positionY` = '-3722.528', `spawn_positionZ` = '123.33' WHERE (`spawn_id` = '16430'); 
+        -- Ghost Mushroom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '337.574', `spawn_positionY` = '-3889.219', `spawn_positionZ` = '119.72' WHERE (`spawn_id` = '16431'); 
+        -- Ghost Mushroom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '373.483', `spawn_positionY` = '-3757.0', `spawn_positionZ` = '148.096' WHERE (`spawn_id` = '16433'); 
+        -- Ghost Mushroom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '405.255', `spawn_positionY` = '-3744.617', `spawn_positionZ` = '116.589' WHERE (`spawn_id` = '16434'); 
+        -- Ghost Mushroom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '432.341', `spawn_positionY` = '-3800.962', `spawn_positionZ` = '114.644' WHERE (`spawn_id` = '16437'); 
+        -- Ghost Mushroom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '352.612', `spawn_positionY` = '-3820.737', `spawn_positionZ` = '104.034' WHERE (`spawn_id` = '16438'); 
+        -- Ghost Mushroom XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '372.982', `spawn_positionY` = '-3784.0', `spawn_positionZ` = '154.539' WHERE (`spawn_id` = '16442'); 
+        -- Ghost Mushroom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '121.689' WHERE (`spawn_id` = '16448'); 
+        -- Gromsblood Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.918' WHERE (`spawn_id` = '16454'); 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '5.042' WHERE (`spawn_id` = '16541'); 
+        -- Gromsblood Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '567.981' WHERE (`spawn_id` = '16543'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14344'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14345'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14343'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14342'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14341'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14340'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14339'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14338'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14337'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '16614'); 
+        -- Stranglekelp ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15761'); 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '23.918' WHERE (`spawn_id` = '15753'); 
+        --  Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '96.532' WHERE (`spawn_id` = '15725'); 
+        --  Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '62.411' WHERE (`spawn_id` = '15723'); 
+        -- The Punisher (DND) ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15705'); 
+        -- Buccaneer's Strongbox ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15702'); 
+        -- Tin Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '94.305' WHERE (`spawn_id` = '15688'); 
+        -- Grim Batol Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '19.059' WHERE (`spawn_id` = '13764'); 
+        -- Buccaneer's Strongbox ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15683'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '96.629' WHERE (`spawn_id` = '15676'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1975.0', `spawn_positionY` = '-3290.534', `spawn_positionZ` = '70.921' WHERE (`spawn_id` = '15675'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '69.406' WHERE (`spawn_id` = '15675'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-1348.71', `spawn_positionY` = '-2963.96', `spawn_positionZ` = '101.549' WHERE (`spawn_id` = '15496'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '100.936' WHERE (`spawn_id` = '15496'); 
+        -- Copper Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-2041.03', `spawn_positionY` = '-3471.56', `spawn_positionZ` = '35.338' WHERE (`spawn_id` = '15495'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '34.748' WHERE (`spawn_id` = '15495'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '15150'); 
+        -- Buccaneer's Strongbox ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15145'); 
+        -- Copper Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '60.775' WHERE (`spawn_id` = '15135'); 
+        -- Buccaneer's Strongbox ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15125'); 
+        -- Buccaneer's Strongbox ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15123'); 
+        -- Buccaneer's Strongbox ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15122'); 
+        -- Buccaneer's Strongbox ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15121'); 
+        -- Buccaneer's Strongbox ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15120'); 
+        -- Buccaneer's Strongbox ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '15119'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13184'); 
+        -- Fiery Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13141'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13138'); 
+        -- Fiery Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13129'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13128'); 
+        -- Fiery Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13126'); 
+        -- High Back Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13125'); 
+        -- High Back Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13124'); 
+        -- Campfire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.994' WHERE (`spawn_id` = '14846'); 
+        -- Anvil ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14774'); 
+        --  ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14681'); 
+        -- Cauldron ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14678'); 
+        --  ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14677'); 
+        --  ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14642'); 
+        --  ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14639'); 
+        --  ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14637'); 
+        -- Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14598'); 
+        -- Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14596'); 
+        -- Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14594'); 
+        -- Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14542'); 
+        -- Stove ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14519'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14197'); 
+        -- Archimonde's Return and the Flight to Kalimdor Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.557' WHERE (`spawn_id` = '13594'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13592'); 
+        -- Miblon's Door Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.847' WHERE (`spawn_id` = '17428'); 
+        -- The New Horde Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '33.492' WHERE (`spawn_id` = '13538'); 
+        -- Lethargy of the Orcs Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '32.751' WHERE (`spawn_id` = '13535'); 
+        -- Master Control Program Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.572' WHERE (`spawn_id` = '13531'); 
+        -- Bonfire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '45.576' WHERE (`spawn_id` = '13526'); 
+        -- War of the Three Hammers Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '108.909' WHERE (`spawn_id` = '13514'); 
+        -- Fierce Blaze Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '93.956' WHERE (`spawn_id` = '13512'); 
+        -- Barrel of Milk Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '13510'); 
+        -- Barrel of Milk Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.02' WHERE (`spawn_id` = '13501'); 
+        -- Ironforge - the Awakening of the Dwarves Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '118.077' WHERE (`spawn_id` = '13496'); 
+        -- Crude Brazier Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '98.811' WHERE (`spawn_id` = '13491'); 
+        -- Burning Embers Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.411' WHERE (`spawn_id` = '13475'); 
+        -- Crude Brazier Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '135.031' WHERE (`spawn_id` = '13474'); 
+        -- Campfire ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13473'); 
+        -- Crude Brazier XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-595.49', `spawn_positionY` = '-3170.718', `spawn_positionZ` = '92.897' WHERE (`spawn_id` = '13470'); 
+        -- Campfire ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13469'); 
+        -- Exile of the High Elves Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '24.83' WHERE (`spawn_id` = '13468'); 
+        -- Crude Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13465'); 
+        -- Crude Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13463'); 
+        -- Crude Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13459'); 
+        -- Crude Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13456'); 
+        -- Crude Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13453'); 
+        -- Crude Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13450'); 
+        -- Food Crate XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '1247.18', `spawn_positionY` = '-3604.149', `spawn_positionZ` = '114.297' WHERE (`spawn_id` = '13448'); 
+        -- Gallywix's Lockbox Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '13434'); 
+        -- Bench Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '27.43' WHERE (`spawn_id` = '13406'); 
+        -- Stolen Silver ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13405'); 
+        -- Bench Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '27.45' WHERE (`spawn_id` = '13399'); 
+        -- Bench Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.696' WHERE (`spawn_id` = '13397'); 
+        -- Bench Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.79' WHERE (`spawn_id` = '13394'); 
+        -- Wild Steelbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '36.683' WHERE (`spawn_id` = '13366'); 
+        -- Forge Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.129' WHERE (`spawn_id` = '13360'); 
+        -- Common Magebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '65.684' WHERE (`spawn_id` = '13358'); 
+        -- Anvil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '13.37' WHERE (`spawn_id` = '13356'); 
+        -- Nijel's Point Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '89.49' WHERE (`spawn_id` = '30226'); 
+        -- Anvil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '13.679' WHERE (`spawn_id` = '13354'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13353'); 
+        -- Anvil ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13352'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13351'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13350'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.129' WHERE (`spawn_id` = '13344'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '16.967' WHERE (`spawn_id` = '13343'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '65.368' WHERE (`spawn_id` = '13342'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '69.855' WHERE (`spawn_id` = '13341'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '49.643' WHERE (`spawn_id` = '13340'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '40.758' WHERE (`spawn_id` = '13337'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.134' WHERE (`spawn_id` = '13336'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '75.836' WHERE (`spawn_id` = '13335'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '57.878' WHERE (`spawn_id` = '13334'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '66.371' WHERE (`spawn_id` = '13333'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.526' WHERE (`spawn_id` = '13332'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '51.573' WHERE (`spawn_id` = '13331'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '51.012' WHERE (`spawn_id` = '13330'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '43.784' WHERE (`spawn_id` = '13329'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '22.152' WHERE (`spawn_id` = '13328'); 
+        -- Burning Embers Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '13326'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13325'); 
+        -- Food Crate ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13319'); 
+        -- Gallywix's Lockbox Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '13316'); 
+        -- Warm Fire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.836' WHERE (`spawn_id` = '13313'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13312'); 
+        -- Warm Fire Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.683' WHERE (`spawn_id` = '13308'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13307'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13302'); 
+        -- Anvil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.229' WHERE (`spawn_id` = '13301'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13299'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13294'); 
+        -- The Jewel of the Southsea ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13293'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.129' WHERE (`spawn_id` = '13290'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '16.967' WHERE (`spawn_id` = '13277'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '65.368' WHERE (`spawn_id` = '13276'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '69.747' WHERE (`spawn_id` = '13275'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '49.643' WHERE (`spawn_id` = '13274'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '40.758' WHERE (`spawn_id` = '13273'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '21.134' WHERE (`spawn_id` = '13272'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '75.836' WHERE (`spawn_id` = '13271'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '57.878' WHERE (`spawn_id` = '13270'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '66.371' WHERE (`spawn_id` = '13269'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.526' WHERE (`spawn_id` = '13268'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '51.573' WHERE (`spawn_id` = '13267'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '51.011' WHERE (`spawn_id` = '13266'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '43.784' WHERE (`spawn_id` = '13265'); 
+        -- Serpentbloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '22.152' WHERE (`spawn_id` = '13264'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13262'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13258'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13257'); 
+        -- Kolkars' Booty ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13253'); 
+        -- Laden Mushroom ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13198'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13183'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13172'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13169'); 
+        -- Kolkar's Booty ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13162'); 
+        -- Cannon ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13153'); 
+        -- Cannon ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13149'); 
+        -- Cannon ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13130'); 
+        -- Battered Chest XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6008.708', `spawn_positionY` = '-2972.425', `spawn_positionZ` = '402.824' WHERE (`spawn_id` = '13209'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13122'); 
+        -- Tin Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6048.852', `spawn_positionY` = '-2798.129', `spawn_positionZ` = '392.479' WHERE (`spawn_id` = '12860'); 
+        -- Tin Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '391.79' WHERE (`spawn_id` = '12860'); 
+        -- Barrel of Milk XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-6024.201', `spawn_positionY` = '-2801.919', `spawn_positionZ` = '386.121' WHERE (`spawn_id` = '12801'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13123'); 
+        -- Cannon ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13082'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13081'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13065'); 
+        -- Kolkar's Booty Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '97.756' WHERE (`spawn_id` = '13061'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13039'); 
+        -- Stonetalon Mountains Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '89.488' WHERE (`spawn_id` = '30232'); 
+        -- Bonfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12961'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12945'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.667' WHERE (`spawn_id` = '12940'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.836' WHERE (`spawn_id` = '12939'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '91.683' WHERE (`spawn_id` = '12938'); 
+        -- Campfire Damage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '92.411' WHERE (`spawn_id` = '12937'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12933'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12931'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12930'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12928'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12857'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12854'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12853'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12852'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12850'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12849'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12835'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12711'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12710'); 
+        -- Ironzar's Imported Weaponry ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12708'); 
+        -- Anvil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '14.297' WHERE (`spawn_id` = '12705'); 
+        -- Jazzik's General Goods ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12704'); 
+        -- Damaged Chest XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-4926.41', `spawn_positionY` = '-2345.391', `spawn_positionZ` = '-49.869' WHERE (`spawn_id` = '12699'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12691'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12669'); 
+        -- Taillasher Eggs Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '3.932' WHERE (`spawn_id` = '12623'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13072'); 
+        -- Rich Thorium Vein ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '18384'); 
+        -- Rich Thorium Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-223.106' WHERE (`spawn_id` = '18424'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13070'); 
+        -- Gold Vein XYZ placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionX` = '-236.393', `spawn_positionY` = '-370.875', `spawn_positionZ` = '69.721' WHERE (`spawn_id` = '33196'); 
+        -- Gold Vein Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '68.876' WHERE (`spawn_id` = '33196'); 
+        -- Fiery Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13069'); 
+        -- Water Barrel Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '1.252' WHERE (`spawn_id` = '12498'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13025'); 
+        -- Fiery Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13023'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13021'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13020'); 
+        -- Fiery Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13018'); 
+        -- High Back Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13013'); 
+        -- Potbelly Stove ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13009'); 
+        -- High Back Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13007'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13004'); 
+        -- Campfire Damage ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13001'); 
+        -- Fiery Brazier ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '13000'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12997');         -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12996'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12988'); 
+        -- High Back Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12925'); 
+        -- High Back Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12924'); 
+        -- High Back Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12922'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12912'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12911'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12908'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12907'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12897'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12896'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12895'); 
+        -- Gnomish Toolbox Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '-14.262' WHERE (`spawn_id` = '12422'); 
+        -- Food Crate Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '26.854' WHERE (`spawn_id` = '12392');         -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12889'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12886'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12884'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12881'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12879'); 
+        -- Wooden Chair ignored, out of reach. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '12878'); 
+        -- Golden Sansam Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.8' WHERE (`spawn_id` = '18972'); 
+        -- Golden Sansam Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.886' WHERE (`spawn_id` = '19004'); 
+        -- Golden Sansam Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '2.886' WHERE (`spawn_id` = '19004'); 
+        -- Golden Sansam Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '117.873' WHERE (`spawn_id` = '19093'); 
+        -- Golden Sansam Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '65.504' WHERE (`spawn_id` = '19173'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '118.658' WHERE (`spawn_id` = '19287'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '60.256' WHERE (`spawn_id` = '19311'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '64.248' WHERE (`spawn_id` = '19332'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.076' WHERE (`spawn_id` = '19333'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '63.923' WHERE (`spawn_id` = '19359'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '128.284' WHERE (`spawn_id` = '19363'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '128.454' WHERE (`spawn_id` = '19364'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '62.483' WHERE (`spawn_id` = '19489'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '60.426' WHERE (`spawn_id` = '19490'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.284' WHERE (`spawn_id` = '19560'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.801' WHERE (`spawn_id` = '19592'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '0.201' WHERE (`spawn_id` = '19608'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.781' WHERE (`spawn_id` = '19612'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '63.534' WHERE (`spawn_id` = '19632'); 
+        -- Dreamfoil Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '4.085' WHERE (`spawn_id` = '19656'); 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '106.304' WHERE (`spawn_id` = '19713'); 
+        -- Mountain Silversage Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '140.878' WHERE (`spawn_id` = '19736'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '80.112' WHERE (`spawn_id` = '19882'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '84.089' WHERE (`spawn_id` = '19883'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '82.082' WHERE (`spawn_id` = '19884'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '129.702' WHERE (`spawn_id` = '19893'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.77' WHERE (`spawn_id` = '19895'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '63.511' WHERE (`spawn_id` = '19911'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '81.348' WHERE (`spawn_id` = '19912'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '83.893' WHERE (`spawn_id` = '19913'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '62.793' WHERE (`spawn_id` = '19916'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '102.343' WHERE (`spawn_id` = '19920'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.37' WHERE (`spawn_id` = '19940'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '78.101' WHERE (`spawn_id` = '19942'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.924' WHERE (`spawn_id` = '19944'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '66.533' WHERE (`spawn_id` = '19975'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '102.31' WHERE (`spawn_id` = '19996'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '61.002' WHERE (`spawn_id` = '19999'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '60.707' WHERE (`spawn_id` = '20001'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '62.044' WHERE (`spawn_id` = '20002'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '137.031' WHERE (`spawn_id` = '20004'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '80.968' WHERE (`spawn_id` = '20028'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '129.097' WHERE (`spawn_id` = '20031'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '101.295' WHERE (`spawn_id` = '20035'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '126.042' WHERE (`spawn_id` = '20045'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '129.752' WHERE (`spawn_id` = '20062'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '136.219' WHERE (`spawn_id` = '20094'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '82.372' WHERE (`spawn_id` = '20108'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '135.51' WHERE (`spawn_id` = '20124'); 
+        -- Plaguebloom Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '103.504' WHERE (`spawn_id` = '20133'); 
+        -- Khadgar's Whisker Z placement. 
+        UPDATE `alpha_world`.`spawns_gameobjects` SET `spawn_positionZ` = '120.328' WHERE (`spawn_id` = '34961'); 
 
         insert into applied_updates values ('190120221');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -29,7 +29,7 @@ begin not atomic
         UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1334.94' WHERE (`spawn_id` = '47061');
         UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1335.55' WHERE (`spawn_id` = '47249');
         UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1335.60' WHERE (`spawn_id` = '47003');
-        UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1336.16' WHERE (`spawn_id` = '47002');
+        UPDATE `alpha_world`.`spawns_creatures` SET `position_x` = '10832.00', `position_y` = '921.21', `position_z` = '1337.127' WHERE (`spawn_id` = '47002');
         UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1332.67' WHERE (`spawn_id` = '47017');
         UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1326.44' WHERE (`spawn_id` = '47018');
         UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1321.23' WHERE (`spawn_id` = '47023');

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -35,45 +35,6 @@ begin not atomic
         UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1321.23' WHERE (`spawn_id` = '47023');
         UPDATE `alpha_world`.`spawns_creatures` SET `position_z` = '1319.51' WHERE (`spawn_id` = '47056');
 
-        -- Ignore Webwood Spiders that have wrong placement in 0.5.3. (Out of reach)
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46958');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46971');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46972');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46974');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46981');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46997');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46998');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '46999');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47000');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47001');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47004');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47006');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47008');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47009');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47010');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47012');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47016');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47021');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47029');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47030');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47031');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47037');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47038');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47039');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47052');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47053');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47054');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47055');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47057');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47060');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47062');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47208');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47262');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47263');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47266');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47267');
-        UPDATE `alpha_world`.`spawns_creatures` SET `ignored` = '1' WHERE (`spawn_id` = '47268');
-	
         -- Small Thorium Vein ignored, out of reach.
         UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '132');
         -- Small Thorium Vein XYZ placement. 

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -28,18 +28,18 @@ class WorldLoader:
             Logger.info('Skipped game object loading.')
 
         # Creature spawns
-        if config.Server.Settings.load_creatures:
-            WorldLoader.load_creature_loot_templates()
-            WorldLoader.load_creature_equip_templates()
-            WorldLoader.load_creatures()
-            WorldLoader.load_creature_quest_starters()
-            WorldLoader.load_creature_quest_finishers()
-            WorldLoader.load_creature_display_info()
-            WorldLoader.load_creature_model_info()
-            WorldLoader.load_npc_gossip()
-            WorldLoader.load_npc_text()
-        else:
-            Logger.info('Skipped creature loading.')
+        # if config.Server.Settings.load_creatures:
+        #     WorldLoader.load_creature_loot_templates()
+        #     WorldLoader.load_creature_equip_templates()
+        #     WorldLoader.load_creatures()
+        #     WorldLoader.load_creature_quest_starters()
+        #     WorldLoader.load_creature_quest_finishers()
+        #     WorldLoader.load_creature_display_info()
+        #     WorldLoader.load_creature_model_info()
+        #     WorldLoader.load_npc_gossip()
+        #     WorldLoader.load_npc_text()
+        # else:
+        #     Logger.info('Skipped creature loading.')
 
         WorldLoader.load_item_templates()
         WorldLoader.load_quests()

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -28,18 +28,18 @@ class WorldLoader:
             Logger.info('Skipped game object loading.')
 
         # Creature spawns
-        # if config.Server.Settings.load_creatures:
-        #     WorldLoader.load_creature_loot_templates()
-        #     WorldLoader.load_creature_equip_templates()
-        #     WorldLoader.load_creatures()
-        #     WorldLoader.load_creature_quest_starters()
-        #     WorldLoader.load_creature_quest_finishers()
-        #     WorldLoader.load_creature_display_info()
-        #     WorldLoader.load_creature_model_info()
-        #     WorldLoader.load_npc_gossip()
-        #     WorldLoader.load_npc_text()
-        # else:
-        #     Logger.info('Skipped creature loading.')
+        if config.Server.Settings.load_creatures:
+            WorldLoader.load_creature_loot_templates()
+            WorldLoader.load_creature_equip_templates()
+            WorldLoader.load_creatures()
+            WorldLoader.load_creature_quest_starters()
+            WorldLoader.load_creature_quest_finishers()
+            WorldLoader.load_creature_display_info()
+            WorldLoader.load_creature_model_info()
+            WorldLoader.load_npc_gossip()
+            WorldLoader.load_npc_text()
+        else:
+            Logger.info('Skipped creature loading.')
 
         WorldLoader.load_item_templates()
         WorldLoader.load_quests()

--- a/game/world/WorldSessionStateHandler.py
+++ b/game/world/WorldSessionStateHandler.py
@@ -1,3 +1,4 @@
+import time
 from database.realm.RealmDatabaseManager import *
 
 WORLD_SESSIONS = []
@@ -88,10 +89,11 @@ class WorldSessionStateHandler(object):
 
     @staticmethod
     def update_players():
+        now = time.time()
         for session in WORLD_SESSIONS:
             if session.player_mgr and session.player_mgr.online:
                 if not session.player_mgr.update_lock:
-                    session.player_mgr.update()
+                    session.player_mgr.update(now)
 
     @staticmethod
     def save_characters():

--- a/game/world/managers/CommandManager.py
+++ b/game/world/managers/CommandManager.py
@@ -169,6 +169,7 @@ class CommandManager(object):
             player_mgr = CommandManager._target_or_self(world_session, only_players=True)
             item_mgr = player_mgr.inventory.add_item(entry=entry, count=count)
             if item_mgr:
+                player_mgr.set_dirty_inventory()
                 return 0, ''
             else:
                 return -1, f'unable to find and / or add item id {entry}.'

--- a/game/world/managers/CommandManager.py
+++ b/game/world/managers/CommandManager.py
@@ -270,7 +270,6 @@ class CommandManager(object):
                 return -1, 'The skill was not found.'
 
             world_session.player_mgr.skill_manager.add_skill(skill_id)
-            world_session.player_mgr.set_dirty()
             return 0, 'Skill learned.'
         except ValueError:
             return -1, 'Invalid ID.'
@@ -412,7 +411,6 @@ class CommandManager(object):
             mount_display_id = int(args)
             player_mgr = CommandManager._target_or_self(world_session, only_players=True)
             player_mgr.mount(mount_display_id)
-            player_mgr.set_dirty()
             return 0, ''
         except ValueError:
             return -1, 'please specify a valid mount display id.'
@@ -421,7 +419,6 @@ class CommandManager(object):
     def unmount(world_session, args):
         player_mgr = CommandManager._target_or_self(world_session, only_players=True)
         player_mgr.unmount()
-        player_mgr.set_dirty()
         return 0, ''
 
     @staticmethod
@@ -430,7 +427,6 @@ class CommandManager(object):
             display_id = int(args)
             unit = CommandManager._target_or_self(world_session)
             unit.set_display_id(display_id)
-            unit.set_dirty()
             return 0, ''
         except ValueError:
             return -1, 'please specify a valid display id.'
@@ -439,7 +435,6 @@ class CommandManager(object):
     def demorph(world_session, args):
         unit = CommandManager._target_or_self(world_session)
         unit.reset_display_id()
-        unit.set_dirty()
         return 0, ''
 
     @staticmethod

--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -1,4 +1,4 @@
-import math
+import math, time
 
 from utils.ConfigManager import config
 from utils.constants.MiscCodes import ObjectTypes
@@ -267,16 +267,18 @@ class GridManager(object):
         return self.cells
 
     def update_creatures(self):
+        now = time.time()
         for key in list(self.active_cell_keys):
             cell = self.cells[key]
             for guid, creature in list(cell.creatures.items()):
-                creature.update()
+                creature.update(now)
 
     def update_gameobjects(self):
+        now = time.time()
         for key in list(self.active_cell_keys):
             cell = self.cells[key]
             for guid, gameobject in list(cell.gameobjects.items()):
-                gameobject.update()
+                gameobject.update(now)
 
 
 class Cell(object):

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -290,7 +290,7 @@ class MapManager(object):
         return current_cell in destination_cells
 
     @staticmethod
-    def update_object(world_object):
+    def update_object(world_object, check_pending_changes=False):
         if world_object.current_cell:
             old_map = int(world_object.current_cell.split(':')[-1])
             old_grid_manager = MapManager.get_grid_manager_by_map_id(old_map)
@@ -298,7 +298,7 @@ class MapManager(object):
             old_grid_manager = None
 
         grid_manager = MapManager.get_grid_manager_by_map_id(world_object.map_)
-        grid_manager.update_object(world_object, old_grid_manager)
+        grid_manager.update_object(world_object, old_grid_manager, check_pending_changes=check_pending_changes)
 
     @staticmethod
     def remove_object(world_object):

--- a/game/world/managers/objects/ObjectManager.py
+++ b/game/world/managers/objects/ObjectManager.py
@@ -257,7 +257,7 @@ class ObjectManager(object):
         return unpack('<f', self.update_packet_factory.update_values[index])[0]
 
     # override
-    def update(self):
+    def update(self, now):
         pass
 
     # override

--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -345,8 +345,7 @@ class GameObjectManager(ObjectManager):
                 # Check "dirtiness" to determine if this game object should be updated yet or not.
                 if self.has_pending_updates():
                     MapManager.update_object(self, check_pending_changes=True)
-                    # Reset fields older than NOW. Do not use 'now' since time and new updates could be made in between.
-                    self.reset_fields_older_than(time.time())
+                    self.reset_fields_older_than(now)
             # Not spawned.
             else:
                 self.respawn_timer += elapsed

--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -336,8 +336,7 @@ class GameObjectManager(ObjectManager):
         MapManager.respawn_object(self)
 
     # override
-    def update(self):
-        now = time.time()
+    def update(self, now):
         if now > self.last_tick > 0:
             elapsed = now - self.last_tick
 

--- a/game/world/managers/objects/item/ItemManager.py
+++ b/game/world/managers/objects/item/ItemManager.py
@@ -320,7 +320,7 @@ class ItemManager(ObjectManager):
         return PacketWriter.get_packet(OpCode.SMSG_ITEM_QUERY_SINGLE_RESPONSE, data)
 
     # override
-    def get_full_update_packet(self, is_self=True):
+    def get_full_update_packet(self, requester):
         if self.item_template and self.item_instance:
             from game.world.managers.objects.item.ContainerManager import ContainerManager
 
@@ -353,7 +353,7 @@ class ItemManager(ObjectManager):
             if self.is_container() and isinstance(self, ContainerManager):
                 self.build_container_update_packet()
 
-            return self.get_object_create_packet(is_self)
+            return self.get_object_create_packet(requester)
 
     def set_enchantment(self, slot, value, duration, charges):
         self.enchantments[slot] = (value, duration, charges)

--- a/game/world/managers/objects/spell/AuraManager.py
+++ b/game/world/managers/objects/spell/AuraManager.py
@@ -58,8 +58,6 @@ class AuraManager:
                 self.unit_mgr.attack(aura.caster)
             self.check_aura_interrupts(negative_aura_applied=True)
 
-        self.unit_mgr.set_dirty()
-
     has_moved = False  # Set from SpellManager - TODO pass movement info from unit update instead
 
     def update(self, timestamp):
@@ -277,7 +275,6 @@ class AuraManager:
 
         self.write_aura_to_unit(aura, clear=True)
         self.write_aura_flag_to_unit(aura, clear=True)
-        self.unit_mgr.set_dirty()
 
     def remove_all_auras(self):
         for aura in list(self.active_auras.values()):

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -118,7 +118,7 @@ class SpellEffectHandler(object):
             return
 
         target.inventory.add_item(effect.item_type,
-                                  count=effect.get_effect_points(casting_spell.caster_effective_level))
+                                  count=effect.get_effect_points(casting_spell.caster_effective_level), update_inventory=True)
 
     @staticmethod
     def handle_teleport_units(casting_spell, effect, caster, target):

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -81,7 +81,6 @@ class SpellEffectHandler(object):
             target.use(caster)
             caster.unit_flags |= UnitFlags.UNIT_FLAG_LOOTING
             caster.set_uint32(UnitFields.UNIT_FIELD_FLAGS, caster.unit_flags)
-            caster.set_dirty()
 
     @staticmethod
     def handle_energize(casting_spell, effect, caster, target):
@@ -103,7 +102,6 @@ class SpellEffectHandler(object):
             # leave any applied aura).
             if target.mount_display_id > 0:
                 target.unmount()
-                target.set_dirty()
         else:
             creature_entry = effect.misc_value
             if not target.summon_mount(creature_entry):
@@ -197,7 +195,6 @@ class SpellEffectHandler(object):
             return
 
         casting_spell.spell_caster.set_channel_object(go_manager.guid)
-        casting_spell.spell_caster.set_dirty()
 
         if go_manager.gobject_template.type == GameObjectTypes.TYPE_RITUAL:
             go_manager.ritual_caster = caster

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -494,7 +494,6 @@ class SpellManager(object):
         if casting_spell.initial_target_is_object():
             self.unit_mgr.set_channel_object(casting_spell.initial_target.guid)
         self.unit_mgr.set_channel_spell(casting_spell.spell_entry.ID)
-        self.unit_mgr.set_dirty()
 
         self.apply_spell_effects(casting_spell)
 
@@ -535,7 +534,6 @@ class SpellManager(object):
 
         self.unit_mgr.set_channel_object(0)
         self.unit_mgr.set_channel_spell(0)
-        self.unit_mgr.set_dirty()
 
         if self.unit_mgr.get_type() != ObjectTypes.TYPE_PLAYER:
             return
@@ -870,7 +868,6 @@ class SpellManager(object):
         if self.unit_mgr.get_type() == ObjectTypes.TYPE_PLAYER and \
                 casting_spell.requires_combo_points():
             self.unit_mgr.remove_combo_points()
-            self.unit_mgr.set_dirty()
 
         for reagent_info in casting_spell.get_reagents():  # Reagents.
             if reagent_info[0] == 0:
@@ -887,8 +884,6 @@ class SpellManager(object):
             if charges != 0 and charges != -1:  # don't modify if no charges remain or this item is a consumable.
                 new_charges = charges-1 if charges > 0 else charges+1
                 spell_stats.charges = new_charges
-
-        self.unit_mgr.set_dirty()
 
     def send_cast_result(self, spell_id, error):
         # TODO CAST_SUCCESS_KEEP_TRACKING

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -190,7 +190,6 @@ class SpellManager(object):
                 self.remove_cast(casting_spell)
 
         self.set_on_cooldown(casting_spell)
-
         self.consume_resources_for_cast(casting_spell)  # Remove resources - order matters for combo points
 
     def apply_spell_effects(self, casting_spell, remove=False, update=False, partial_targets=None):
@@ -884,6 +883,9 @@ class SpellManager(object):
             if charges != 0 and charges != -1:  # don't modify if no charges remain or this item is a consumable.
                 new_charges = charges-1 if charges > 0 else charges+1
                 spell_stats.charges = new_charges
+
+        if self.unit_mgr.get_type() == ObjectTypes.TYPE_PLAYER:
+            self.unit_mgr.set_dirty_inventory()
 
     def send_cast_result(self, spell_id, error):
         # TODO CAST_SUCCESS_KEEP_TRACKING

--- a/game/world/managers/objects/timers/MirrorTimer.py
+++ b/game/world/managers/objects/timers/MirrorTimer.py
@@ -113,7 +113,6 @@ class MirrorTimer(object):
             else:
                 new_health = self.owner.health - damage
                 self.owner.set_health(new_health)
-                self.owner.set_dirty()
 
     def handle_feign_death_timer(self):
         if self.remaining <= 0:

--- a/game/world/managers/objects/units/MovementManager.py
+++ b/game/world/managers/objects/units/MovementManager.py
@@ -71,7 +71,7 @@ class MovementManager(object):
             # Path finished.
             if self.total_waypoint_timer >= self.total_waypoint_time:
                 if self.is_player and self.unit.pending_taxi_destination:
-                    self.unit.set_taxi_flying_state(False, set_dirty=True)
+                    self.unit.set_taxi_flying_state(False)
                     self.unit.teleport(self.unit.map_, self.unit.pending_taxi_destination, is_instant=True)
                     self.unit.pending_taxi_destination = None
                     self.unit.taxi_manager.update_flight_state()

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -240,9 +240,16 @@ class UnitManager(ObjectManager):
         MapManager.send_surrounding(PacketWriter.get_packet(OpCode.SMSG_ATTACKSTOP, data), self)
 
     def attack_update(self, elapsed):
-        if self.combat_target and not self.combat_target.is_alive:
+        # If we have a single attacker and is no longer alive, leave combat.
+        if self.combat_target and not self.combat_target.is_alive and len(self.attackers) == 0:
             self.leave_combat()
             return
+        # We have more attackers, switch to next alive target.
+        elif self.combat_target and not self.combat_target.is_alive and len(self.attackers) > 0:
+            for guid, attacker in self.attackers.items():
+                if attacker.is_alive:
+                    self.attack(attacker)
+                    return
 
         self.update_attack_time(AttackTypes.BASE_ATTACK, elapsed * 1000.0)
         if self.has_offhand_weapon():

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -482,8 +482,7 @@ class CreatureManager(UnitManager):
                 self.movement_manager.send_move_normal([combat_location], self.running_speed, SplineFlags.SPLINEFLAG_RUNMODE)
 
     # override
-    def update(self):
-        now = time.time()
+    def update(self, now):
         if now > self.last_tick > 0:
             elapsed = now - self.last_tick
 

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -512,8 +512,7 @@ class CreatureManager(UnitManager):
             # Check "dirtiness" to determine if this creature object should be updated yet or not.
             if self.has_pending_updates():
                 MapManager.update_object(self, check_pending_changes=True)
-                # Reset fields older than NOW. Do not use 'now' since time and new updates could be made in between.
-                self.reset_fields_older_than(time.time())
+                self.reset_fields_older_than(now)
 
         self.last_tick = now
 

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -129,8 +129,6 @@ class CreatureManager(UnitManager):
             creature.faction = override_faction
 
         creature.load()
-        creature.send_create_packet_surroundings()
-
         return creature
 
     def generate_display_id(self):
@@ -263,7 +261,7 @@ class CreatureManager(UnitManager):
                         self.set_virtual_item(2, creature_equip_template.equipentry3)
 
                 self.stat_manager.init_stats()
-                self.stat_manager.apply_bonuses(set_dirty=False)
+                self.stat_manager.apply_bonuses()
 
                 self.fully_loaded = True
 
@@ -342,7 +340,7 @@ class CreatureManager(UnitManager):
         return False
 
     # override
-    def get_full_update_packet(self, is_self=True):
+    def get_full_update_packet(self, requester):
         self.finish_loading()
 
         # race, class, gender, power_type
@@ -391,7 +389,7 @@ class CreatureManager(UnitManager):
         self.set_uint32(UnitFields.UNIT_DYNAMIC_FLAGS, self.dynamic_flags)
         self.set_uint32(UnitFields.UNIT_FIELD_DAMAGE, self.damage)
 
-        return self.get_object_create_packet(is_self)
+        return self.get_object_create_packet(requester)
 
     def query_details(self):
         name_bytes = PacketWriter.string_to_bytes(self.creature_template.name)
@@ -418,7 +416,6 @@ class CreatureManager(UnitManager):
         self.leave_combat(force=True)
         self.set_health(self.max_health)
         self.recharge_power()
-        self.set_dirty()
         self.movement_manager.send_move_normal([self.spawn_position], self.running_speed,
                                                SplineFlags.SPLINEFLAG_RUNMODE)
 
@@ -513,11 +510,10 @@ class CreatureManager(UnitManager):
                     self.despawn()
 
             # Check "dirtiness" to determine if this creature object should be updated yet or not.
-            if self.dirty:
-                MapManager.send_surrounding(self.generate_proper_update_packet(create=False), self, include_self=False)
-                MapManager.update_object(self)
-                if self.reset_fields_older_than(now):
-                    self.set_dirty(is_dirty=False)
+            if self.has_pending_updates():
+                MapManager.update_object(self, check_pending_changes=True)
+                # Reset fields older than NOW. Do not use 'now' since time and new updates could be made in between.
+                self.reset_fields_older_than(time.time())
 
         self.last_tick = now
 
@@ -555,8 +551,10 @@ class CreatureManager(UnitManager):
             # If the player/group requires the kill, reward it to them.
             if self.killed_by.group_manager:
                 self.killed_by.group_manager.reward_group_creature_or_go(self.killed_by, self)
-            elif self.killed_by.quest_manager.reward_creature_or_go(self):
-                self.killed_by.send_update_self()
+            else:
+                # Reward quest creature or go to player with killing blow.
+                self.killed_by.quest_manager.reward_creature_or_go(self)
+
             # If the player is in a group, set the group as allowed looters if needed.
             if self.killed_by.group_manager and self.loot_manager.has_loot():
                 self.killed_by.group_manager.set_allowed_looters(self)
@@ -564,7 +562,6 @@ class CreatureManager(UnitManager):
         if self.loot_manager.has_loot():
             self.set_lootable(True)
 
-        self.set_dirty()
         return True
 
     def reward_kill_xp(self, player):

--- a/game/world/managers/objects/units/player/DuelManager.py
+++ b/game/world/managers/objects/units/player/DuelManager.py
@@ -58,7 +58,6 @@ class DuelManager(object):
             for entry in duel_manager.players.values():
                 entry.player.duel_manager = duel_manager
                 duel_manager.build_update(entry.player)
-                entry.player.set_dirty()
 
             return 1
         else:
@@ -81,7 +80,6 @@ class DuelManager(object):
         for entry in self.players.values():
             entry.duel_status = DuelStatus.DUEL_STATUS_INBOUNDS
             self.build_update(entry.player, set_hostile=True)
-            entry.player.set_dirty()
 
     def force_duel_end(self, player_mgr, retreat=True):
         if player_mgr.guid in self.players:
@@ -121,7 +119,6 @@ class DuelManager(object):
             entry.player.enqueue_packet(packet)
             entry.player.leave_combat()
             self.build_update(entry.player)
-            entry.player.set_dirty()
 
             entry.player.spell_manager.remove_unit_from_all_cast_targets(entry.target.guid)
             entry.player.aura_manager.remove_harmful_auras_by_caster(entry.target.guid)

--- a/game/world/managers/objects/units/player/GroupManager.py
+++ b/game/world/managers/objects/units/player/GroupManager.py
@@ -315,14 +315,13 @@ class GroupManager(object):
         surrounding_players = MapManager.get_surrounding_players(player).values()
         surrounding_members = [player for player in surrounding_players if player.guid in self.members]
 
-        # Party kill log packet, not sure how to display on client but it is handled.
+        # Party kill log packet, not sure how to display on client but, it is handled.
         data = pack('<2Q', player.guid, creature.guid)  # Player with killing blow and victim guid.
         kill_log_packet = PacketWriter.get_packet(OpCode.SMSG_PARTYKILLLOG, data)
 
         for member in surrounding_members:
             member.enqueue_packet(kill_log_packet)
             member.quest_manager.reward_creature_or_go(creature)
-            member.send_update_self()
 
     def send_invite_decline(self, player_name):
         player_mgr = WorldSessionStateHandler.find_player_by_guid(self.group.leader_guid)
@@ -479,7 +478,6 @@ class GroupManager(object):
             player_mgr.player.extra_flags |= PlayerFlags.PLAYER_FLAGS_GROUP_LEADER
             player_mgr.player_bytes_2 = unpack('<I', pack('<4B', player_mgr.player.extra_flags, player_mgr.player.facialhair, player_mgr.player.bankslots, 0))[0]
             player_mgr.set_uint32(PlayerFields.PLAYER_BYTES_2, player_mgr.player_bytes_2)
-            player_mgr.set_dirty()
 
     @staticmethod
     def _remove_leader_flag(member):
@@ -488,7 +486,6 @@ class GroupManager(object):
             player_mgr.player.extra_flags &= ~PlayerFlags.PLAYER_FLAGS_GROUP_LEADER
             player_mgr.player_bytes_2 = unpack('<I', pack('<4B', player_mgr.player.extra_flags, player_mgr.player.facialhair, player_mgr.player.bankslots, 0))[0]
             player_mgr.set_uint32(PlayerFields.PLAYER_BYTES_2, player_mgr.player_bytes_2)
-            player_mgr.set_dirty()
 
     @staticmethod
     def _create_group(player_mgr):

--- a/game/world/managers/objects/units/player/InventoryManager.py
+++ b/game/world/managers/objects/units/player/InventoryManager.py
@@ -82,7 +82,7 @@ class InventoryManager(object):
         return InventorySlots.SLOT_INBACKPACK.value
 
     def add_item(self, entry=0, item_template=None, count=1, handle_error=True, looted=False,
-                 send_message=True, show_item_get=True):
+                 send_message=True, show_item_get=True, update_inventory=False):
         if entry != 0 and not item_template:
             item_template = WorldDatabaseManager.ItemTemplateHolder.item_template_get_by_entry(entry)
         amount_left = count
@@ -124,6 +124,9 @@ class InventoryManager(object):
 
             # Update quest item count, if needed.
             self.owner.quest_manager.reward_item(item_template.entry, item_count=count)
+
+            if update_inventory:
+                self.owner.set_dirty_inventory()
 
         return items_added
 

--- a/game/world/managers/objects/units/player/InventoryManager.py
+++ b/game/world/managers/objects/units/player/InventoryManager.py
@@ -125,7 +125,7 @@ class InventoryManager(object):
             # Update quest item count, if needed.
             self.owner.quest_manager.reward_item(item_template.entry, item_count=count)
             # Update own inventory.
-            self.owner.send_update_self(force_inventory_update=True)
+            self.owner.dirty_inventory = True
 
         return items_added
 
@@ -167,7 +167,7 @@ class InventoryManager(object):
                 self.add_item(item_template=item_template, count=remaining)  # Overflow to inventory
             else:
                 # Update if container is modified self.add_item isn't called
-                self.owner.send_update_self(force_inventory_update=True)
+                self.owner.dirty_inventory = True
             return True
 
         # Stack handling
@@ -181,7 +181,7 @@ class InventoryManager(object):
                         dest_item.item_instance.stackcount += diff
                         self.add_item(item_template=item_template, count=count-diff, handle_error=False)
 
-                    self.owner.send_update_self(force_inventory_update=True)
+                    self.owner.dirty_inventory = True
                     RealmDatabaseManager.character_inventory_update_item(dest_item.item_instance)
                     return True
                 else:
@@ -203,7 +203,7 @@ class InventoryManager(object):
             self.handle_equipment_change(generated_item)
             RealmDatabaseManager.character_inventory_update_item(generated_item.item_instance)
         else:
-            self.owner.send_update_self(force_inventory_update=True)
+            self.owner.dirty_inventory = True
 
         return True
 
@@ -243,7 +243,7 @@ class InventoryManager(object):
                 dest_item.item_instance.stackcount = dest_item.item_template.stackable
                 RealmDatabaseManager.character_inventory_update_item(source_item.item_instance)
 
-            self.owner.send_update_self(force_inventory_update=True)
+            self.owner.dirty_inventory = True
             RealmDatabaseManager.character_inventory_update_item(dest_item.item_instance)
             return
 
@@ -277,7 +277,7 @@ class InventoryManager(object):
                 (self.is_equipment_pos(dest_bag, dest_slot) or self.is_bag_pos(dest_slot)):  # Added equipment or bag
             self.handle_equipment_change(source_item, dest_item)
         else:
-            self.owner.send_update_self(force_inventory_update=True)
+            self.owner.dirty_inventory = True
 
         # Finally, update items and client
         RealmDatabaseManager.character_inventory_update_item(source_item.item_instance)
@@ -357,7 +357,7 @@ class InventoryManager(object):
                     elif count >= item.item_instance.stackcount:
                         self.remove_item(container_slot, slot, True)
                         count -= item.item_instance.stackcount
-        self.owner.send_update_self(force_inventory_update=True)
+        self.owner.dirty_inventory = True
         return count  # Return the amount of items not removed
 
     def get_item_info_by_guid(self, guid):
@@ -596,9 +596,9 @@ class InventoryManager(object):
             self.remove_item(InventorySlots.SLOT_INBACKPACK, InventorySlots.SLOT_OFFHAND)
 
         # Bonus application.
-        self.owner.stat_manager.apply_bonuses(set_dirty=False)
+        self.owner.stat_manager.apply_bonuses()
         # Mark as dirty to update equipment for other players.
-        self.owner.set_dirty(dirty_inventory=True)
+        self.owner.dirty_inventory = True
 
     def is_bag_pos(self, slot):
         return (InventorySlots.SLOT_BAG1 <= slot < InventorySlots.SLOT_INBACKPACK) or \
@@ -715,26 +715,26 @@ class InventoryManager(object):
         for slot, item in self.get_backpack().sorted_slots.items():
             self.owner.set_uint64(PlayerFields.PLAYER_FIELD_INV_SLOT_1 + item.current_slot * 2, item.guid)
 
-    def send_single_item_update(self, item, is_self):
+    def get_single_item_update_packets(self, item, requester):
         update_packet = UpdatePacketFactory.compress_if_needed(PacketWriter.get_packet(
-            OpCode.SMSG_UPDATE_OBJECT, item.get_full_update_packet(is_self=False)))
-        if is_self:
-            self.owner.enqueue_packet(update_packet)
-            self.owner.enqueue_packet(item.query_details())
-        else:
-            MapManager.send_surrounding(update_packet, self.owner, include_self=False)
-            MapManager.send_surrounding(item.query_details(), self.owner, include_self=False)
+            OpCode.SMSG_UPDATE_OBJECT, item.get_full_update_packet(requester)))
+        return [update_packet, item.query_details()]
 
-    def send_inventory_update(self, is_self=True):
+    def get_inventory_update_packets(self, requester):
         # Edge case where the session might be null at some point.
         if self.owner and not self.owner.session:
-            return
+            return []
 
+        update_packets = []
         for container_slot, container in list(self.containers.items()):
             if not container:
                 continue
             if not container.is_backpack:
-                self.send_single_item_update(container, is_self)
+                for packet in self.get_single_item_update_packets(container, requester):
+                    update_packets.append(packet)
 
             for slot, item in list(container.sorted_slots.items()):
-                self.send_single_item_update(item, is_self)
+                for _packet in self.get_single_item_update_packets(item, requester):
+                    update_packets.append(_packet)
+
+        return update_packets

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1415,7 +1415,6 @@ class PlayerManager(UnitManager):
             # Check if player has pending updates.
             if self.has_pending_updates() and self.online:
                 MapManager.update_object(self, check_pending_changes=True)
-                # Reset fields older than NOW. Do not use 'now' since new updates could've been made in between.
                 self.reset_fields_older_than(now)
                 if self.dirty_inventory:
                     self.dirty_inventory = False

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -638,6 +638,7 @@ class PlayerManager(UnitManager):
                         packet = PacketWriter.get_packet(OpCode.SMSG_LOOT_REMOVED, data)
                         for looter in world_obj_target.loot_manager.get_active_looters():
                             looter.enqueue_packet(packet)
+                        self.set_dirty_inventory()
 
     def send_loot_release(self, guid):
         self.unit_flags &= ~UnitFlags.UNIT_FLAG_LOOTING
@@ -1373,6 +1374,45 @@ class PlayerManager(UnitManager):
     def update(self, now):
 
         if now > self.last_tick > 0:
+            elapsed = now - self.last_tick
+
+            # Update played time.
+            self.player.totaltime += elapsed
+            self.player.leveltime += elapsed
+
+            # Regeneration.
+            self.regenerate(now)
+            # Attack update.
+            self.attack_update(elapsed)
+            # Waypoints (mostly flying paths) update.
+            self.movement_manager.update_pending_waypoints(elapsed)
+
+            # SpellManager tick.
+            self.spell_manager.update(now, elapsed)
+            # AuraManager tick.
+            self.aura_manager.update(now)
+
+            # Duel tick.
+            if self.duel_manager:
+                self.duel_manager.update(self, elapsed)
+
+            # Release spirit timer.
+            if not self.is_alive:
+                if self.spirit_release_timer < 300:  # 5 min.
+                    self.spirit_release_timer += elapsed
+                else:
+                    self.repop()
+
+            # Update timers (Breath, Fatigue, Feign Death).
+            if self.is_alive:
+                self.mirror_timers_manager.update(elapsed)
+
+            # Logout timer.
+            if self.logout_timer > 0:
+                self.logout_timer -= elapsed
+                if self.logout_timer < 0:
+                    self.logout()
+
             # Check if player has pending updates.
             if self.has_pending_updates() and self.online:
                 MapManager.update_object(self, check_pending_changes=True)
@@ -1382,46 +1422,6 @@ class PlayerManager(UnitManager):
             # Not dirty, has a pending teleport and a teleport is not ongoing.
             elif not self.has_pending_updates() and self.pending_teleport_destination and not self.update_lock:
                 self.trigger_teleport()
-
-            elapsed = now - self.last_tick
-
-            # Update played time.
-            self.player.totaltime += elapsed
-            self.player.leveltime += elapsed
-
-            if not self.update_lock:
-                # Regeneration.
-                self.regenerate(now)
-                # Attack update.
-                self.attack_update(elapsed)
-                # Waypoints (mostly flying paths) update.
-                self.movement_manager.update_pending_waypoints(elapsed)
-
-                # SpellManager tick.
-                self.spell_manager.update(now, elapsed)
-                # AuraManager tick.
-                self.aura_manager.update(now)
-
-                # Duel tick.
-                if self.duel_manager:
-                    self.duel_manager.update(self, elapsed)
-
-                # Release spirit timer.
-                if not self.is_alive:
-                    if self.spirit_release_timer < 300:  # 5 min.
-                        self.spirit_release_timer += elapsed
-                    else:
-                        self.repop()
-
-                # Update timers (Breath, Fatigue, Feign Death).
-                if self.is_alive:
-                    self.mirror_timers_manager.update(elapsed)
-
-                # Logout timer.
-                if self.logout_timer > 0:
-                    self.logout_timer -= elapsed
-                    if self.logout_timer < 0:
-                        self.logout()
 
         self.last_tick = now
 

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -224,7 +224,7 @@ class PlayerManager(UnitManager):
         self.online = True
 
         # Calculate stat bonuses at this point.
-        self.stat_manager.apply_bonuses(replenish=first_login, set_dirty=False)
+        self.stat_manager.apply_bonuses(replenish=first_login)
 
         # Join default channels.
         ChannelManager.join_default_channels(self)
@@ -237,7 +237,7 @@ class PlayerManager(UnitManager):
         if taxi_resume_info.is_valid():
             self.location = taxi_resume_info.start_location
             # Set player flags.
-            self.set_taxi_flying_state(True, taxi_resume_info.mount_display_id, set_dirty=False)
+            self.set_taxi_flying_state(True, taxi_resume_info.mount_display_id)
 
         # Notify player with create packet.
         self.send_update_self(create=True)
@@ -247,7 +247,7 @@ class PlayerManager(UnitManager):
 
         # Try to resume pending flight once player has been created and set on a world cell.
         if taxi_resume_info.is_valid() and not self.taxi_manager.resume_taxi_flight():
-            self.set_taxi_flying_state(False, set_dirty=True)
+            self.set_taxi_flying_state(False)
 
         # Notify friends about player login.
         self.friends_manager.send_online_notification()
@@ -316,9 +316,26 @@ class PlayerManager(UnitManager):
             )
         return PacketWriter.get_packet(OpCode.SMSG_BINDPOINTUPDATE, data)
 
-    # Notify self with surrounding objects or destroy objects that are no longer in range.
+    # Retrieve update packets from world objects, this is called only if object has pending changes. (update_mask bits set)
+    def update_world_object_on_me(self, world_object):
+        if world_object.guid in self.known_objects:
+            if world_object.get_type() == ObjectTypes.TYPE_PLAYER and world_object.dirty_inventory:
+                # This is a known player and has inventory changes.
+                for update_packet in world_object.inventory.get_inventory_update_packets(self):
+                    self.enqueue_packet(update_packet)
+            # Update self with known world object update packet.
+            self.enqueue_packet(world_object.generate_partial_packet(requester=self))
+        # Self (Player), send proper update packets to self.
+        elif world_object.guid == self.guid:
+            self.enqueue_packet(self.generate_partial_packet(requester=self))
+            if self.dirty_inventory:
+                for update_packet in self.inventory.get_inventory_update_packets(self):
+                    self.enqueue_packet(update_packet)
+                self.inventory.build_update()
+
+    # Notify self with create / destroy / partial movement packets of world objects in range.
     # Range = This player current active cell plus its adjacent cells.
-    def update_surrounding_on_me(self):
+    def update_known_world_objects(self, force_update=False):
         players, creatures, game_objects = MapManager.get_surrounding_objects(self, [ObjectTypes.TYPE_PLAYER,
                                                                               ObjectTypes.TYPE_UNIT,
                                                                               ObjectTypes.TYPE_GAMEOBJECT])
@@ -333,12 +350,17 @@ class PlayerManager(UnitManager):
                 if guid not in self.known_objects or not self.known_objects[guid]:
                     # We don't know this player, notify self with its update packet.
                     self.enqueue_packet(NameQueryHandler.get_query_details(player.player))
-                    self.enqueue_packet(player.generate_proper_update_packet(create=True, is_self=False))
+                    # Retrieve their inventory updates.
+                    for update_packet in player.inventory.get_inventory_update_packets(self):
+                        self.enqueue_packet(update_packet)
+                    self.enqueue_packet(player.generate_create_packet(requester=self))
                     # Get partial movement packet if any.
                     if player.movement_manager.unit_is_moving():
                         packet = player.movement_manager.try_build_movement_packet(is_initial=False)
                         if packet:
                             self.enqueue_packet(packet)
+                elif force_update and guid in active_objects:
+                    self.update_world_object_on_me(player)
                 self.known_objects[guid] = player
 
         # Surrounding creatures.
@@ -348,7 +370,7 @@ class PlayerManager(UnitManager):
                 # We don't know this creature, notify self with its update packet.
                 self.enqueue_packet(creature.query_details())
                 if creature.is_spawned:
-                    self.enqueue_packet(creature.generate_proper_update_packet(create=True, is_self=False))
+                    self.enqueue_packet(creature.generate_create_packet(requester=self))
                     # Get partial movement packet if any.
                     if creature.movement_manager.unit_is_moving():
                         packet = creature.movement_manager.try_build_movement_packet(is_initial=False)
@@ -359,6 +381,8 @@ class PlayerManager(UnitManager):
             # Player knows the creature but is not spawned anymore, destroy it for self.
             elif guid in self.known_objects and not creature.is_spawned:
                 active_objects.pop(guid)
+            elif force_update and guid in active_objects:
+                self.update_world_object_on_me(creature)
 
         # Surrounding game objects.
         for guid, gobject in game_objects.items():
@@ -367,12 +391,14 @@ class PlayerManager(UnitManager):
                 # We don't know this game object, notify self with its update packet.
                 self.enqueue_packet(gobject.query_details())
                 if gobject.is_spawned:
-                    self.enqueue_packet(gobject.generate_proper_update_packet(create=True, is_self=False))
+                    self.enqueue_packet(gobject.generate_create_packet(requester=self))
                     # We only consider 'known' if its spawned, the details query is still sent.
                     self.known_objects[guid] = gobject
             # Player knows the game object but is not spawned anymore, destroy it for self.
             elif guid in self.known_objects and not gobject.is_spawned:
                 active_objects.pop(guid)
+            elif force_update and guid in active_objects:
+                self.update_world_object_on_me(gobject)
 
         # World objects which are known but no longer active to self should be destroyed.
         for guid, known_object in list(self.known_objects.items()):
@@ -495,14 +521,14 @@ class PlayerManager(UnitManager):
 
         # Notify player with create packet if not relocating (Changed map).
         if not self.is_relocating:
-            self.enqueue_packet(self.generate_proper_update_packet(is_self=True, create=True))
+            self.enqueue_packet(self.generate_create_packet(requester=self))
 
         # Get us in a new grid.
         MapManager.update_object(self)
 
         # Update self and surroundings, map/cell might be the same but states could've changed.
         if self.is_relocating:
-            MapManager.send_surrounding(self.generate_proper_update_packet(), self)
+            MapManager.send_surrounding(self.generate_partial_packet(requester=self), self)
 
         self.pending_teleport_destination_map = -1
         self.pending_teleport_destination = None
@@ -632,7 +658,6 @@ class PlayerManager(UnitManager):
 
                 if not enemy.loot_manager.has_loot():
                     enemy.set_lootable(False)
-                    enemy.set_dirty()
                     enemy.loot_manager.clear()
 
                 enemy.loot_manager.remove_active_looter(self)
@@ -647,7 +672,6 @@ class PlayerManager(UnitManager):
             Logger.warning(f'Unhandled loot release for type {HighGuid(high_guid).name}')
 
         self.current_loot_selection = 0
-        self.set_dirty()
 
     def send_loot(self, world_object):
         self.current_loot_selection = world_object.guid
@@ -739,7 +763,6 @@ class PlayerManager(UnitManager):
         else:
             self.xp = self.xp + total_amount
             self.set_uint32(PlayerFields.PLAYER_XP, self.xp)
-            self.send_update_self()
 
     def mod_level(self, level):
         if level != self.level:
@@ -773,7 +796,7 @@ class PlayerManager(UnitManager):
                 self.player.leveltime = 0
 
                 self.stat_manager.init_stats()
-                hp_diff, mana_diff = self.stat_manager.apply_bonuses(set_dirty=False)
+                hp_diff, mana_diff = self.stat_manager.apply_bonuses()
                 self.set_health(self.max_health)
                 self.set_mana(self.max_power_1)
 
@@ -794,8 +817,6 @@ class PlayerManager(UnitManager):
                 self.set_uint32(PlayerFields.PLAYER_NEXT_LEVEL_XP, self.next_level_xp)
                 self.quest_manager.update_surrounding_quest_status()
                 self.friends_manager.send_update_to_friends()
-
-                self.set_dirty()
 
     def player_or_group_require_quest_item(self, item_entry, only_self=False):
         if not self.group_manager or only_self:
@@ -824,7 +845,10 @@ class PlayerManager(UnitManager):
             self.coinage += amount
 
         self.set_uint32(UnitFields.UNIT_FIELD_COINAGE, self.coinage)
-        self.send_update_self(self.generate_proper_update_packet(is_self=True), force_inventory_update=reload_items)
+
+        # If there was a pending dirty inventory, do not override.
+        if not reload_items and not self.dirty_inventory:
+            self.dirty_inventory = False
 
     def on_zone_change(self, new_zone):
         # Update player zone.
@@ -912,7 +936,7 @@ class PlayerManager(UnitManager):
             self.liquid_information = MapManager.get_liquid_information(self.map_, self.location.x, self.location.y, self.location.z)
 
     # override
-    def get_full_update_packet(self, is_self=True):
+    def get_full_update_packet(self, requester):
         self.bytes_0 = unpack('<I', pack('<4B', self.player.race, self.player.class_, self.gender, self.power_type))[0]
         self.bytes_1 = unpack('<I', pack('<4B', self.stand_state, 0, self.shapeshift_form, self.sheath_state))[0]
         self.bytes_2 = unpack('<I', pack('<4B', self.combo_points, 0, 0, 0))[0]
@@ -1010,13 +1034,14 @@ class PlayerManager(UnitManager):
             self.duel_manager.build_update(self)
 
         # Inventory
-        self.inventory.send_inventory_update(is_self)
+        for update_packet in self.inventory.get_inventory_update_packets(self):
+            self.enqueue_packet(update_packet)
         self.inventory.build_update()
 
         # Quests
         self.quest_manager.build_update()
 
-        return self.get_object_create_packet(is_self)
+        return self.get_object_create_packet(requester)
 
     def set_current_selection(self, guid):
         self.current_selection = guid
@@ -1171,9 +1196,6 @@ class PlayerManager(UnitManager):
                     elif self.power_4 < self.max_power_4:
                         self.set_energy(self.power_4 + 20)
 
-            if should_update_health or should_update_power:
-                self.set_dirty()
-
             self.last_regen = current_time
 
     def calculate_base_attack_damage(self, attack_type: AttackTypes, attack_school: SpellSchools, target: UnitManager, apply_bonuses=True):
@@ -1203,7 +1225,6 @@ class PlayerManager(UnitManager):
         if self.player.class_ == Classes.CLASS_WARRIOR or (self.player.class_ == Classes.CLASS_DRUID and
                                                            self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BEAR)):
             self.set_rage(self.power_2 + Formulas.PlayerFormulas.calculate_rage_regen(damage_info, is_player=is_player))
-            self.set_dirty()
 
     # override
     def handle_combat_skill_gain(self, damage_info):
@@ -1311,8 +1332,6 @@ class PlayerManager(UnitManager):
         self.combo_target = target.guid
         self.set_uint64(UnitFields.UNIT_FIELD_COMBO_TARGET, self.combo_target)
 
-        self.set_dirty()
-
     # override
     def remove_combo_points(self):
         self.combo_points = 0
@@ -1336,15 +1355,15 @@ class PlayerManager(UnitManager):
         data = pack('<IQ', amount, source.guid)
         self.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_HEALSPELL_ON_PLAYER, data))
 
-    def set_dirty(self, is_dirty=True, dirty_inventory=False):
-        self.dirty = is_dirty
-        self.dirty_inventory = dirty_inventory
-
     def enqueue_packet(self, data):
         if self.session:
             self.session.enqueue_packet(data)
         else:
             Logger.warning('Tried to send packet to null session.')
+
+    # override
+    def has_pending_updates(self):
+        return self.update_packet_factory.has_pending_updates() or self.dirty_inventory
 
     # override
     def update(self):
@@ -1393,46 +1412,35 @@ class PlayerManager(UnitManager):
                 if self.logout_timer < 0:
                     self.logout()
 
-            # Check "dirtiness" to determine if this player object should be updated yet or not.
-            if self.dirty and self.online:
-                self.send_update_self(reset_fields=False)
-                self.send_create_packet_surroundings(self.generate_proper_update_packet())
-                if self.reset_fields_older_than(now):
-                    self.set_dirty(is_dirty=False, dirty_inventory=False)
+            # Check if player has pending updates.
+            if self.has_pending_updates() and self.online:
+                MapManager.update_object(self, check_pending_changes=True)
+                # Reset fields older than NOW. Do not use 'now' since new updates could've been made in between.
+                self.reset_fields_older_than(now)
+                if self.dirty_inventory:
+                    self.dirty_inventory = False
             # Not dirty, has a pending teleport and a teleport is not ongoing.
-            elif not self.dirty and self.pending_teleport_destination and not self.update_lock:
+            elif not self.has_pending_updates() and self.pending_teleport_destination and not self.update_lock:
                 self.trigger_teleport()
 
         self.last_tick = now
 
-    def send_update_self(self, update_packet=None, create=False, force_inventory_update=False, reset_fields=True):
+    def send_update_self(self, update_packet=None, create=False):
+
         if create:
             self.enqueue_packet(NameQueryHandler.get_query_details(self.player))
         else:
-            if self.dirty_inventory or force_inventory_update:
-                self.inventory.send_inventory_update(is_self=True)
-                self.inventory.build_update()
+            if self.dirty_inventory:
+                for update_packet in self.inventory.get_inventory_update_packets(self):
+                    self.enqueue_packet(update_packet)
 
         if not update_packet:
-            update_packet = self.generate_proper_update_packet(is_self=True, create=create)
+            if create:
+                update_packet = self.generate_create_packet(requester=self)
+            else:
+                update_packet = self.generate_partial_packet(requester=self)
 
         self.enqueue_packet(update_packet)
-
-        if reset_fields:
-            self.reset_fields_older_than(time.time())
-
-    # override
-    def send_create_packet_surroundings(self, update_packet, include_self=False, create=False,
-                                        force_inventory_update=False):
-        if create:
-            MapManager.send_surrounding(NameQueryHandler.get_query_details(self.player), self,
-                                        include_self=include_self)
-        else:
-            if self.dirty_inventory or force_inventory_update:
-                self.inventory.send_inventory_update(is_self=False)
-                self.inventory.build_update()
-
-        MapManager.send_surrounding(update_packet, self, include_self=include_self)
 
     def teleport_deathbind(self):
         self.teleport(self.deathbind.deathbind_map, Vector(self.deathbind.deathbind_position_x,
@@ -1463,7 +1471,6 @@ class PlayerManager(UnitManager):
         self.mirror_timers_manager.stop_all()
         self.update_swimming_state(False)
 
-        self.set_dirty()
         return True
 
     # override

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -357,7 +357,6 @@ class SkillManager(object):
         # TODO Skill gain config value?
         self.set_skill(skill_id, current_unmodified_skill + 1)
         self.build_update()
-        self.player_mgr.set_dirty()
         return True
 
     def handle_defense_skill_gain_chance(self, damage_info):
@@ -393,7 +392,6 @@ class SkillManager(object):
         # Dodge / parry / block chance displayed in the player's abilities depends on current defense skill.
         self.player_mgr.stat_manager.send_defense_bonuses()
 
-        self.player_mgr.set_dirty()
         return True
 
     def can_use_equipment(self, item_class, item_subclass):

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -187,7 +187,7 @@ class StatManager(object):
     def get_stat_skill_bonus(self, skill_type):  # Avoids circular import with SkillManager
         return self.get_total_stat(UnitStats.SKILL, misc_value=skill_type)
 
-    def apply_bonuses(self, replenish=False, set_dirty=True):
+    def apply_bonuses(self, replenish=False):
         self.calculate_item_stats()
 
         # Always update base attack since unarmed damage should update.
@@ -223,9 +223,6 @@ class StatManager(object):
             self.unit_mgr.set_health(self.unit_mgr.max_health)
             if self.unit_mgr.power_type != PowerTypes.TYPE_RAGE:
                 self.unit_mgr.recharge_power()
-
-        if set_dirty:
-            self.unit_mgr.set_dirty()
 
         return hp_diff, mana_diff
 

--- a/game/world/managers/objects/units/player/guild/GuildManager.py
+++ b/game/world/managers/objects/units/player/guild/GuildManager.py
@@ -64,7 +64,6 @@ class GuildManager(object):
         player_mgr = WorldSessionStateHandler.find_player_by_guid(player_guid)
         if player_mgr:
             player_mgr.set_uint32(PlayerFields.PLAYER_GUILDRANK, member.rank)
-            player_mgr.set_dirty()
 
     def update_db_guild_members(self):
         for member in self.members.values():
@@ -118,7 +117,6 @@ class GuildManager(object):
         data += pack(f'<{len(name_bytes)}s', name_bytes)
 
         self.build_update(player_mgr)
-        player_mgr.set_dirty()
 
         packet = PacketWriter.get_packet(OpCode.SMSG_GUILD_EVENT, data)
         self.send_message_to_guild(packet, GuildChatMessageTypes.G_MSGTYPE_ALL)
@@ -152,7 +150,6 @@ class GuildManager(object):
         if player_mgr:
             self.build_update(player_mgr, unset=True)
             player_mgr.guild_manager = None
-            player_mgr.set_dirty()
 
     def leave(self, player_guid):
         member = self.members[player_guid]
@@ -173,7 +170,6 @@ class GuildManager(object):
         if player_mgr:
             self.build_update(player_mgr, unset=True)
             player_mgr.guild_manager = None
-            player_mgr.set_dirty()
 
     def disband(self):
         data = pack('<2B', GuildEvents.GUILD_EVENT_DISBANDED, 1)
@@ -191,7 +187,6 @@ class GuildManager(object):
             if player_mgr:
                 self.build_update(player_mgr, unset=True)
                 player_mgr.guild_manager = None
-                player_mgr.set_dirty()
 
         GuildManager.GUILDS.pop(self.guild.name)
         self.members.clear()
@@ -251,7 +246,6 @@ class GuildManager(object):
         player_mgr = WorldSessionStateHandler.find_player_by_guid(member.guid)
         if player_mgr:
             player_mgr.set_uint32(PlayerFields.PLAYER_GUILDRANK, member.rank)
-            player_mgr.set_dirty()
 
         self.update_db_guild_members()
         return True
@@ -286,7 +280,6 @@ class GuildManager(object):
         player_mgr = WorldSessionStateHandler.find_player_by_guid(member.guid)
         if player_mgr:
             player_mgr.set_uint32(PlayerFields.PLAYER_GUILDRANK, member.rank)
-            player_mgr.set_dirty()
 
         self.update_db_guild_members()
         return True
@@ -323,7 +316,7 @@ class GuildManager(object):
 
         query_packet = self.build_guild_query()
         MapManager.send_surrounding(query_packet, player_mgr, include_self=True)
-        player_mgr.set_dirty(dirty_inventory=True)
+        player_mgr.dirty_inventory = True
 
     def build_guild_query(self):
         data = pack('<I', self.guild.guild_id)

--- a/game/world/managers/objects/units/player/guild/GuildManager.py
+++ b/game/world/managers/objects/units/player/guild/GuildManager.py
@@ -316,7 +316,6 @@ class GuildManager(object):
 
         query_packet = self.build_guild_query()
         MapManager.send_surrounding(query_packet, player_mgr, include_self=True)
-        player_mgr.dirty_inventory = True
 
     def build_guild_query(self):
         data = pack('<I', self.guild.guild_id)

--- a/game/world/managers/objects/units/player/quest/ActiveQuest.py
+++ b/game/world/managers/objects/units/player/quest/ActiveQuest.py
@@ -19,6 +19,24 @@ class ActiveQuest:
         # TODO: check that quest_giver_guid is turn-in for quest_id
         return True
 
+    def need_item_from_go(self, go_loot_template):
+        # Quest is complete.
+        if self.is_quest_complete(0):
+            return False
+
+        needed_items = list(filter((0).__ne__, QuestHelpers.generate_req_item_list(self.quest)))
+
+        # Not required items for this quest.
+        if len(needed_items) == 0:
+            return False
+
+        # Check if any needed items match the provided go_loot_template.
+        for entry in go_loot_template:
+            if entry.item in needed_items:
+                return True
+
+        return False
+
     # noinspection PyMethodMayBeStatic
     def has_item_reward(self):
         for index in range(1, 5):

--- a/game/world/managers/objects/units/player/quest/QuestManager.py
+++ b/game/world/managers/objects/units/player/quest/QuestManager.py
@@ -578,7 +578,7 @@ class QuestManager(object):
         req_src_item = quest.SrcItemId
         req_src_item_count = quest.SrcItemCount
         if req_src_item != 0:
-            if not self.player_mgr.inventory.add_item(req_src_item, count=req_src_item_count):
+            if not self.player_mgr.inventory.add_item(req_src_item, count=req_src_item_count, update_inventory=True):
                 return
 
         active_quest = self._create_db_quest_status(quest)
@@ -658,7 +658,7 @@ class QuestManager(object):
         # Add the chosen item, if any.
         rew_item_choice_list = QuestHelpers.generate_rew_choice_item_list(active_quest.quest)
         if item_choice < len(rew_item_choice_list) and rew_item_choice_list[item_choice] > 0:
-            self.player_mgr.inventory.add_item(entry=rew_item_choice_list[item_choice], show_item_get=False)
+            self.player_mgr.inventory.add_item(entry=rew_item_choice_list[item_choice], show_item_get=False, update_inventory=True)
 
         given_xp = active_quest.reward_xp()
         given_gold = active_quest.reward_gold()
@@ -684,7 +684,7 @@ class QuestManager(object):
         data += pack('<I', len(rew_item_list))
         for index, rew_item in enumerate(rew_item_list):
             data += pack('<2I', rew_item_list[index], rew_item_count_list[index])
-            self.player_mgr.inventory.add_item(entry=rew_item_list[index], show_item_get=False)
+            self.player_mgr.inventory.add_item(entry=rew_item_list[index], show_item_get=False, update_inventory=True)
 
         # TODO: Handle RewSpell and RewSpellCast upon completion.
         self.player_mgr.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_QUESTGIVER_QUEST_COMPLETE, data))

--- a/game/world/managers/objects/units/player/taxi/TaxiManager.py
+++ b/game/world/managers/objects/units/player/taxi/TaxiManager.py
@@ -60,7 +60,7 @@ class TaxiManager(object):
 
         dest_taxi_node = DbcDatabaseManager.TaxiNodesHolder.taxi_nodes_get_by_map_and_id(self.owner.map_, dest_node)
         self.owner.pending_taxi_destination = Vector(dest_taxi_node.X, dest_taxi_node.Y, dest_taxi_node.Z)
-        self.owner.set_taxi_flying_state(True, mount_display_id, set_dirty=True)
+        self.owner.set_taxi_flying_state(True, mount_display_id)
 
         speed = config.Unit.Player.Defaults.flight_speed
         spline = SplineFlags.SPLINEFLAG_FLYING

--- a/game/world/opcode_handling/handlers/guild/GuildSaveEmblemHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildSaveEmblemHandler.py
@@ -27,5 +27,6 @@ class GuildSaveEmblemHandler(object):
                 world_session.player_mgr.guild_manager.modify_emblem(world_session.player_mgr, style, color,
                                                                      border_style, border_color, background_color)
                 world_session.player_mgr.mod_money(-EMBLEM_COST)
+                world_session.player_mgr.set_dirty_inventory()
 
         return 0

--- a/game/world/opcode_handling/handlers/inventory/AutoequipItemHandler.py
+++ b/game/world/opcode_handling/handlers/inventory/AutoequipItemHandler.py
@@ -17,7 +17,7 @@ class AutoequipItemHandler(object):
             source_item = inventory.get_item(source_bag_slot, source_slot)
             if not source_container or not source_item:
                 # Something is really malfunctioning or client sent wrong data, try to reload the inventory
-                world_session.player_mgr.dirty_inventory = True
+                world_session.player_mgr.set_dirty_inventory()
                 return 0
 
             inv_type = source_item.item_template.inventory_type
@@ -33,4 +33,5 @@ class AutoequipItemHandler(object):
                 inventory.send_equip_error(InventoryError.BAG_NOT_EQUIPPABLE, source_item, None)
                 return 0
             inventory.swap_item(source_bag_slot, source_slot, target_bag_slot, target_slot)
+            world_session.player_mgr.set_dirty_inventory()
         return 0

--- a/game/world/opcode_handling/handlers/inventory/AutoequipItemHandler.py
+++ b/game/world/opcode_handling/handlers/inventory/AutoequipItemHandler.py
@@ -17,7 +17,7 @@ class AutoequipItemHandler(object):
             source_item = inventory.get_item(source_bag_slot, source_slot)
             if not source_container or not source_item:
                 # Something is really malfunctioning or client sent wrong data, try to reload the inventory
-                world_session.player_mgr.set_dirty(is_dirty=True, dirty_inventory=True)
+                world_session.player_mgr.dirty_inventory = True
                 return 0
 
             inv_type = source_item.item_template.inventory_type

--- a/game/world/opcode_handling/handlers/inventory/AutostoreBagItemHandler.py
+++ b/game/world/opcode_handling/handlers/inventory/AutostoreBagItemHandler.py
@@ -44,5 +44,6 @@ class AutostoreBagItemHandler(object):
                 inventory.send_equip_error(InventoryError.BAG_LOOT_GONE, source_item, None)
                 return 0
             inventory.swap_item(source_bag_slot, source_slot, dest_bag_slot, dest_slot)
+            world_session.player_mgr.set_dirty_inventory()
 
         return 0

--- a/game/world/opcode_handling/handlers/inventory/DestroyItemHandler.py
+++ b/game/world/opcode_handling/handlers/inventory/DestroyItemHandler.py
@@ -25,7 +25,7 @@ class DestroyItemHandler(object):
             world_session.player_mgr.inventory.remove_item(bag, source_slot, True)
 
             if world_session.player_mgr.inventory.is_equipment_pos(bag, source_slot):
-                world_session.player_mgr.set_dirty(dirty_inventory=True)
+                world_session.player_mgr.dirty_inventory = True
             else:
-                world_session.player_mgr.send_update_self(force_inventory_update=True)
+                world_session.player_mgr.dirty_inventory = True
         return 0

--- a/game/world/opcode_handling/handlers/inventory/DestroyItemHandler.py
+++ b/game/world/opcode_handling/handlers/inventory/DestroyItemHandler.py
@@ -23,9 +23,5 @@ class DestroyItemHandler(object):
                 return 0
 
             world_session.player_mgr.inventory.remove_item(bag, source_slot, True)
-
-            if world_session.player_mgr.inventory.is_equipment_pos(bag, source_slot):
-                world_session.player_mgr.dirty_inventory = True
-            else:
-                world_session.player_mgr.dirty_inventory = True
+            world_session.player_mgr.set_dirty_inventory()
         return 0

--- a/game/world/opcode_handling/handlers/inventory/SplitItemHandler.py
+++ b/game/world/opcode_handling/handlers/inventory/SplitItemHandler.py
@@ -31,5 +31,5 @@ class SplitItemHandler(object):
                 return 0
             source_item.item_instance.stackcount -= count
             RealmDatabaseManager.character_inventory_update_item(source_item.item_instance)
-            inventory.owner.send_update_self(force_inventory_update=True)
+            inventory.owner.dirty_inventory = True
         return 0

--- a/game/world/opcode_handling/handlers/inventory/SplitItemHandler.py
+++ b/game/world/opcode_handling/handlers/inventory/SplitItemHandler.py
@@ -31,5 +31,5 @@ class SplitItemHandler(object):
                 return 0
             source_item.item_instance.stackcount -= count
             RealmDatabaseManager.character_inventory_update_item(source_item.item_instance)
-            inventory.owner.dirty_inventory = True
+            world_session.player_mgr.set_dirty_inventory()
         return 0

--- a/game/world/opcode_handling/handlers/inventory/SwapInvItemHandler.py
+++ b/game/world/opcode_handling/handlers/inventory/SwapInvItemHandler.py
@@ -11,4 +11,5 @@ class SwapInvItemHandler(object):
             source_slot, dest_slot = unpack('<2B', reader.data[:2])
             bag = InventorySlots.SLOT_INBACKPACK.value
             world_session.player_mgr.inventory.swap_item(bag, source_slot, bag, dest_slot)
+            world_session.player_mgr.set_dirty_inventory()
         return 0

--- a/game/world/opcode_handling/handlers/inventory/SwapItemHandler.py
+++ b/game/world/opcode_handling/handlers/inventory/SwapItemHandler.py
@@ -15,4 +15,5 @@ class SwapItemHandler(object):
                 source_bag = InventorySlots.SLOT_INBACKPACK.value
 
             world_session.player_mgr.inventory.swap_item(source_bag, source_slot, dest_bag, dest_slot)
+            world_session.player_mgr.set_dirty_inventory()
         return 0

--- a/game/world/opcode_handling/handlers/loot/LootRequestHandler.py
+++ b/game/world/opcode_handling/handlers/loot/LootRequestHandler.py
@@ -21,6 +21,5 @@ class LootRequestHandler(object):
                 if player.send_loot(enemy):
                     player.unit_flags |= UnitFlags.UNIT_FLAG_LOOTING
                     player.set_uint32(UnitFields.UNIT_FIELD_FLAGS, player.unit_flags)
-                    player.set_dirty()
 
         return 0

--- a/game/world/opcode_handling/handlers/npc/BuyItemHandler.py
+++ b/game/world/opcode_handling/handlers/npc/BuyItemHandler.py
@@ -37,7 +37,7 @@ class BuyItemHandler(object):
                         return 0
 
                     if world_session.player_mgr.inventory.add_item(item_template=item_template, count=real_count):
-                        world_session.player_mgr.mod_money(total_cost * -1)
+                        world_session.player_mgr.mod_money(total_cost * -1, reload_items=True)
                         # vendor_npc.send_inventory_list(world_session)
                 else:
                     world_session.player_mgr.inventory.send_buy_error(BuyResults.BUY_ERR_CANT_FIND_ITEM, item,

--- a/game/world/opcode_handling/handlers/npc/BuyItemHandler.py
+++ b/game/world/opcode_handling/handlers/npc/BuyItemHandler.py
@@ -37,7 +37,7 @@ class BuyItemHandler(object):
                         return 0
 
                     if world_session.player_mgr.inventory.add_item(item_template=item_template, count=real_count):
-                        world_session.player_mgr.mod_money(total_cost * -1, reload_items=True)
+                        world_session.player_mgr.mod_money(total_cost * -1, update_inventory=True)
                         # vendor_npc.send_inventory_list(world_session)
                 else:
                     world_session.player_mgr.inventory.send_buy_error(BuyResults.BUY_ERR_CANT_FIND_ITEM, item,

--- a/game/world/opcode_handling/handlers/npc/PetitionBuyHandler.py
+++ b/game/world/opcode_handling/handlers/npc/PetitionBuyHandler.py
@@ -37,6 +37,6 @@ class PetitionBuyHandler(object):
                     petition = PetitionManager.create_petition(world_session.player_mgr.guid, guild_name, petition_item.guid)
                     # We bind this petition to the charter guild item, else its just a dummy item for the client.
                     petition_item.set_enchantment(0, petition.petition_id, 0, 0)
-                    world_session.player_mgr.mod_money(-PetitionManager.CHARTER_COST, reload_items=True)
+                    world_session.player_mgr.mod_money(-PetitionManager.CHARTER_COST, update_inventory=True)
 
         return 0

--- a/game/world/opcode_handling/handlers/npc/SellItemHandler.py
+++ b/game/world/opcode_handling/handlers/npc/SellItemHandler.py
@@ -53,5 +53,5 @@ class SellItemHandler(object):
                 else:
                     world_session.player_mgr.inventory.remove_item(container_slot, slot)
 
-                world_session.player_mgr.mod_money(price * sell_amount, reload_items=True)
+                world_session.player_mgr.mod_money(price * sell_amount, update_inventory=True)
         return 0

--- a/game/world/opcode_handling/handlers/npc/TrainerBuySpellHandler.py
+++ b/game/world/opcode_handling/handlers/npc/TrainerBuySpellHandler.py
@@ -43,9 +43,6 @@ class TrainerBuySpellHandler(object):
                     world_session.player_mgr.spell_manager.start_spell_cast(initialized_spell=initialized_spell)
 
                     world_session.player_mgr.remove_talent_points(talent_cost)
-                    world_session.player_mgr.send_update_self(
-                        world_session.player_mgr.generate_proper_update_packet(is_self=True),
-                        force_inventory_update=False)
                     TrainerBuySpellHandler.send_trainer_buy_succeeded(world_session, trainer_guid, spell_id)
                     # Send talent list again to refresh it.
                     world_session.player_mgr.talent_manager.send_talent_list()
@@ -101,9 +98,6 @@ class TrainerBuySpellHandler(object):
 
                     if spell_skill_cost > 0:  # Some trainer spells cost skill points in alpha - class trainers trained weapon skills, which cost skill points.
                         world_session.player_mgr.remove_skill_points(spell_skill_cost)
-                        world_session.player_mgr.send_update_self(
-                            world_session.player_mgr.generate_proper_update_packet(is_self=True),
-                            force_inventory_update=False)
 
                     TrainerBuySpellHandler.send_trainer_buy_succeeded(world_session, trainer_guid, spell_id)
                     # TODO Revisit later - re-sending the list is (probably) not the way it should be done,

--- a/game/world/opcode_handling/handlers/player/InspectHandler.py
+++ b/game/world/opcode_handling/handlers/player/InspectHandler.py
@@ -18,8 +18,6 @@ class InspectHandler(object):
                     return 0
 
                 world_session.player_mgr.set_current_selection(guid)
-                world_session.player_mgr.set_dirty()
-
                 data = pack('<Q', world_session.player_mgr.guid)
                 inspected_player.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_INSPECT, data))
         return 0

--- a/game/world/opcode_handling/handlers/player/LogoutCancelHandler.py
+++ b/game/world/opcode_handling/handlers/player/LogoutCancelHandler.py
@@ -9,7 +9,6 @@ class LogoutCancelHandler(object):
     def handle(world_session, socket, reader: PacketReader) -> int:
         world_session.player_mgr.set_stand_state(StandState.UNIT_STANDING)
         world_session.player_mgr.set_root(False)
-        world_session.player_mgr.set_dirty()
         world_session.player_mgr.logout_timer = -1
         world_session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_LOGOUT_CANCEL_ACK))
 

--- a/game/world/opcode_handling/handlers/player/LogoutRequestHandler.py
+++ b/game/world/opcode_handling/handlers/player/LogoutRequestHandler.py
@@ -15,7 +15,6 @@ class LogoutRequestHandler(object):
             if not world_session.player_mgr.is_swimming():
                 world_session.player_mgr.set_stand_state(StandState.UNIT_SITTING)
             world_session.player_mgr.set_root(True)
-            world_session.player_mgr.set_dirty()
             world_session.player_mgr.logout_timer = 20
         world_session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_LOGOUT_RESPONSE, pack('<B', res)))
 

--- a/game/world/opcode_handling/handlers/player/MovementHandler.py
+++ b/game/world/opcode_handling/handlers/player/MovementHandler.py
@@ -57,8 +57,10 @@ class MovementHandler(object):
                                      world_session.player_mgr.guid,
                                      reader.data)
 
-                MapManager.send_surrounding(PacketWriter.get_packet(OpCode(reader.opcode), movement_data),
-                                            world_session.player_mgr, include_self=False)
+                movement_packet = PacketWriter.get_packet(OpCode(reader.opcode), movement_data)
+                if world_session.player_mgr.group_manager:
+                    world_session.player_mgr.group_manager.send_packet_to_members(movement_packet, ignore=[world_session.player_mgr.guid])
+                MapManager.send_surrounding(movement_packet, world_session.player_mgr, include_self=False)
                 MapManager.update_object(world_session.player_mgr)
                 world_session.player_mgr.sync_player()
 
@@ -72,8 +74,7 @@ class MovementHandler(object):
                 if reader.opcode == OpCode.MSG_MOVE_JUMP and \
                         world_session.player_mgr.stand_state != StandState.UNIT_DEAD and \
                         world_session.player_mgr.stand_state != StandState.UNIT_STANDING:
-                    world_session.player_mgr.stand_state = StandState.UNIT_STANDING
-                    world_session.player_mgr.set_dirty()
+                    world_session.player_mgr.set_stand_state(StandState.UNIT_STANDING)
 
             except (AttributeError, error):
                 Logger.error(f'Error while handling {OpCode(reader.opcode).name}, skipping. Data: {reader.data}')

--- a/game/world/opcode_handling/handlers/player/MovementHandler.py
+++ b/game/world/opcode_handling/handlers/player/MovementHandler.py
@@ -58,8 +58,6 @@ class MovementHandler(object):
                                      reader.data)
 
                 movement_packet = PacketWriter.get_packet(OpCode(reader.opcode), movement_data)
-                if world_session.player_mgr.group_manager:
-                    world_session.player_mgr.group_manager.send_packet_to_members(movement_packet, ignore=[world_session.player_mgr.guid])
                 MapManager.send_surrounding(movement_packet, world_session.player_mgr, include_self=False)
                 MapManager.update_object(world_session.player_mgr)
                 world_session.player_mgr.sync_player()

--- a/game/world/opcode_handling/handlers/player/SetWeaponModeHandler.py
+++ b/game/world/opcode_handling/handlers/player/SetWeaponModeHandler.py
@@ -9,6 +9,5 @@ class SetWeaponModeHandler(object):
         if len(reader.data) >= 1:  # Avoid handling empty set weapon mode packet.
             weapon_mode: int = unpack('<B', reader.data[:1])[0]
             world_session.player_mgr.set_weapon_mode(weapon_mode)
-            world_session.player_mgr.set_dirty()
 
         return 0

--- a/game/world/opcode_handling/handlers/player/StandStateChangeHandler.py
+++ b/game/world/opcode_handling/handlers/player/StandStateChangeHandler.py
@@ -11,6 +11,5 @@ class StandStateChangeHandler(object):
         if len(reader.data) >= 4:  # Avoid handling empty stand state packet.
             state: int = unpack('<I', reader.data[:4])[0]
             world_session.player_mgr.set_stand_state(StandState(state))
-            world_session.player_mgr.set_dirty()
 
         return 0

--- a/game/world/opcode_handling/handlers/player/cheats/CreateItemHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/CreateItemHandler.py
@@ -15,5 +15,4 @@ class CreateItemHandler(object):
                 return 0
 
             CommandManager.additem(world_session, str(item_entry))
-
         return 0

--- a/game/world/opcode_handling/handlers/player/cheats/RechargeHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/RechargeHandler.py
@@ -11,6 +11,5 @@ class RechargeHandler(object):
             return 0
 
         world_session.player_mgr.recharge_power()
-        world_session.player_mgr.send_update_self(world_session.player_mgr.generate_proper_update_packet(is_self=True))
 
         return 0

--- a/game/world/opcode_handling/handlers/social/TextEmoteHandler.py
+++ b/game/world/opcode_handling/handlers/social/TextEmoteHandler.py
@@ -40,7 +40,6 @@ class TextEmoteHandler(object):
 
                 emote_id = emote.EmoteID
                 state = StandState.UNIT_STANDING
-                needs_broadcast = True
 
                 if emote_text_id == Emotes.SIT:
                     if not world_session.player_mgr.is_sitting:
@@ -57,10 +56,6 @@ class TextEmoteHandler(object):
                         state = StandState.UNIT_KNEEL
                     world_session.player_mgr.set_stand_state(state)
                 else:
-                    needs_broadcast = False
                     world_session.player_mgr.play_emote(emote_id)
-
-                if needs_broadcast:
-                    world_session.player_mgr.set_dirty()
 
         return 0

--- a/game/world/opcode_handling/handlers/trade/AcceptTradeHandler.py
+++ b/game/world/opcode_handling/handlers/trade/AcceptTradeHandler.py
@@ -60,7 +60,8 @@ class AcceptTradeHandler(object):
                 if other_player_item:
                     player.inventory.add_item(item_template=other_player_item.item_template,
                                               count=other_player_item.item_instance.stackcount,
-                                              show_item_get=False)
+                                              show_item_get=False,
+                                              update_inventory=True)
 
                     other_player.inventory.remove_item(other_player_item.item_instance.bag,
                                                        other_player_item.current_slot, True)
@@ -68,7 +69,8 @@ class AcceptTradeHandler(object):
                 if player_item:
                     other_player.inventory.add_item(item_template=player_item.item_template,
                                                     count=player_item.item_instance.stackcount,
-                                                    show_item_get=False)
+                                                    show_item_get=False,
+                                                    update_inventory=True)
 
                     player.inventory.remove_item(player_item.item_instance.bag,
                                                  player_item.current_slot, True)

--- a/game/world/opcode_handling/handlers/unit/SetSelectionHandler.py
+++ b/game/world/opcode_handling/handlers/unit/SetSelectionHandler.py
@@ -9,6 +9,5 @@ class SetSelectionHandler(object):
             guid = unpack('<Q', reader.data[:8])[0]
             if world_session.player_mgr and world_session.player_mgr.current_selection != guid:
                 world_session.player_mgr.set_current_selection(guid)
-                world_session.player_mgr.set_dirty()
 
         return 0

--- a/game/world/opcode_handling/handlers/unit/SetTargetHandler.py
+++ b/game/world/opcode_handling/handlers/unit/SetTargetHandler.py
@@ -9,6 +9,5 @@ class SetTargetHandler(object):
             guid = unpack('<Q', reader.data[:8])[0]
             if world_session.player_mgr and world_session.player_mgr.current_target != guid:
                 world_session.player_mgr.set_current_target(guid)
-                world_session.player_mgr.set_dirty()
 
         return 0

--- a/network/packet/update/UpdateMask.py
+++ b/network/packet/update/UpdateMask.py
@@ -21,6 +21,9 @@ class UpdateMask(object):
     def to_bytes(self):
         return self.update_mask.tobytes()
 
+    def copy(self):
+        return self.update_mask.copy()
+
     def clear(self):
         self.update_mask.setall(0)
 

--- a/network/packet/update/UpdatePacketFactory.py
+++ b/network/packet/update/UpdatePacketFactory.py
@@ -22,6 +22,9 @@ class UpdatePacketFactory(object):
     def reset(self):
         self.update_mask.clear()
 
+    def has_pending_updates(self):
+        return not self.update_mask.is_empty()
+
     def reset_older_than(self, timestamp_to_compare):
         all_clear = True
         for index, timestamp in enumerate(self.update_timestamps):


### PR DESCRIPTION
- Removed most of 'dirtiness' handling code, a world object is dirty if its update mask has bits set.
- Removed unnecessary create packets, this are only needed when a player meets a world object for the first time.
- Use real tick time and propagate to world objects update calls, this way deltas will be properly calculated towards tick rate.
- Fixed some inventory bugs that were not noticable before, mainly with item swapping.
- Inventory - Set dirtiness mostly from outter caller methods to avoid dirtiness while in the middle of an inventory operation.
- Added support for Quests game objects selective interaction.
- Fixed combat bug in which creatures did not consider more combat targets after killing their main combat target.
- Fixed a lot of wrong Z placements on game objects. (Floating, buried, out of reach, etc)