### PR TITLE
Improve proximity aggro.

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -5049,7 +5049,7 @@ begin not atomic
     
     -- 13/06/2022 1
     if (select count(*) from applied_updates where id='131620221') = 0 then
-        -- Invalid Factin 1094 -> 32 (Beast)
+        -- Invalid Faction 1094 -> 32 (Beast)
         UPDATE `alpha_world`.`creature_template` SET `faction` = '32' WHERE (`entry` = '330');
         UPDATE `alpha_world`.`creature_template` SET `faction` = '32' WHERE (`entry` = '390');
         UPDATE `alpha_world`.`creature_template` SET `faction` = '32' WHERE (`entry` = '708');

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -5046,5 +5046,15 @@ begin not atomic
 
         insert into applied_updates values ('280520221');
     end if;
+    
+    -- 13/06/2022 1
+    if (select count(*) from applied_updates where id='131620221') = 0 then
+        -- Invalid Factin 1094 -> 32 (Beast)
+        UPDATE `alpha_world`.`creature_template` SET `faction` = '32' WHERE (`entry` = '330');
+        UPDATE `alpha_world`.`creature_template` SET `faction` = '32' WHERE (`entry` = '390');
+        UPDATE `alpha_world`.`creature_template` SET `faction` = '32' WHERE (`entry` = '708');
+        UPDATE `alpha_world`.`creature_template` SET `faction` = '32' WHERE (`entry` = '1190');
+        insert into applied_updates values ('131620221');
+    end if;
 end $
 delimiter ;

--- a/game/world/managers/objects/ObjectManager.py
+++ b/game/world/managers/objects/ObjectManager.py
@@ -384,15 +384,13 @@ class ObjectManager:
             Logger.error(f'Invalid faction template: {target.faction}.')
             return not check_friendly
 
-        own_enemies = [own_faction.Enemies_1, own_faction.Enemies_2, own_faction.Enemies_3, own_faction.Enemies_4]
-        own_friends = [own_faction.Friend_1, own_faction.Friend_2, own_faction.Friend_3, own_faction.Friend_4]
+        own_enemies = {own_faction.Enemies_1, own_faction.Enemies_2, own_faction.Enemies_3, own_faction.Enemies_4}
+        own_friends = {own_faction.Friend_1, own_faction.Friend_2, own_faction.Friend_3, own_faction.Friend_4}
         if target_faction.Faction > 0:
-            for enemy in own_enemies:
-                if enemy == target_faction.Faction:
-                    return not check_friendly
-            for friend in own_friends:
-                if friend == target_faction.Faction:
-                    return check_friendly
+            if target_faction.Faction in own_enemies:
+                return not check_friendly
+            if target_faction.Faction in own_friends:
+                return check_friendly
 
         if check_friendly:
             return ((own_faction.FriendGroup & target_faction.FactionGroup) or (own_faction.FactionGroup & target_faction.FriendGroup)) != 0

--- a/game/world/managers/objects/ai/BasicCreatureAI.py
+++ b/game/world/managers/objects/ai/BasicCreatureAI.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from game.world.managers.maps.MapManager import MapManager
 from game.world.managers.objects.ai.CreatureAI import CreatureAI
 from utils.constants.CustomCodes import Permits
 from utils.constants.MiscCodes import ObjectTypeIds
-from utils.constants.UnitCodes import CreatureReactStates
+from utils.constants.UnitCodes import CreatureReactStates, AIReactionStates
 
 if TYPE_CHECKING:
     from game.world.managers.objects.units.creature.CreatureManager import CreatureManager
@@ -48,7 +47,8 @@ class BasicCreatureAI(CreatureAI):
             target_is_player = unit.get_type_id() == ObjectTypeIds.ID_PLAYER
             on_same_map = self.creature.map_ == unit.map_
             target_distance = self.creature.location.distance(unit.location)
