### PR TITLE
Proper spell movement interrupt checks, basic stealth aura handling.

### DIFF
--- a/game/world/managers/objects/spell/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/AuraEffectHandler.py
@@ -333,8 +333,7 @@ class AuraEffectHandler:
         if remove:
             effect_target.stat_manager.remove_aura_stat_bonus(aura.index, percentual=True)
             return
-        # Points are positive in dbc
-        amount = -aura.get_effect_points()
+        amount = aura.get_effect_points() - 100
         effect_target.stat_manager.apply_aura_stat_bonus(aura.index, UnitStats.SPEED_RUNNING, amount, percentual=True)
 
     @staticmethod

--- a/game/world/managers/objects/spell/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/AuraEffectHandler.py
@@ -192,6 +192,10 @@ class AuraEffectHandler:
         effect_target.set_root(not remove)
 
     @staticmethod
+    def handle_mod_stealth(aura, effect_target, remove):
+        effect_target.set_stealthed(not remove)
+
+    @staticmethod
     def handle_mod_resistance(aura, effect_target, remove):
         if remove:
             effect_target.stat_manager.remove_aura_stat_bonus(aura.index)
@@ -435,7 +439,9 @@ AURA_EFFECTS = {
     AuraTypes.SPELL_AURA_MOD_STUN: AuraEffectHandler.handle_mod_stun,
     AuraTypes.SPELL_AURA_TRANSFORM: AuraEffectHandler.handle_transform,
     AuraTypes.SPELL_AURA_MOD_ROOT: AuraEffectHandler.handle_mod_root,
+    AuraTypes.SPELL_AURA_MOD_STEALTH: AuraEffectHandler.handle_mod_stealth,
 
+    # Stat modifiers.
     AuraTypes.SPELL_AURA_MOD_RESISTANCE: AuraEffectHandler.handle_mod_resistance,
     AuraTypes.SPELL_AURA_MOD_BASE_RESISTANCE: AuraEffectHandler.handle_mod_base_resistance,
     AuraTypes.SPELL_AURA_MOD_STAT: AuraEffectHandler.handle_mod_stat,

--- a/game/world/managers/objects/spell/AuraManager.py
+++ b/game/world/managers/objects/spell/AuraManager.py
@@ -55,17 +55,11 @@ class AuraManager:
                 self.unit_mgr.attack(aura.caster)
             self.check_aura_interrupts(negative_aura_applied=True)
 
-    has_moved = False  # Set from SpellManager - TODO pass movement info from unit update instead
-
     def update(self, timestamp):
         for aura in list(self.active_auras.values()):
             aura.update(timestamp)  # Update duration and handle periodic effects.
             if aura.has_duration() and aura.get_duration() <= 0:
                 self.remove_aura(aura)
-
-        if len(self.active_auras) > 0:
-            self.check_aura_interrupts(has_moved=self.has_moved)
-        self.has_moved = False
 
     def can_apply_aura(self, aura) -> bool:
         if aura.spell_effect.aura_type == AuraTypes.SPELL_AURA_MOD_SHAPESHIFT and \
@@ -91,7 +85,7 @@ class AuraManager:
                 # as the mount aura is removed via aura interrupts on cast (fixable?).
                 # This results in the spell effect's mount applying instead of dismounting the player,
                 # visually leaving the player on the aura-applied mount.
-                
+
                 return False
 
             if spell_effect.effect_type != SpellEffects.SPELL_EFFECT_APPLY_AURA:
@@ -102,13 +96,13 @@ class AuraManager:
                 return False
         return True
 
-    def check_aura_interrupts(self, has_moved=False, negative_aura_applied=False, cast_spell=False, received_damage=False):
+    def check_aura_interrupts(self, moved=False, negative_aura_applied=False, cast_spell=False, received_damage=False):
         # TODO turning and water-related checks
         # Add once movement information is passed to update.
         flag_cases = {
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_ENTER_COMBAT: self.unit_mgr.in_combat,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NOT_MOUNTED: self.unit_mgr.unit_flags & UnitFlags.UNIT_MASK_MOUNTED,
-            SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_MOVE: has_moved,
+            SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_MOVE: moved,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_CAST: cast_spell,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NEGATIVE_SPELL: negative_aura_applied,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_DAMAGE: received_damage

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -285,22 +285,8 @@ class SpellManager(object):
             return casting_spell
         return None
 
-    has_moved = False
-
-    def flag_as_moved(self):
-        # TODO temporary way of handling this until movement data can be passed to update()
-        if self.caster.object_type_mask & ObjectTypeFlags.TYPE_UNIT:
-            self.caster.aura_manager.has_moved = True
-
-        if len(self.casting_spells) == 0:
-            return
-        self.has_moved = True
-
     def update(self, timestamp):
-        moved = self.has_moved
-        self.has_moved = False  # Reset has_moved on every update
         self.check_spell_cooldowns()
-        self.check_spell_interrupts(moved=moved)
         for casting_spell in list(self.casting_spells):
             # Queued spells cast on swing will be updated on call from attack handling.
             if casting_spell.cast_state == SpellState.SPELL_STATE_DELAYED and \
@@ -337,7 +323,7 @@ class SpellManager(object):
                 self.apply_spell_effects(casting_spell, partial_targets=targets_due)
 
     def check_spell_interrupts(self, moved=False, turned=False, received_damage=False, hit_info=HitInfo.DAMAGE,
-                               interrupted=False, received_auto_attack=False):  # TODO provide interrupted, turned
+                               interrupted=False, received_auto_attack=False):  # TODO provide interrupted
         casting_spell_flag_cases = {
             SpellInterruptFlags.SPELL_INTERRUPT_FLAG_MOVEMENT: moved,
             SpellInterruptFlags.SPELL_INTERRUPT_FLAG_DAMAGE: received_damage,

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -687,7 +687,7 @@ class SpellManager(object):
             self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_NOT_KNOWN)
             return False
 
-        # Unit-only checks.
+        # Caster unit-only checks.
         if self.caster.object_type_mask & ObjectTypeFlags.TYPE_UNIT:
             if not self.caster.is_alive and \
                     casting_spell.spell_entry.Attributes & SpellAttributes.SPELL_ATTR_ALLOW_CAST_WHILE_DEAD != SpellAttributes.SPELL_ATTR_ALLOW_CAST_WHILE_DEAD:
@@ -698,6 +698,13 @@ class SpellManager(object):
                     self.caster.stand_state != StandState.UNIT_STANDING:
                 self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_NOTSTANDING)
                 return False
