### PR TITLE
Rage generation on received damage

### DIFF
--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -17,7 +17,7 @@ from utils.Formulas import UnitFormulas
 from utils.constants.MiscCodes import ObjectTypeFlags, ObjectTypeIds, AttackTypes, ProcFlags, \
     HitInfo, AttackSwingError, MoveFlags, VictimStates, UnitDynamicTypes, HighGuid
 from utils.constants.SpellCodes import SpellMissReason, SpellHitFlags, SpellSchools, ShapeshiftForms
-from utils.constants.UnitCodes import UnitFlags, StandState, WeaponMode, SplineFlags, PowerTypes, SplineType, UnitStates, Classes
+from utils.constants.UnitCodes import UnitFlags, StandState, WeaponMode, SplineFlags, PowerTypes, SplineType, UnitStates
 from utils.constants.UpdateFields import UnitFields
 
 

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -451,7 +451,11 @@ class UnitManager(ObjectManager):
         return random.randint(min_damage, max_damage)
 
     # Implemented by PlayerManager
-    def generate_rage(self, damage_info, is_player=False):
+    def generate_rage(self, damage_info):
+        return
+
+    # Implemented by PlayerManager
+    def generate_rage_on_received_damage(self, damage_info, is_player=False):
         return
 
     # Implemented by PlayerManager
@@ -495,7 +499,12 @@ class UnitManager(ObjectManager):
         if new_health <= 0:
             self.die(killer=source)
         else:
+            damage_info = DamageInfoHolder()
+            damage_info.damage = amount
+            damage_info.victim = self                                    
             self.set_health(new_health)
+            self.generate_rage_on_received_damage(damage_info, is_player)
+
 
         # If unit is a creature and it's being attacked by another unit, automatically set combat target.
         if not self.combat_target and not is_player and source and source.get_type_id() != ObjectTypeIds.ID_GAMEOBJECT:

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -17,7 +17,7 @@ from utils.Formulas import UnitFormulas
 from utils.constants.MiscCodes import ObjectTypeFlags, ObjectTypeIds, AttackTypes, ProcFlags, \
     HitInfo, AttackSwingError, MoveFlags, VictimStates, UnitDynamicTypes, HighGuid
 from utils.constants.SpellCodes import SpellMissReason, SpellHitFlags, SpellSchools, ShapeshiftForms
-from utils.constants.UnitCodes import UnitFlags, StandState, WeaponMode, SplineFlags, PowerTypes, SplineType, UnitStates
+from utils.constants.UnitCodes import UnitFlags, StandState, WeaponMode, SplineFlags, PowerTypes, SplineType, UnitStates, Classes
 from utils.constants.UpdateFields import UnitFields
 
 
@@ -450,13 +450,24 @@ class UnitManager(ObjectManager):
 
         return random.randint(min_damage, max_damage)
 
-    # Implemented by PlayerManager
     def generate_rage(self, damage_info, is_player=False):
-        return
+        # Defensive/Berserker/Battle stance or Bear form 
+        if self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_DEFENSIVESTANCE)\
+           or self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BERSERKERSTANCE)\
+           or self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BATTLESTANCE)\
+           or self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BEAR):
 
-    # Implemented by PlayerManager
+            self.set_rage(self.power_2 + UnitFormulas.calculate_rage_regen(damage_info, is_player=is_player))
+
     def generate_rage_on_received_damage(self, damage_info):
-        return
+        # Defensive/Battle stance or Bear form 
+        # (0.5.3 Berserker stance does not generate rage on received dmg)
+        if self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_DEFENSIVESTANCE)\
+           or self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BATTLESTANCE)\
+           or self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BEAR):
+
+            add_rage = UnitFormulas.calculate_rage_regen_on_received_damage(damage_info)
+            self.set_rage(self.power_2 + add_rage)
 
     # Implemented by PlayerManager
     def handle_combat_skill_gain(self, damage_info):

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -503,7 +503,7 @@ class UnitManager(ObjectManager):
             damage_info.damage = amount
             damage_info.victim = self                                    
             self.set_health(new_health)
-            self.generate_rage_on_received_damage(damage_info, is_player)
+            self.generate_rage_on_received_damage(damage_info)
 
 
         # If unit is a creature and it's being attacked by another unit, automatically set combat target.

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -451,11 +451,11 @@ class UnitManager(ObjectManager):
         return random.randint(min_damage, max_damage)
 
     # Implemented by PlayerManager
-    def generate_rage(self, damage_info):
+    def generate_rage(self, damage_info, is_player=False):
         return
 
     # Implemented by PlayerManager