-            in_detection_range = target_distance <= self.creature.creature_template.detection_range
+            detection_range = self.creature.creature_template.detection_range
+            in_detection_range = target_distance <= detection_range
             if target_is_player and on_same_map and in_detection_range:
                 self._start_proximity_aggro_attack(unit)
 
@@ -71,6 +71,7 @@ class BasicCreatureAI(CreatureAI):
 
     def _start_proximity_aggro_attack(self, victim):
         self.creature.attack(victim)
+        self.send_ai_reaction(victim, AIReactionStates.AI_REACT_HOSTILE)
         threat_not_to_leave_combat = 1E-4
         self.creature.threat_manager.add_threat(victim, threat_not_to_leave_combat)
 

--- a/game/world/managers/objects/ai/BasicCreatureAI.py
+++ b/game/world/managers/objects/ai/BasicCreatureAI.py
@@ -35,10 +35,10 @@ class BasicCreatureAI(CreatureAI):
     def movement_inform(self, move_type=None, data=None):
         if self._is_ready_for_new_attack():
             max_distance = self.creature.creature_template.detection_range
-            aggro_players = MapManager.get_surrounding_players_by_location(self.creature.location, self.creature.map_,
-                                                                           max_distance)
+            aggro_players = self.creature.known_players
             for guid, victim in aggro_players.items():
-                if self.creature.can_attack_target(victim):
+                distance = victim.location.distance(self.creature.location)
+                if self.creature.can_attack_target(victim) and distance <= max_distance:
                     self._start_proximity_aggro_attack(victim)
                     break
 
@@ -62,6 +62,8 @@ class BasicCreatureAI(CreatureAI):
         self.can_summon_guards = self.creature.can_summon_guards() if self.creature else False
 
     def _is_ready_for_new_attack(self):
+        if len(self.creature.known_players) == 0:
+            return False
         return self._is_aggressive() and not self.creature.combat_target and not self.creature.is_evading
 
     def _is_aggressive(self):

--- a/game/world/managers/objects/ai/CreatureAI.py
+++ b/game/world/managers/objects/ai/CreatureAI.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import math
 from random import randint
+from struct import pack
 from typing import TYPE_CHECKING, Optional
 
 from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.managers.objects.script.ScriptManager import ScriptManager
 from game.world.managers.objects.spell import ExtendedSpellData
 from game.world.managers.objects.units.creature.CreatureSpellsEntry import CreatureAISpellsEntry
+from network.packet.PacketWriter import PacketWriter
+from utils.constants.OpCodes import OpCode
 from utils.constants.ScriptCodes import CastFlags
 from utils.constants.SpellCodes import SpellCheckCastResult, SpellTargetMask
 from utils.constants.UnitCodes import UnitFlags, UnitStates
@@ -62,8 +65,15 @@ class CreatureAI:
         pass
 
     # Distract creature, if player gets too close while stealth/prowling.
+    # AIReactionStates.AI_REACT_ALERT
     def trigger_alert(self, unit):
         pass
+
+    # The client modifies unit facing, depending on the reaction.
+    def send_ai_reaction(self, victim, ai_reaction):
+        data = pack('<QI', self.creature.guid, ai_reaction)
+        packet = PacketWriter.get_packet(OpCode.SMSG_AI_REACTION, data)
+        victim.enqueue_packet(packet)
 
     # Called when the creature is killed.
     def just_died(self, unit):

--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -37,6 +37,7 @@ class GameObjectManager(ObjectManager):
         self.gobject_instance = gobject_instance
         self.summoner = summoner
         self.spell_id = 0  # Spell that summoned this object.
+        self.known_players = {}
 
         self.entry = self.gobject_template.entry
         self.native_display_id = self.gobject_template.display_id
@@ -284,6 +285,9 @@ class GameObjectManager(ObjectManager):
                 # Interrupt ritual channel if the summon fails.
                 self.summoner.spell_manager.remove_cast_by_id(ritual_channel_spell_id)
 
