### PR TITLE
Fishing and enchanting refactoring

### DIFF
--- a/game/world/managers/objects/spell/AuraManager.py
+++ b/game/world/managers/objects/spell/AuraManager.py
@@ -29,8 +29,9 @@ class AuraManager:
 
         # Application threat and negative aura application interrupts.
         if aura.harmful:
-            # Check if we need to add threat on units only.
-            if self.unit_mgr.get_type_id() == ObjectTypeIds.ID_UNIT and aura.source_spell.generates_threat():
+            # Add threat for non-player targets against unit casters.
+            if aura.caster.object_type_mask & ObjectTypeFlags.TYPE_UNIT and \
+                    self.unit_mgr.get_type_id() == ObjectTypeIds.ID_UNIT and aura.source_spell.generates_threat():
                 # TODO: Threat calculation.
                 self.unit_mgr.threat_manager.add_threat(aura.caster, 10)
 

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -200,7 +200,7 @@ class CastingSpell:
 
         # Self casts that require an unit target for other effects (arcane missiles).
         if self.spell_entry.ImplicitTargetA_1 == SpellImplicitTargets.TARGET_SELF and \
-                self.spell_entry.ImplicitTargetA_2 == 6:
+                self.spell_entry.ImplicitTargetA_2 == SpellImplicitTargets.TARGET_ENEMY_UNIT:
             return True
 
         # Return true if the effect has an implicit unit selection target.

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -198,7 +198,7 @@ class CastingSpell:
         if self.spell_target_mask != SpellTargetMask.SELF:
             return False
 
-        # Self casts that require an unit target for other effects (arcane missiles).
+        # Self casts that require a unit target for other effects (arcane missiles).
         if self.spell_entry.ImplicitTargetA_1 == SpellImplicitTargets.TARGET_SELF and \
                 self.spell_entry.ImplicitTargetA_2 == SpellImplicitTargets.TARGET_ENEMY_UNIT:
             return True

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -53,11 +53,11 @@ class EffectTargets:
         target_is_gameobject = self.casting_spell.initial_target_is_gameobject()
         target_is_item = self.casting_spell.initial_target_is_item()
 
-        target_is_friendly = not self.casting_spell.is_fishing_spell() and not caster_is_gameobject \
+        target_is_friendly = not caster_is_gameobject \
             and self.casting_spell.initial_target_is_unit_or_player() and not \
             caster.can_attack_target(self.casting_spell.initial_target)
 
-        targeted_unit_is_hostile = not self.casting_spell.is_fishing_spell() and not caster_is_gameobject and \
+        targeted_unit_is_hostile = not caster_is_gameobject and \
             self.casting_spell.requires_implicit_initial_unit_target() and \
             caster.can_attack_target(self.casting_spell.targeted_unit_on_cast_start)
 

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -321,9 +321,7 @@ class SpellEffectHandler:
             return
 
         target = None
-        if casting_spell.initial_target_is_terrain() and casting_spell.is_fishing_spell():
-            target = casting_spell.initial_target
-        elif isinstance(effect.targets.resolved_targets_a[0], ObjectManager):
+        if isinstance(effect.targets.resolved_targets_a[0], ObjectManager):
             target = effect.targets.resolved_targets_a[0].location
         elif isinstance(effect.targets.resolved_targets_a[0], Vector):
             target = effect.targets.resolved_targets_a[0]

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -613,6 +613,9 @@ class SpellEffectHandler:
         # Apply permanent enchantment.
         owner_player.enchantment_manager.set_item_enchantment(target, enchantment_slot, effect.misc_value,
                                                               duration, charges)
+
+        caster.skill_manager.handle_profession_skill_gain_chance(casting_spell.spell_entry.ID)
+
         # Save item.
         target.save()
 

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -770,7 +770,7 @@ class SpellManager:
         validation_target = casting_spell.initial_target
         # In the case of the spell requiring a unit target but being cast on self,
         # validate the spell against the caster's current unit selection instead.
-        if casting_spell.spell_target_mask == SpellTargetMask.SELF and not casting_spell.is_fishing_spell() and \
+        if casting_spell.spell_target_mask == SpellTargetMask.SELF and \
                 casting_spell.requires_implicit_initial_unit_target():
             validation_target = casting_spell.targeted_unit_on_cast_start
             if validation_target and not self.caster.can_attack_target(validation_target):
@@ -800,7 +800,7 @@ class SpellManager:
 
                 return False
 
-        # Range validations, if needed.
+        # Range validations. Skip for fishing as generated targets will always be valid.
         if not casting_spell.is_fishing_spell() and not casting_spell.initial_target_is_item():
             # Check if the caster is within range of the (world) target to cast the spell.
             if casting_spell.range_entry.RangeMin > 0 or casting_spell.range_entry.RangeMax > 0:

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -236,10 +236,6 @@ class SpellManager:
             if casting_spell.cast_state != SpellState.SPELL_STATE_ACTIVE:
                 self.remove_cast(casting_spell)
 
