### PR TITLE
Aura updates.

### DIFF
--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -274,7 +274,7 @@ class GameObjectManager(ObjectManager):
         return True
 
     # override
-    def _get_fields_update(self, requester):
+    def _get_fields_update(self, is_create, requester):
         data = pack('<B', self.update_packet_factory.update_mask.block_count)
 
         # Use a temporary bit mask in case we need to set more bits.

--- a/game/world/managers/objects/spell/AuraManager.py
+++ b/game/world/managers/objects/spell/AuraManager.py
@@ -311,8 +311,8 @@ class AuraManager:
         for aura in list(self.active_auras.values()):
             self.remove_aura(aura)
 
-    def build_update(self, send_durations=False):
-        [self.write_aura_to_unit(aura, send_duration=send_durations) for aura in list(self.active_auras.values())]
+    def build_update(self):
+        [self.write_aura_to_unit(aura, send_duration=False) for aura in list(self.active_auras.values())]
 
     def cancel_auras_by_spell_id(self, spell_id):
         auras = self.get_auras_by_spell_id(spell_id)

--- a/game/world/managers/objects/spell/AuraManager.py
+++ b/game/world/managers/objects/spell/AuraManager.py
@@ -63,11 +63,7 @@ class AuraManager:
         # TODO Some aura applications appear twice in the combat log.
         # For example, the proc effect from frost armor appears twice.
         # Gouge seems to appear twice against players (tested in duels), but not against NPCs.
-        if not aura.passive:
-            if not is_refresh:
-                self.write_aura_to_unit(aura)
-                self.write_aura_flag_to_unit(aura)
-            self.send_aura_duration(aura)
+        self.write_aura_to_unit(aura, is_refresh=is_refresh)
 
     def update(self, timestamp):
         for aura in list(self.active_auras.values()):
@@ -309,15 +305,14 @@ class AuraManager:
         if aura.source_spell.trigger_cooldown_on_aura_remove():
             self.unit_mgr.spell_manager.set_on_cooldown(aura.source_spell, start_locked_cooldown=True)
 
-        if aura.passive:
-            return  # Passive auras aren't written to unit.
-
         self.write_aura_to_unit(aura, clear=True)
-        self.write_aura_flag_to_unit(aura, clear=True)
 
     def remove_all_auras(self):
         for aura in list(self.active_auras.values()):
             self.remove_aura(aura)
+
+    def build_update(self, send_durations=False):
+        [self.write_aura_to_unit(aura, send_duration=send_durations) for aura in list(self.active_auras.values())]
 
     def cancel_auras_by_spell_id(self, spell_id):
         auras = self.get_auras_by_spell_id(spell_id)
@@ -348,11 +343,22 @@ class AuraManager:
         data = pack('<Bi', aura.index, int(aura.get_duration()))
         self.unit_mgr.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_UPDATE_AURA_DURATION, data))
 
-    def write_aura_to_unit(self, aura, clear=False):
+    def write_aura_to_unit(self, aura, clear=False, is_refresh=False, send_duration=True):
+        if aura.passive:
+            return  # Passive auras are server-side only.
+
+        if send_duration:
+            self.send_aura_duration(aura)
+
+        if is_refresh:
+            # When refreshing auras, only a duration update is sent.
+            return
+
         field_index = UnitFields.UNIT_FIELD_AURA + aura.index
         self.unit_mgr.set_uint32(field_index, aura.spell_id if not clear else 0)
+        self._write_aura_flag_to_unit(aura, clear)
 
-    def write_aura_flag_to_unit(self, aura, clear=False):
+    def _write_aura_flag_to_unit(self, aura, clear=False):
         if not aura:
             return
         byte = (aura.index & 7) << 2  # magic value for AuraFlags.

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -474,9 +474,6 @@ class CreatureManager(UnitManager):
         self.set_uint32(UnitFields.UNIT_DYNAMIC_FLAGS, self.dynamic_flags)
         self.set_uint32(UnitFields.UNIT_FIELD_DAMAGE, self.damage)
 
