### PR TITLE
Fix creatures infinite dying bug.

### DIFF
--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -604,7 +604,9 @@ class CreatureManager(UnitManager):
 
     # override
     def die(self, killer=None):
-        super().die(killer)
+        if not super().die(killer):
+            return False
+
         self.loot_manager.generate_loot(killer)
 
         if killer and killer.get_type() == ObjectTypes.TYPE_PLAYER:


### PR DESCRIPTION
/ Dead creatures over Campfires should no longer 'keep dying' and generating infinite loot while still receiving spell damage.