### PR TITLE
/ Threat changes and others.

### DIFF
--- a/game/world/managers/objects/ai/BasicCreatureAI.py
+++ b/game/world/managers/objects/ai/BasicCreatureAI.py
@@ -62,7 +62,7 @@ class BasicCreatureAI(CreatureAI):
         self.can_summon_guards = self.creature.can_summon_guards() if self.creature else False
 
     def _is_ready_for_new_attack(self):
-        if len(self.creature.known_players) == 0:
+        if not self.creature.is_alive or not self.creature.is_spawned or len(self.creature.known_players) == 0:
             return False
         return self._is_aggressive() and not self.creature.combat_target and not self.creature.is_evading
 
@@ -70,7 +70,6 @@ class BasicCreatureAI(CreatureAI):
         return self.creature.react_state == CreatureReactStates.REACT_AGGRESSIVE
 
     def _start_proximity_aggro_attack(self, victim):
-        self.creature.attack(victim)
         self.send_ai_reaction(victim, AIReactionStates.AI_REACT_HOSTILE)
         threat_not_to_leave_combat = 1E-4
         self.creature.threat_manager.add_threat(victim, threat_not_to_leave_combat)

--- a/game/world/managers/objects/ai/BasicCreatureAI.py
+++ b/game/world/managers/objects/ai/BasicCreatureAI.py
@@ -62,9 +62,8 @@ class BasicCreatureAI(CreatureAI):
         self.can_summon_guards = self.creature.can_summon_guards() if self.creature else False
 
     def _is_ready_for_new_attack(self):
-        if not self.creature.is_alive or not self.creature.is_spawned or len(self.creature.known_players) == 0:
-            return False
-        return self._is_aggressive() and not self.creature.combat_target and not self.creature.is_evading
+        return self.creature.is_alive and self.creature.is_spawned and len(self.creature.known_players) > 0 \
+               and self._is_aggressive() and not self.creature.combat_target and not self.creature.is_evading
 
     def _is_aggressive(self):
         return self.creature.react_state == CreatureReactStates.REACT_AGGRESSIVE

--- a/game/world/managers/objects/ai/PetAI.py
+++ b/game/world/managers/objects/ai/PetAI.py
@@ -44,7 +44,6 @@ class PetAI(CreatureAI):
 
     # override
     def attack_start(self, victim):
-        self.creature.attack(victim)
         # TODO This is bad, but a workaround for now until a valid solution is discussed.
         self.creature.threat_manager.add_threat(victim, 10)
         self.is_at_home = False

--- a/game/world/managers/objects/gameobjects/FishingNodeManager.py
+++ b/game/world/managers/objects/gameobjects/FishingNodeManager.py
@@ -14,7 +14,7 @@ class FishingNodeManager(object):
     def __init__(self, fishing_node):
         self.fishing_node = fishing_node
         # TODO: Is this the correct approach for splash generation?
-        self.fishing_timer = randint(1, FISHING_CHANNEL_TIME - FISHING_REACTION_TIME)
+        self.fishing_timer = randint(1, int(FISHING_CHANNEL_TIME - FISHING_REACTION_TIME))
         self.became_active_time = 0
         self.hook_result = False
         self.got_away = False

--- a/game/world/managers/objects/gameobjects/GameObjectLootManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectLootManager.py
@@ -17,7 +17,6 @@ class GameObjectLootManager(LootManager):
     # override
     def populate_loot_template(self):
         # Handle Chest
-        # TODO: Investigate db fields 'data'[0/3/N] and 'groupid' so we can filter the loot table properly.
         if self.world_object.gobject_template.type == GameObjectTypes.TYPE_CHEST:
             loot_template_id = self.world_object.gobject_template.data1
             return WorldDatabaseManager.GameObjectLootTemplateHolder.gameobject_loot_template_get_by_entry(loot_template_id)

--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -490,7 +490,7 @@ class GameObjectManager(ObjectManager):
         if now > self.last_tick > 0:
             elapsed = now - self.last_tick
 
-            if self.is_spawned:
+            if self.is_spawned and self.initialized:
                 # Logic for Trap GameObjects (type 6).
                 if self.has_observers() and self.gobject_template.type == GameObjectTypes.TYPE_TRAP:
                     self.trap_manager.update(elapsed)
@@ -505,8 +505,8 @@ class GameObjectManager(ObjectManager):
                 if self.has_pending_updates():
                     MapManager.update_object(self, has_changes=True)
                     self.reset_fields_older_than(now)