-    def generate_rage_on_received_damage(self, damage_info, is_player=False):
+    def generate_rage_on_received_damage(self, damage_info):
         return
 
     # Implemented by PlayerManager

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1235,22 +1235,6 @@ class PlayerManager(UnitManager):
 
         return self.stat_manager.apply_bonuses_for_damage(base_damage, spell_school, target, subclass)
 
-    def generate_rage(self, damage_info, is_player=False):
-        # Warriors or Druids in Bear form
-        if self.player.class_ == Classes.CLASS_WARRIOR or (self.player.class_ == Classes.CLASS_DRUID and
-                                                           self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BEAR)):
-            self.set_rage(self.power_2 + Formulas.PlayerFormulas.calculate_rage_regen(damage_info, is_player=is_player))
-
-    def generate_rage_on_received_damage(self, damage_info):
-        # Def/Battle stance or Bear form 
-        # (Berserker stance doesn't generate rage in 0.5.3)
-        if self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_DEFENSIVESTANCE)\
-           or self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BATTLESTANCE)\
-           or self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BEAR):
-
-            add_rage = Formulas.PlayerFormulas.calculate_rage_regen_on_received_damage(damage_info)
-            self.set_rage(self.power_2 + add_rage)
-
     # override
     def handle_combat_skill_gain(self, damage_info):
         if damage_info.attacker == self:

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1241,6 +1241,13 @@ class PlayerManager(UnitManager):
                                                            self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BEAR)):
             self.set_rage(self.power_2 + Formulas.PlayerFormulas.calculate_rage_regen(damage_info, is_player=is_player))
 
+    def generate_rage_on_received_damage(self, damage_info):
+        # Warriors or Druids in Bear form
+        if self.player.class_ == Classes.CLASS_WARRIOR or (self.player.class_ == Classes.CLASS_DRUID and
+                                                           self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BEAR)):
+            add_rage = Formulas.PlayerFormulas.calculate_rage_regen_on_received_damage(damage_info)
+            self.set_rage(self.power_2 + add_rage)
+
     # override
     def handle_combat_skill_gain(self, damage_info):
         if damage_info.attacker == self:

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1242,9 +1242,12 @@ class PlayerManager(UnitManager):
             self.set_rage(self.power_2 + Formulas.PlayerFormulas.calculate_rage_regen(damage_info, is_player=is_player))
 
     def generate_rage_on_received_damage(self, damage_info):
-        # Warriors or Druids in Bear form
-        if self.player.class_ == Classes.CLASS_WARRIOR or (self.player.class_ == Classes.CLASS_DRUID and
-                                                           self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BEAR)):
+        # Def/Battle stance or Bear form 
+        # (Berserker stance doesn't generate rage in 0.5.3)
+        if self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_DEFENSIVESTANCE)\
+           or self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BATTLESTANCE)\
+           or self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BEAR):
+
             add_rage = Formulas.PlayerFormulas.calculate_rage_regen_on_received_damage(damage_info)
             self.set_rage(self.power_2 + add_rage)
 

--- a/utils/Formulas.py
+++ b/utils/Formulas.py
@@ -75,6 +75,18 @@ class PlayerFormulas(object):
         return gray_level
 
     @staticmethod
+    def calculate_rage_regen_on_received_damage(damage_info):
+        # Vanilla rage formula source http://blue.mmo-champion.com/topic/18325-the-new-rage-formula-by-kalgan/
+
+        rage_gained = (damage_info.damage / PlayerFormulas.rage_conversion_value(damage_info.victim.level)) * 2.5
+
+        # 2458 - Berserker stance generates 30% more rage
+        if (damage_info.victim.aura_manager.get_auras_by_spell_id(2458)):
+            rage_gained *= 1.3
+
+        return int(rage_gained*10)
+
+    @staticmethod
     def calculate_rage_regen(damage_info, is_player=True):
         # R=(15d/4c)+(fs/2) | d=WeaponDamage, c=rage conversion rate, f=hit rating, s=speed
         if is_player:

--- a/utils/Formulas.py
+++ b/utils/Formulas.py
@@ -1,7 +1,7 @@
 import math
 
 from utils.constants.MiscCodes import AttackTypes
-
+from utils.constants.SpellCodes import ShapeshiftForms
 
 # Extracted from the 0.5.3 client as is.
 class Distances(object):
@@ -79,8 +79,8 @@ class PlayerFormulas(object):
         # Vanilla rage formula source http://blue.mmo-champion.com/topic/18325-the-new-rage-formula-by-kalgan/
         rage_gained = (damage_info.damage / PlayerFormulas.rage_conversion_value(damage_info.victim.level)) * 2.5
 
-        # 2458 Berserker stance - generate 30% more rage
-        if (damage_info.victim.aura_manager.get_auras_by_spell_id(2458)):
+        # Berserker stance - generate 30% more rage
+        if (damage_info.victim.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BERSERKERSTANCE)):
             rage_gained *= 1.3
 
         return int(rage_gained*10)