-        # Auras
-        self.aura_manager.build_update()
-
         for slot, virtual_item in self.virtual_item_info.items():
             self.set_uint32(UnitFields.UNIT_VIRTUAL_ITEM_SLOT_DISPLAY + slot, virtual_item.display_id)
             self.set_uint32(UnitFields.UNIT_VIRTUAL_ITEM_INFO + (slot * 2) + 0, virtual_item.info_packed)

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -474,6 +474,9 @@ class CreatureManager(UnitManager):
         self.set_uint32(UnitFields.UNIT_DYNAMIC_FLAGS, self.dynamic_flags)
         self.set_uint32(UnitFields.UNIT_FIELD_DAMAGE, self.damage)
 
+        # Auras
+        self.aura_manager.build_update()
+
         for slot, virtual_item in self.virtual_item_info.items():
             self.set_uint32(UnitFields.UNIT_VIRTUAL_ITEM_SLOT_DISPLAY + slot, virtual_item.display_id)
             self.set_uint32(UnitFields.UNIT_VIRTUAL_ITEM_INFO + (slot * 2) + 0, virtual_item.info_packed)

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -528,6 +528,9 @@ class PlayerManager(UnitManager):
         # Get us in a new cell and check for pending changes.
         MapManager.update_object(self, check_pending_changes=True)
 
+        # Restore auras after teleport, else they don't show up on client.
+        self.aura_manager.restore_aura_fields()
+
         self.pending_teleport_destination_map = -1
         self.pending_teleport_destination = None
         self.update_lock = False
@@ -1072,9 +1075,6 @@ class PlayerManager(UnitManager):
 
         # Quests
         self.quest_manager.build_update()
-
-        # Auras
-        self.aura_manager.build_update()
 
         return self.get_object_create_packet(requester)
 

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -517,10 +517,11 @@ class PlayerManager(UnitManager):
             self.map_ = self.pending_teleport_destination_map
             self.location = Vector(self.pending_teleport_destination.x, self.pending_teleport_destination.y, self.pending_teleport_destination.z, self.pending_teleport_destination.o)
 
-        # Player changed map, send initial spells, action buttons and create packet.
+        # Player changed map. Send initial spells, applied auras, action buttons and create packet.
         if not self.is_relocating:
             self.enqueue_packet(self.spell_manager.get_initial_spells())
             self.enqueue_packet(self.get_action_buttons())
+            self.aura_manager.build_update(send_durations=False)
             self.enqueue_packet(self.generate_create_packet(requester=self))
 
         self.unmount()

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -517,11 +517,10 @@ class PlayerManager(UnitManager):
             self.map_ = self.pending_teleport_destination_map
             self.location = Vector(self.pending_teleport_destination.x, self.pending_teleport_destination.y, self.pending_teleport_destination.z, self.pending_teleport_destination.o)
 
-        # Player changed map. Send initial spells, applied auras, action buttons and create packet.
+        # Player changed map. Send initial spells, action buttons and create packet.
         if not self.is_relocating:
             self.enqueue_packet(self.spell_manager.get_initial_spells())
             self.enqueue_packet(self.get_action_buttons())
-            self.aura_manager.build_update(send_durations=False)
             self.enqueue_packet(self.generate_create_packet(requester=self))
 
         self.unmount()
@@ -1073,6 +1072,9 @@ class PlayerManager(UnitManager):
 
         # Quests
         self.quest_manager.build_update()
+
+        # Auras
+        self.aura_manager.build_update()
 
         return self.get_object_create_packet(requester)
 


### PR DESCRIPTION
/ This continues PR #289 by Flug.
/ Aura fields cannot be written like we do with other fields for updates. The client see this as if the aura was applied again even if value did not change for a given field.
/ Player AuraFields will be written once again after teleports, else, the aura does not show up in the UI even if its active.
/ Players will retrieve all AuraFields upon meeting a new unit, after that, they will only update those fields from other units on partial updates if they were really dirty (Changed values)
/ Tested this with players not creatures.