+    def has_observers(self):
+        return any(self.known_players)
+
     def apply_spell_damage(self, target, damage, casting_spell, is_periodic=False):
         damage_info = casting_spell.get_cast_damage_info(self, target, damage, 0)
         miss_info = casting_spell.object_target_results[target.guid].result
@@ -488,10 +492,10 @@ class GameObjectManager(ObjectManager):
 
             if self.is_spawned:
                 # Logic for Trap GameObjects (type 6).
-                if self.gobject_template.type == GameObjectTypes.TYPE_TRAP:
+                if self.has_observers() and self.gobject_template.type == GameObjectTypes.TYPE_TRAP:
                     self.trap_manager.update(elapsed)
                 # Logic for Fishing node.
-                if self.gobject_template.type == GameObjectTypes.TYPE_FISHINGNODE:
+                if self.has_observers() and self.gobject_template.type == GameObjectTypes.TYPE_FISHINGNODE:
                     self.fishing_node_manager.update(elapsed)
 
                 # SpellManager update.

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -753,9 +753,13 @@ class UnitManager(ObjectManager):
             return
 
         # Remove self from attacker list of attackers
-        for victim in list(self.attackers.values()):
+        for guid, victim in self.attackers.items():
             if self.guid in victim.attackers:
                 victim.attackers.pop(self.guid)
+                # If this was a forced call, and attacker is attacking this unit, make attackers leave combat as well.
+                if victim.combat_target == self.guid and force:
+                    victim.leave_combat(force=force)
+
         self.attackers.clear()
 
         self.send_attack_stop(self.combat_target.guid if self.combat_target else self.guid)

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -380,7 +380,7 @@ class CreatureManager(UnitManager):
         return False
 
     def can_have_target(self):
-        return self.creature_template.flags_extra & CreatureFlagsExtra.CREATURE_FLAG_EXTRA_NO_TARGET
+        return not self.creature_template.flags_extra & CreatureFlagsExtra.CREATURE_FLAG_EXTRA_NO_TARGET
 
     def set_virtual_item(self, slot, item_entry):
         item_template = None
@@ -603,9 +603,15 @@ class CreatureManager(UnitManager):
     def is_casting(self):
         return self.spell_manager.is_casting()
 
+    def has_observers(self):
+        return any(self.known_players)
+
+    def has_wander_type(self):
+        return self.creature_instance.movement_type == MovementTypes.WANDER
+
     def _perform_random_movement(self, now):