-        # Handle enchanting skill gain here for now.
-        if self.caster.get_type_id() == ObjectTypeIds.ID_PLAYER and casting_spell.is_enchantment_spell():
-            self.caster.skill_manager.handle_craft_skill_gain(SkillTypes.ENCHANTING)
-
         self.set_on_cooldown(casting_spell)
         self.consume_resources_for_cast(casting_spell)  # Remove resources - order matters for combo points
 

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -411,12 +411,19 @@ class SkillManager(object):
 
         return True
 
-    def handle_craft_skill_gain(self, skill_type):
-        skill = self.skills.get(skill_type, None)
-        if not skill:
+    def handle_profession_skill_gain_chance(self, spell_id):
+        skill_template = self.get_skill_for_spell_id(spell_id)
+        if not skill_template:
             return False
 
-        self.set_skill(skill_type, skill.value + 1)
+        if skill_template.ID not in self.skills:
+            return False
+
+        skill = self.skills[skill_template.ID]
+
+        # TODO Roll profession skill gain chance - currently skill is always gained.
+
+        self.set_skill(skill_template.ID, skill.value + 1)
         self.build_update()
         return True
 

--- a/game/world/managers/objects/units/player/trade/ProposedEnchantment.py
+++ b/game/world/managers/objects/units/player/trade/ProposedEnchantment.py
@@ -25,3 +25,6 @@ class ProposedEnchantment:
         self.enchantment_entry = 0  # ItemEnchantment id.
         self.duration = 0
         self.charges = 0
+
+    def is_valid(self):
+        return self.trade_slot != -1

--- a/game/world/managers/objects/units/player/trade/TradeData.py
+++ b/game/world/managers/objects/units/player/trade/TradeData.py
@@ -39,6 +39,22 @@ class TradeData(object):
         # Update the proposed enchant.
         self.proposed_enchantment.set_enchantment(trade_slot, spell_id, enchantment_slot, entry, duration, charges)
 
+    def apply_proposed_enchant(self):
+        if not self.proposed_enchantment.is_valid():
+            return
+
+        item = self.other_player.trade_data.get_item_by_slot(self.proposed_enchantment.trade_slot)
+        if not item:
+            return
+
+        self.player.enchantment_manager.set_item_enchantment(item,
+                                                             self.proposed_enchantment.enchantment_slot,
+                                                             self.proposed_enchantment.enchantment_entry,
+                                                             self.proposed_enchantment.duration,
+                                                             self.proposed_enchantment.charges)
+
+        self.player.skill_manager.handle_profession_skill_gain_chance(self.proposed_enchantment.spell_id)
+
     def set_item(self, slot, item):
         if self.items[slot] and self.items[slot] == item:
             return

--- a/game/world/opcode_handling/handlers/trade/AcceptTradeHandler.py
+++ b/game/world/opcode_handling/handlers/trade/AcceptTradeHandler.py
@@ -94,13 +94,8 @@ class AcceptTradeHandler(object):
                         player.inventory.remove_item(player_item.item_instance.bag,
                                                      player_item.current_slot, True)
 
-            # Apply enchantment to item.
-            if item_to_receive_enchant:
-                enchantment_slot = player_trade.proposed_enchantment.enchantment_slot
-                entry = player_trade.proposed_enchantment.enchantment_entry
-                duration = player_trade.proposed_enchantment.duration
-                charges = player_trade.proposed_enchantment.charges
-                item_to_receive_enchant.set_enchantment(enchantment_slot, entry, duration, charges)
+            # Apply enchantment to item (if any).
+            player_trade.apply_proposed_enchant()
 
             player.mod_money(other_player_trade.money)
             player.mod_money(-player_trade.money)

--- a/utils/constants/SpellCodes.py
+++ b/utils/constants/SpellCodes.py
@@ -223,7 +223,7 @@ class SpellAttributesEx(IntEnum):
     SPELL_ATTR_EX_THREAT_ON_MISS = 0x00200000  # 21
     SPELL_ATTR_EX_REQ_COMBO_POINTS = 0x00400000  # 22 Use combo points (in 4.x not required combo point target selected)
     SPELL_ATTR_EX_IGNORE_OWNER_DEATH = 0x00800000  # 23
-    SPELL_ATTR_EX_IS_FISHING = 0x01000000  # 24 Req fishing pole
+    SPELL_ATTR_EX_IS_FISHING = 0x01000000  # 24 Req fishing pole  TODO Also Pick Pocket - rename.
     SPELL_ATTR_EX_AURA_STAYS_AFTER_COMBAT = 0x02000000  # 25
     SPELL_ATTR_EX_REQUIRE_ALL_TARGETS = 0x04000000  # 26
     SPELL_ATTR_EX_REFUND_POWER = 0x08000000  # 27


### PR DESCRIPTION
* Simplify fishing and enchanting implementations.
* Restrict enchanting skill gain to profession spells.
    * TODO: Skill gain is currently guaranteed for all enchants regardless of skill level.
* Fix minor edge case for GO casters.