-            # Not spawned.
-            else:
+            # Not spawned but initialized.
+            elif self.initialized:
                 self.respawn_timer += elapsed
                 if self.respawn_timer >= self.respawn_time:
                     if self.summoner:

--- a/game/world/managers/objects/loot/LootMapper.py
+++ b/game/world/managers/objects/loot/LootMapper.py
@@ -28,6 +28,6 @@ class LootMapper:
             return loot
 
         if not loot:
-            Logger.warning(f'Unable to locate referenced loot for id {loot_id}')
+            Logger.warning(f'Unable to locate referenced loot for id {loot_id}.')
 
         return None

--- a/game/world/managers/objects/loot/LootMapper.py
+++ b/game/world/managers/objects/loot/LootMapper.py
@@ -1,4 +1,5 @@
 from database.world.WorldDatabaseManager import WorldDatabaseManager
+from utils.Logger import Logger
 
 
 class LootMapper:
@@ -25,4 +26,8 @@ class LootMapper:
         loot = WorldDatabaseManager.ItemLootTemplateHolder.item_loot_template_get_by_entry(loot_id)
         if loot:
             return loot
+
+        if not loot:
+            Logger.warning(f'Unable to locate referenced loot for id {loot_id}')
+
         return None

--- a/game/world/managers/objects/spell/AuraManager.py
+++ b/game/world/managers/objects/spell/AuraManager.py
@@ -29,10 +29,10 @@ class AuraManager:
 
         # Application threat and negative aura application interrupts.
         if aura.harmful:
-            if aura.caster.object_type_mask & ObjectTypeFlags.TYPE_UNIT and \
-                    aura.source_spell.generates_threat():
-                # TODO Replace once threat is handled properly.
-                self.unit_mgr.attack(aura.caster)
+            # Check if we need to add threat on units only.
+            if aura.caster.get_type_id() == ObjectTypeIds.ID_UNIT and aura.source_spell.generates_threat():
+                # TODO: Threat calculation.
+                self.unit_mgr.threat_manager.add_threat(aura.caster, 10)
 
             self.check_aura_interrupts(negative_aura_applied=True)
 

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -191,6 +191,9 @@ class CastingSpell:
     def generates_threat(self):
         return not self.spell_entry.AttributesEx & SpellAttributesEx.SPELL_ATTR_EX_NO_THREAT
 
+    def generates_threat_on_miss(self):
+        return self.spell_entry.AttributesEx & SpellAttributesEx.SPELL_ATTR_EX_THREAT_ON_MISS
+
     def requires_implicit_initial_unit_target(self):
         # Some spells are self casts, but require an implicit unit target when casted.
 

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -757,7 +757,7 @@ class UnitManager(ObjectManager):
             if self.guid in victim.attackers:
                 victim.attackers.pop(self.guid)
                 # If this was a forced call, and attacker is attacking this unit, make attackers leave combat as well.
-                if victim.combat_target == self.guid and force:
+                if victim.combat_target == self and force:
                     victim.leave_combat(force=force)
 
         self.attackers.clear()

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -565,7 +565,7 @@ class UnitManager(ObjectManager):
                                spell_attack_type: AttackTypes = -1):
         return base_damage
 
-    def deal_damage(self, target, damage, is_periodic=False):
+    def deal_damage(self, target, damage, is_periodic=False, casting_spell=None):
         if not target or not target.is_alive:
             return
 
@@ -582,9 +582,9 @@ class UnitManager(ObjectManager):
             if not target.in_combat:
                 target.enter_combat()
 
-        target.receive_damage(damage, source=self, is_periodic=is_periodic)
+        target.receive_damage(damage, source=self, is_periodic=is_periodic, casting_spell=casting_spell)
 
-    def receive_damage(self, amount, source=None, is_periodic=False):
+    def receive_damage(self, amount, source=None, is_periodic=False, casting_spell=None):
         if source is not self and not is_periodic and amount > 0:
             self.aura_manager.check_aura_interrupts(received_damage=True)
             self.spell_manager.check_spell_interrupts(received_damage=True)
@@ -649,7 +649,7 @@ class UnitManager(ObjectManager):
         self.send_spell_cast_debug_info(damage_info, miss_reason, casting_spell.spell_entry.ID, is_periodic=is_periodic,
                                         is_cast_on_swing=is_cast_on_swing)
 