-        # Do not wander in combat, while evading or without wander flag.
-        if not self.in_combat and not self.is_evading and self.creature_instance.movement_type == MovementTypes.WANDER:
+        # Do not wander in combat, while evading, without wander flag or if unit has no observers.
+        if self.in_combat and not self.is_evading and self.has_wander_type():
             if len(self.movement_manager.pending_waypoints) == 0:
                 if now > self.last_random_movement + self.random_movement_wait_time:
                     self.movement_manager.move_random(self.spawn_position,
@@ -613,9 +619,11 @@ class CreatureManager(UnitManager):
                     self.random_movement_wait_time = randint(1, 12)
                     self.last_random_movement = now
 
+    # TODO: All the evade calls should be probably handled by aggro manager, it should be able to decide if unit can
+    #  switch toanother target from the Threat list or evade, or some other action.
     def _perform_combat_movement(self):
         if self.combat_target and not self.is_casting() and not self.is_evading:
-            if not self.combat_target.is_alive and len(self.attackers) == 0:
+            if not self.combat_target.is_alive and len(self.attackers) == 0 or not self.combat_target.online:
                 self.evade()
                 return
 
@@ -645,7 +653,12 @@ class CreatureManager(UnitManager):
             current_distance = self.location.distance(self.combat_target.location)
             combat_position_distance = UnitFormulas.combat_distance(self, self.combat_target)
 
-            # If target is within combat distance, don't move but do check creature orientation.
+            # Current distance to player is above 50.
+            if current_distance > 50:
+                self.evade()
+                return
+
+             # If target is within combat distance, don't move but do check creature orientation.
             if current_distance <= combat_position_distance:
                 # If this creature is not facing the attacker, update its orientation (server-side).
                 if not self.location.has_in_arc(self.combat_target.location, math.pi):
@@ -692,8 +705,9 @@ class CreatureManager(UnitManager):
                 if self.has_moved:
                     self._on_relocation()
                     self.set_has_moved(False)
-                # Random Movement.
-                self._perform_random_movement(now)
+                # Random Movement, if visible to players.
+                if self.has_observers():
+                    self._perform_random_movement(now)
                 # Combat Movement.
                 self._perform_combat_movement()
                 # AI.

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -48,6 +48,7 @@ class CreatureManager(UnitManager):
         self.fully_loaded = False
         self.killed_by = None
         self.summoner = summoner
+        self.known_players = {}
 
         self.entry = self.creature_template.entry
         self.class_ = self.creature_template.unit_class
@@ -90,9 +91,13 @@ class CreatureManager(UnitManager):
         if 0 < self.creature_template.rank < 4:
             self.unit_flags = self.unit_flags | UnitFlags.UNIT_FLAG_PLUS_MOB
 
-        self.react_state = CreatureReactStates.REACT_DEFENSIVE \
-            if self.creature_template.flags_extra & CreatureFlagsExtra.CREATURE_FLAG_EXTRA_NO_AGGRO \
-            else CreatureReactStates.REACT_AGGRESSIVE
+        # TODO, creatures are still resolving to aggressive.
+        if self.is_totem() or self.is_critter() or not self.can_have_target():
+            self.react_state = CreatureReactStates.REACT_PASSIVE
+        elif self.creature_template.flags_extra & CreatureFlagsExtra.CREATURE_FLAG_EXTRA_NO_AGGRO:
+            self.react_state = CreatureReactStates.REACT_DEFENSIVE
+        else:
+            self.react_state = CreatureReactStates.REACT_AGGRESSIVE
 
         self.wearing_offhand_weapon = False
         self.wearing_ranged_weapon = False
@@ -373,6 +378,9 @@ class CreatureManager(UnitManager):
     # TODO, should be able to check 'ownership' or set a custom flag upon creature creation.
     def is_totem(self):
         return False
+
+    def can_have_target(self):
+        return self.creature_template.flags_extra & CreatureFlagsExtra.CREATURE_FLAG_EXTRA_NO_TARGET
 
     def set_virtual_item(self, slot, item_entry):
         item_template = None

--- a/utils/constants/UnitCodes.py
+++ b/utils/constants/UnitCodes.py
@@ -43,6 +43,13 @@ class CreatureReactStates(IntEnum):
     REACT_AGGRESSIVE = 2
 
 
+class AIReactionStates(IntEnum):
+    AI_REACT_ALERT = 0
+    AI_REACT_FRIENDLY = 1
+    AI_REACT_HOSTILE = 2
+    AI_REACT_AFRAID = 3
+
+
 class CreatureTypeFlags(IntEnum):
     # Tameable by any hunter.
     CREATURE_TYPEFLAGS_TAMEABLE = 0x00000001


### PR DESCRIPTION
/ Creatures will now use their known_players collection and avoid get surrounding calls.
/ Invalid Faction 1094 -> 32 (Beast)
/ Send AI reaction state hostile upon aggro.
/ Gameobjects - Do not update traps nor fishing nodes if they have no observers. (Cell still active but no players)
/ Creatures - Do not wander if no observers.
/ Combat - If leave_combat has force flag set, also force current unit attackers to leave combat as well.
/ Quests - use known_objects for update_surrounding_quest_status() calls.
/ Player - Destroy all current known objects to player upon logout and remove self from objects known_players dictionaries.