--- a/utils/Formulas.py
+++ b/utils/Formulas.py
@@ -1,7 +1,6 @@
 import math
 
 from utils.constants.MiscCodes import AttackTypes
-from utils.constants.SpellCodes import ShapeshiftForms
 
 # Extracted from the 0.5.3 client as is.
 class Distances(object):
@@ -78,10 +77,6 @@ class PlayerFormulas(object):
     def calculate_rage_regen_on_received_damage(damage_info):
         # Vanilla rage formula source http://blue.mmo-champion.com/topic/18325-the-new-rage-formula-by-kalgan/
         rage_gained = (damage_info.damage / PlayerFormulas.rage_conversion_value(damage_info.victim.level)) * 2.5
-
-        # Berserker stance - generate 30% more rage
-        if (damage_info.victim.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BERSERKERSTANCE)):
-            rage_gained *= 1.3
 
         return int(rage_gained*10)
 

--- a/utils/Formulas.py
+++ b/utils/Formulas.py
@@ -54,29 +54,14 @@ class UnitFormulas(object):
         # TODO: Find better formula?
         return UnitFormulas.interactable_distance(attacker, target) * 0.6
 
-
-class PlayerFormulas(object):
-
     @staticmethod
     def rage_conversion_value(level):
         return 0.0091107836 * level ** 2 + 3.225598133 * level + 4.2652911
 
     @staticmethod
-    def get_gray_level(player_level):
-        gray_level = 0
-        if 5 < player_level < 50:
-            gray_level = int(player_level - math.floor(player_level / 10.0) - 5)
-        elif player_level == 50:
-            gray_level = 40
-        elif 50 < player_level < 60:
-            gray_level = int(player_level - math.floor(player_level / 5.0) - 1)
-
-        return gray_level
-
-    @staticmethod
     def calculate_rage_regen_on_received_damage(damage_info):
         # Vanilla rage formula source http://blue.mmo-champion.com/topic/18325-the-new-rage-formula-by-kalgan/
-        rage_gained = (damage_info.damage / PlayerFormulas.rage_conversion_value(damage_info.victim.level)) * 2.5
+        rage_gained = (damage_info.damage / UnitFormulas.rage_conversion_value(damage_info.victim.level)) * 2.5
 
         return int(rage_gained*10)
 
@@ -98,13 +83,28 @@ class PlayerFormulas(object):
                 if offhand:
                     speed = offhand.item_template.delay
 
-            regen = ((15 * damage) / (4 * PlayerFormulas.rage_conversion_value(damage_info.attacker.level)) + (
+            regen = ((15 * damage) / (4 * UnitFormulas.rage_conversion_value(damage_info.attacker.level)) + (
                         (hit_rate * speed) / 2))
         else:
-            regen = (2.5 * (damage_info.damage / PlayerFormulas.rage_conversion_value(damage_info.victim.level)))
+            regen = (2.5 * (damage_info.damage / UnitFormulas.rage_conversion_value(damage_info.victim.level)))
 
         # Rage is measured 0 - 1000
         return int(regen / 100)
+
+
+class PlayerFormulas(object):
+
+    @staticmethod
+    def get_gray_level(player_level):
+        gray_level = 0
+        if 5 < player_level < 50:
+            gray_level = int(player_level - math.floor(player_level / 10.0) - 5)
+        elif player_level == 50:
+            gray_level = 40
+        elif 50 < player_level < 60:
+            gray_level = int(player_level - math.floor(player_level / 5.0) - 1)
+
+        return gray_level
 
     @staticmethod
     def zero_difference_value(level):

--- a/utils/Formulas.py
+++ b/utils/Formulas.py
@@ -77,10 +77,9 @@ class PlayerFormulas(object):
     @staticmethod
     def calculate_rage_regen_on_received_damage(damage_info):
         # Vanilla rage formula source http://blue.mmo-champion.com/topic/18325-the-new-rage-formula-by-kalgan/
-
         rage_gained = (damage_info.damage / PlayerFormulas.rage_conversion_value(damage_info.victim.level)) * 2.5
 
-        # 2458 - Berserker stance generates 30% more rage
+        # 2458 Berserker stance - generate 30% more rage
         if (damage_info.victim.aura_manager.get_auras_by_spell_id(2458)):
             rage_gained *= 1.3
 


### PR DESCRIPTION
Formula :  Rage Gained = (Damage Taken) / (Rage Conversion at Your Level) * 2.5 

Generate rage on received damage when units have def/battle stance or bear form
(Berserker stance does not generate rage in 0.5.3)

Move rage logic from PlayerMgr to UnitMgr so all units can use rage