+
+            if casting_spell.spell_entry.Attributes & SpellAttributes.SPELL_ATTR_ONLY_STEALTHED and \
+                    not self.caster.is_stealthed():
+                self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_ONLY_STEALTHED)
+                return True
+
+        # Target validation.
 
         validation_target = casting_spell.initial_target
         # In the case of the spell requiring an unit target but being cast on self,

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -700,6 +700,16 @@ class UnitManager(ObjectManager):
             self.unit_flags &= ~UnitFlags.UNIT_FLAG_FLEEING
         self.set_uint32(UnitFields.UNIT_FIELD_FLAGS, self.unit_flags)
 
+    def is_stealthed(self):
+        return self.unit_flags & UnitFlags.UNIT_FLAG_SNEAK == UnitFlags.UNIT_FLAG_SNEAK
+
+    def set_stealthed(self, stealthed):
+        if stealthed:
+            self.unit_flags |= UnitFlags.UNIT_FLAG_SNEAK
+        else:
+            self.unit_flags &= ~UnitFlags.UNIT_FLAG_SNEAK
+        self.set_uint32(UnitFields.UNIT_FIELD_FLAGS, self.unit_flags)
+
     def is_fleeing(self):
         return self.unit_flags & UnitFlags.UNIT_FLAG_FLEEING
 


### PR DESCRIPTION
- Remove hacky way of checking for movement on Spell/Aura updates. Use interrupts with movement flags instead.
- Apply unit sneak flag when stealthed and validate stealth state on cast.
- Fix incorrect value for speed decrease auras.