-        self.deal_damage(target, damage, is_periodic)
+        self.deal_damage(target, damage, is_periodic=is_periodic, casting_spell=casting_spell)
 
     def apply_spell_healing(self, target, healing, casting_spell, is_periodic=False):
         miss_info = casting_spell.object_target_results[target.guid].result

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -748,7 +748,7 @@ class CreatureManager(UnitManager):
     # override
     def attack_update(self, elapsed):
         target = self.threat_manager.get_hostile_target()
-        # Have a target, check if we need to attack or switch target.
+        # Has a target, check if we need to attack or switch target.
         if target and self.combat_target != target:
             self.attack(target)
         # No target at all, leave combat, reset aggro.

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -753,7 +753,6 @@ class CreatureManager(UnitManager):
             self.attack(target)
         # No target at all, leave combat, reset aggro.
         elif not target:
-            self.threat_manager.reset()
             self.leave_combat()
             return
 

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -759,7 +759,7 @@ class CreatureManager(UnitManager):
         super().attack_update(elapsed)
 
     # override
-    def receive_damage(self, amount, source=None, is_periodic=False):
+    def receive_damage(self, amount, source=None, is_periodic=False, casting_spell=None):
         super().receive_damage(amount, source, is_periodic)
 
         if self.is_alive:
@@ -769,8 +769,17 @@ class CreatureManager(UnitManager):
                 # Make sure to first stop any movement right away.
                 if len(self.movement_manager.pending_waypoints) > 0:
                     self.movement_manager.send_move_stop()
+
+            threat = amount
             # TODO: Threat calculation.
-            self.threat_manager.add_threat(source, amount if amount > 0 else 10)
+            # No threat but source spell generates threat on miss.
+            if casting_spell and threat == 0 and casting_spell.generates_threat_on_miss():
+                threat = 10
+            # Physical miss, block, etc.
+            elif not casting_spell and threat == 0:
+                threat = 10
+
+            self.threat_manager.add_threat(source, threat)
 
     # override
     def respawn(self):

--- a/game/world/managers/objects/units/creature/ThreatManager.py
+++ b/game/world/managers/objects/units/creature/ThreatManager.py
@@ -33,6 +33,12 @@ class ThreatManager:
             else:
                 Logger.warning(f'Passed non positive threat {threat} from {source.guid & ~HighGuid.HIGHGUID_UNIT}')
 
+    def resolve_target(self):
+        if len(self.holders) == 0:
+            return None
+        else:
+            return self.get_hostile_target()
+
     def get_hostile_target(self) -> Optional[UnitManager]:
         max_threat_holder = self._get_max_threat_holder()
 

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -396,6 +396,8 @@ class PlayerManager(UnitManager):
                     self.known_objects[guid] = creature
                     # Add ourselves to creature known players.
                     creature.known_players[self.guid] = self
+                    # Notify this creature of our presence, e.g. player just logged in or a creature spawns near.
+                    creature.notify_moved_in_line_of_sight(self)
             # Player knows the creature but is not spawned anymore, destroy it for self.
             elif guid in self.known_objects and not creature.is_spawned:
                 active_objects.pop(guid)
@@ -1594,8 +1596,8 @@ class PlayerManager(UnitManager):
 
     def _on_relocation(self):
         for guid, unit in MapManager.get_surrounding_units(self).items():
-            # Skip notify if the unit is already in combat with self.
-            if self.guid not in unit.attackers:
+            # Skip notify if the unit is already in combat with self, not alive or not spawned.
+            if self.guid not in unit.attackers and unit.is_alive and unit.is_spawned:
                 unit.notify_moved_in_line_of_sight(self)
 
     # override

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1372,7 +1372,7 @@ class PlayerManager(UnitManager):
         self.set_uint64(UnitFields.UNIT_FIELD_COMBO_TARGET, self.combo_target)
 
     # override
-    def receive_damage(self, amount, source=None, is_periodic=False):
+    def receive_damage(self, amount, source=None, is_periodic=False, casting_spell=None):
         if self.is_god:
             return
 


### PR DESCRIPTION
/ ThreatManager - Creatures should no longer keep looking for players and trying to aggro them while dead or not spawned.
/ ThreatManager - All attack starts should now be triggered by ThreatManager.
/ ThreatManager - Damage 0 (Miss, Block, etc) should now trigger aggro.
/ ThreatManager - attack_update will only call attack() if ThreatManager finds a target and unit is not already in combat with that target (This includes target switch because of threat) and will call leave_combat when 0 targets are resolved.
/ ThreatManager - Negative auras will now also use ThreatManager.
/ ProximityAggro - Players will not notify movement to dead or not spawned units.
/ Creatures/GO's - Avoid update calls if the object has not fishined lazy initialization.
