### PR TITLE
Enchant procs and damage application, minor bug fixes and spell refactoring

### DIFF
--- a/game/world/managers/objects/locks/LockManager.py
+++ b/game/world/managers/objects/locks/LockManager.py
@@ -48,7 +48,7 @@ class LockManager:
                     skill_value = 0 if cast_item or caster.get_type_id() != ObjectTypeIds.ID_PLAYER else \
                         caster.skill_manager.get_total_skill_value(skill_type)
                     bonus_skill_value = skill_value + bonus_points
-                    if bonus_skill_value < required_skill_value:
+                    if bonus_skill_value < required_skill_value or skill_value == -1:
                         return OpenLockResult(SpellCheckCastResult.SPELL_FAILED_LOW_CASTLEVEL)
 
                 return OpenLockResult(SpellCheckCastResult.SPELL_NO_ERROR, skill_type,

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -229,6 +229,9 @@ class CastingSpell:
     def is_target_immune_to_damage(self):
         return False
 
+    def cast_breaks_stealth(self):
+        return not self.spell_entry.AttributesEx & SpellAttributesEx.SPELL_ATTR_EX_NOT_BREAK_STEALTH
+
     def is_fishing_spell(self):
         return self.spell_entry.ImplicitTargetA_1 == SpellImplicitTargets.TARGET_SELF_FISHING
 

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -209,18 +209,6 @@ class CastingSpell:
     def has_spell_visual_pre_cast_kit(self):
         return self.spell_visual_entry and self.spell_visual_entry.PrecastKit > 0
 
-    def is_fishing_spell(self):
-        return self.spell_entry.ImplicitTargetA_1 == SpellImplicitTargets.TARGET_SELF_FISHING
-
-    def is_pick_pocket_spell(self):
-        return self.spell_entry.AttributesEx & SpellAttributesEx.SPELL_ATTR_EX_FAILURE_BREAKS_STEALTH
-
-    def is_area_of_effect_spell(self):
-        for effect in self.get_effects():
-            if {effect.implicit_target_a, effect.implicit_target_b}.intersection(EffectTargets.AREA_TARGETS):
-                return True
-        return False
-
     def is_target_power_type_valid(self):
         if not self.initial_target:
             return False
@@ -237,14 +225,26 @@ class CastingSpell:
             return True
         return False
 
+    # TODO, Check 'IsImmuneToDamage' - VMaNGOS
+    def is_target_immune_to_damage(self):
+        return False
+
+    def is_fishing_spell(self):
+        return self.spell_entry.ImplicitTargetA_1 == SpellImplicitTargets.TARGET_SELF_FISHING
+
+    def is_pick_pocket_spell(self):
+        return self.spell_entry.AttributesEx & SpellAttributesEx.SPELL_ATTR_EX_FAILURE_BREAKS_STEALTH
+
+    def is_area_of_effect_spell(self):
+        for effect in self.get_effects():
+            if {effect.implicit_target_a, effect.implicit_target_b}.intersection(EffectTargets.AREA_TARGETS):
+                return True
+        return False
+
     # TODO, need more checks.
     #  Refer to 'IsPositiveEffect' in SpellEntry.cpp - VMaNGOS
     def is_positive_spell(self):
         return not self.spell_caster.can_attack_target(self.initial_target)
-
-    # TODO, Check 'IsImmuneToDamage' - VMaNGOS
-    def is_target_immune_to_damage(self):
-        return False
 
     def is_charm_spell(self):
         for spell_effect in self.get_effects():
@@ -263,13 +263,6 @@ class CastingSpell:
         return any(effect.effect_type == SpellEffects.SPELL_EFFECT_ENCHANT_ITEM_TEMPORARY
                    for effect in self.get_effects())
 
-    def get_enchantment_id(self):
-        enchantment_effects = [SpellEffects.SPELL_EFFECT_ENCHANT_ITEM_PERMANENT,
-                               SpellEffects.SPELL_EFFECT_ENCHANT_ITEM_TEMPORARY]
-        for effect in self.get_effects():
-            if effect.effect_type in enchantment_effects:
-                return effect.misc_value
-
     def is_refreshment_spell(self):
         spell_effect = self._effects[0]  # Food/drink effect should be first.
         if not spell_effect:
@@ -286,6 +279,13 @@ class CastingSpell:
             spell_effect.aura_type == AuraTypes.SPELL_AURA_PERIODIC_ENERGIZE
 
         return has_sitting_attribute and is_regen_buff and has_refreshment_period
+
+    def get_enchantment_id(self):
+        enchantment_effects = [SpellEffects.SPELL_EFFECT_ENCHANT_ITEM_PERMANENT,
+                               SpellEffects.SPELL_EFFECT_ENCHANT_ITEM_TEMPORARY]
+        for effect in self.get_effects():
+            if effect.effect_type in enchantment_effects:
+                return effect.misc_value
 
     def has_effect_of_type(self, effect_type: SpellEffects):
         for effect in self.get_effects():

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -266,6 +266,17 @@ class CastingSpell:
         return any(effect.effect_type == SpellEffects.SPELL_EFFECT_ENCHANT_ITEM_TEMPORARY
                    for effect in self.get_effects())
 
+    def is_duel_spell(self):
+        return any(effect.effect_type == SpellEffects.SPELL_EFFECT_DUEL
+                   for effect in self.get_effects())
+
+    def is_unlocking_spell(self):
+        unlock_effects = [SpellEffects.SPELL_EFFECT_OPEN_LOCK, SpellEffects.SPELL_EFFECT_OPEN_LOCK_ITEM]
+        return any(effect.effect_type in unlock_effects for effect in self.get_effects())
+
+    def is_pickpocket_spell(self):
+        return any(effect.effect_type == SpellEffects.SPELL_EFFECT_PICKPOCKET for effect in self.get_effects())
+
     def is_refreshment_spell(self):
         spell_effect = self._effects[0]  # Food/drink effect should be first.
         if not spell_effect:
@@ -283,18 +294,17 @@ class CastingSpell:
 
         return has_sitting_attribute and is_regen_buff and has_refreshment_period
 
-    def get_enchantment_id(self):
-        enchantment_effects = [SpellEffects.SPELL_EFFECT_ENCHANT_ITEM_PERMANENT,
-                               SpellEffects.SPELL_EFFECT_ENCHANT_ITEM_TEMPORARY]
-        for effect in self.get_effects():
-            if effect.effect_type in enchantment_effects:
-                return effect.misc_value
-
     def has_effect_of_type(self, effect_type: SpellEffects):
         for effect in self.get_effects():
             if effect.effect_type == effect_type:
                 return True
         return False
+
+    def get_effect_by_type(self, effect_type: SpellEffects) -> Optional[SpellEffect]:
+        for effect in self.get_effects():
+            if effect.effect_type == effect_type:
+                return effect
+        return None
 
     def trigger_cooldown_on_aura_remove(self):
         return self.spell_entry.Attributes & SpellAttributes.SPELL_ATTR_DISABLED_WHILE_ACTIVE == SpellAttributes.SPELL_ATTR_DISABLED_WHILE_ACTIVE

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -581,9 +581,14 @@ class SpellEffectHandler:
         # Calculate slot, duration and charges.
         enchantment_slot = EnchantmentSlots.PermanentSlot if not is_temporary else EnchantmentSlots.TemporarySlot
         effect_index = effect.get_effect_points(casting_spell.caster_effective_level)
-        duration = 0 if not is_temporary else int(eval(f'enchantment.EffectPointsMin_{effect_index}')) * 1000
-        charges = 0 if not is_temporary else \
-            int(WorldDatabaseManager.spell_enchant_charges_get_by_spell(casting_spell.spell_entry.ID))
+
+        duration = 0
+        charges = 0
+
+        if is_temporary:
+            # Temporary enchantments from professions (enchanting) have a duration of 1h while others have 30min.
+            duration = 30 * 60 if not casting_spell.spell_entry.CastUI else 60 * 60
+            charges = int(WorldDatabaseManager.spell_enchant_charges_get_by_spell(casting_spell.spell_entry.ID))
 
         # If this enchantment is being applied on a trade, update trade status with proposed enchant.
         # Enchant will be applied after trade is accepted.

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -11,6 +11,7 @@ from game.world.WorldSessionStateHandler import WorldSessionStateHandler
 from game.world.managers.abstractions.Vector import Vector
 from game.world.managers.maps.MapManager import MapManager
 from game.world.managers.objects.ObjectManager import ObjectManager
+from game.world.managers.objects.locks.LockManager import LockManager
 from game.world.managers.objects.spell import ExtendedSpellData
 from game.world.managers.objects.spell.CastingSpell import CastingSpell
 from game.world.managers.objects.spell.CooldownEntry import CooldownEntry
@@ -19,11 +20,12 @@ from game.world.managers.objects.units.player.EnchantmentManager import Enchantm
 from game.world.managers.objects.units.player.SkillManager import SkillTypes
 from network.packet.PacketWriter import PacketWriter, OpCode
 from utils.Logger import Logger
-from utils.constants.ItemCodes import InventoryError, ItemSubClasses, ItemClasses
+from utils.constants.ItemCodes import InventoryError, ItemSubClasses, ItemClasses, ItemDynFlags
 from utils.constants.MiscCodes import ObjectTypeFlags, HitInfo, GameObjectTypes, AttackTypes, ObjectTypeIds
+from utils.constants.MiscFlags import GameObjectFlags
 from utils.constants.SpellCodes import SpellCheckCastResult, SpellCastStatus, \
     SpellMissReason, SpellTargetMask, SpellState, SpellAttributes, SpellCastFlags, \
-    SpellInterruptFlags, SpellChannelInterruptFlags, SpellAttributesEx
+    SpellInterruptFlags, SpellChannelInterruptFlags, SpellAttributesEx, SpellEffects
 from utils.constants.UnitCodes import PowerTypes, StandState, WeaponMode
 
 
@@ -738,6 +740,18 @@ class SpellManager:
             self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_NOT_READY)
             return False
 
+        # Rough target type check for the client-provided target to avoid crashes.
+        # If the client is behaving as expected, this will always be valid.
+        if casting_spell.spell_entry.Targets == SpellTargetMask.ITEM and \
+                not casting_spell.initial_target_is_item() or \
+                (casting_spell.spell_entry.Targets == SpellTargetMask.UNIT_SELF and
+                 not casting_spell.initial_target_is_unit_or_player()) or \
+                (casting_spell.spell_entry.Targets == SpellTargetMask.DEST_LOCATION and
+                 not casting_spell.initial_target_is_terrain()):
+            self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS)
+            return False
+
+        # Unlearned spell.
         if (not casting_spell.triggered and not casting_spell.source_item) and \
                 casting_spell.cast_state == SpellState.SPELL_STATE_PREPARING and \
                 self.caster.get_type_id() == ObjectTypeIds.ID_PLAYER and \
@@ -745,10 +759,10 @@ class SpellManager:
             self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_NOT_KNOWN)
             return False
 
-        # Caster unit-only checks.
+        # Caster unit-only state checks.
         if self.caster.object_type_mask & ObjectTypeFlags.TYPE_UNIT:
-            if not self.caster.is_alive and \
-                    casting_spell.spell_entry.Attributes & SpellAttributes.SPELL_ATTR_ALLOW_CAST_WHILE_DEAD != SpellAttributes.SPELL_ATTR_ALLOW_CAST_WHILE_DEAD:
+            if not casting_spell.spell_entry.Attributes & SpellAttributes.SPELL_ATTR_ALLOW_CAST_WHILE_DEAD and \
+                    not self.caster.is_alive:
                 self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_CASTER_DEAD)
                 return False
 
@@ -812,44 +826,25 @@ class SpellManager:
                     self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_TOO_CLOSE)
                     return False
 
-        # Validate enchantments.
-        if casting_spell.is_enchantment_spell():
-            # Invalid target.
-            if not casting_spell.initial_target_is_item():
-                self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_ITEM_NOT_FOUND)
-                return False
-
-            # Do not allow temporary enchantments in trade slot.
-            if casting_spell.is_temporary_enchant_spell():
-                # TODO: Further research needed, we have neither SPELL_FAILED_NOT_TRADEABLE or 'Slot' in
-                #   SpellItemEnchantment. Refer to VMaNGOS Spell.cpp 7822.
-                if casting_spell.initial_target.get_owner_guid() != casting_spell.spell_caster.guid:
-                    self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_ERROR)
-                    return False
-
-            # Do not allow to enchant if it has an existent permanent enchantment.
-            if EnchantmentManager.get_permanent_enchant_value(casting_spell.initial_target) != 0:
-                self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_ITEM_ALREADY_ENCHANTED)
-                return False
-
-            # Validate enchantment exist.
-            enchantment_id = casting_spell.get_enchantment_id()
-            enchantment = DbcDatabaseManager.spell_get_item_enchantment(enchantment_id)
-            if not enchantment:
-                self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_ERROR)
-                return False
-
-            # Validate target item class and subclass, if needed.
-            # TODO: We don't have EquippedItemInventoryTypeMask, so we have no way to validate inventory slots.
-            #  e.g. Enchant bracers would still work on legs, chest, etc. So maybe they had some filtering by name?
+        # Item target checks.
+        if casting_spell.initial_target_is_item():
+            # Match item class/subclass.
             if casting_spell.spell_entry.EquippedItemClass != -1:
                 required_item_class = casting_spell.spell_entry.EquippedItemClass
-                required_item_sub_class = casting_spell.spell_entry.EquippedItemSubclass
+                required_item_subclass = casting_spell.spell_entry.EquippedItemSubclass
+
                 item_class = casting_spell.initial_target.item_template.class_
                 item_subclass_mask = 1 << casting_spell.initial_target.item_template.subclass
-                if required_item_class != item_class or required_item_sub_class & item_subclass_mask == 0:
+                if required_item_class != item_class or \
+                        not required_item_subclass & item_subclass_mask:
                     self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS)
                     return False
+
+            # Validate item owner online status.
+            item_owner = validation_target.get_owner_guid()
+            if not item_owner or not WorldSessionStateHandler.find_player_by_guid(item_owner):
+                self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS)
+                return False
 
         # Aura bounce check.
         if casting_spell.initial_target_is_unit_or_player():
@@ -868,6 +863,27 @@ class SpellManager:
                 self.send_cast_result(casting_spell.spell_entry.ID, error)
                 return False
 
+        # Effect-specific validation.
+
+        # Enchanting checks.
+        if casting_spell.is_enchantment_spell():
+            # TODO: We don't have EquippedItemInventoryTypeMask, so we have no way to validate inventory slots.
+            #  e.g. Enchant bracers would still work on legs, chest, etc. So maybe they had some filtering by name?
+
+            # Do not allow temporary enchantments in trade slot.
+            if casting_spell.is_temporary_enchant_spell():
+                # TODO: Further research needed, we have neither SPELL_FAILED_NOT_TRADEABLE or 'Slot' in
+                #   SpellItemEnchantment. Refer to VMaNGOS Spell.cpp 7822.
+                if casting_spell.initial_target.get_owner_guid() != casting_spell.spell_caster.guid:
+                    self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_ERROR)
+                    return False
+
+            # Do not allow to enchant if it has an existent permanent enchantment.
+            if EnchantmentManager.get_permanent_enchant_value(casting_spell.initial_target) != 0:
+                self.send_cast_result(casting_spell.spell_entry.ID,
+                                      SpellCheckCastResult.SPELL_FAILED_ITEM_ALREADY_ENCHANTED)
+                return False
+
         # Charm checks.
         if self.caster.get_type_id() == ObjectTypeIds.ID_PLAYER and casting_spell.is_charm_spell():
             if not self.caster.can_attack_target(validation_target):
@@ -879,6 +895,56 @@ class SpellManager:
                 error = SpellCheckCastResult.SPELL_FAILED_ALREADY_HAVE_SUMMON if active_pet.permanent \
                     else SpellCheckCastResult.SPELL_FAILED_ALREADY_HAVE_CHARM
                 self.send_cast_result(casting_spell.spell_entry.ID, error)
+                return False
+
+        # Pickpocketing target validity check.
+        if casting_spell.is_pickpocket_spell() and not validation_target.pickpocket_loot_manager:
+            self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_TARGET_NO_POCKETS)
+            return False
+
+        # Duel target check.
+        if casting_spell.is_duel_spell() and validation_target.duel_manager:
+            self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_TARGET_DUELING)
+            return False
+
+        # Lock/chest checks.
+        if casting_spell.is_unlocking_spell():
+            # Already unlocked.
+            if not validation_target.lock:
+                self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_ALREADY_OPEN)
+                return False
+
+            # GameObject already in use. TODO, 'gameobject_requirement' table.
+            if casting_spell.initial_target_is_gameobject() and \
+                    (validation_target.is_active() or validation_target.has_flag(GameObjectFlags.IN_USE)):
+                self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_CHEST_IN_USE)
+                return False
+
+            # Item already unlocked.
+            if casting_spell.initial_target_is_item() and \
+                    validation_target.has_flag(ItemDynFlags.ITEM_DYNFLAG_UNLOCKED):
+                self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_ALREADY_OPEN)
+                return False
+
+            # OPEN_LOCK spells can provide bonus skill.
+            lock_effect = casting_spell.get_effect_by_type(SpellEffects.SPELL_EFFECT_OPEN_LOCK)
+            bonus_skill = lock_effect.get_effect_simple_points()
+
+            # Skill checks and random failure chance.
+            if casting_spell.cast_state == SpellState.SPELL_STATE_PREPARING:
+                # Skill check only on initial validation.
+                unlock_result = LockManager.can_open_lock(self.caster, lock_effect.misc_value, validation_target.lock,
+                                                          cast_item=casting_spell.source_item, bonus_points=bonus_skill)
+                unlock_result = unlock_result.result
+            else:
+                # Include failure chance on cast.
+                unlock_result = self.caster.skill_manager.get_unlocking_attempt_result(lock_effect.misc_value,
+                                                                                       validation_target.lock,
+                                                                                       used_item=casting_spell.source_item,
+                                                                                       bonus_skill=bonus_skill)
+
+            if unlock_result != SpellCheckCastResult.SPELL_NO_ERROR:
+                self.send_cast_result(casting_spell.spell_entry.ID, unlock_result)
                 return False
 
         # Special case of Ritual of Summoning.

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -212,7 +212,7 @@ class SpellManager:
 
         if self.caster.object_type_mask & ObjectTypeFlags.TYPE_UNIT and \
                 not casting_spell.triggered:  # Triggered spells (ie. channel ticks) shouldn't interrupt other casts
-            self.caster.aura_manager.check_aura_interrupts(cast_spell=True)
+            self.caster.aura_manager.check_aura_interrupts(cast_spell=casting_spell)
 
         travel_times = self.calculate_impact_delays(casting_spell)
 

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -366,8 +366,7 @@ class UnitManager(ObjectManager):
         if damage_info.total_damage > 0:
             victim.spell_manager.check_spell_interrupts(received_auto_attack=True, hit_info=damage_info.hit_info)
 
-        victim.aura_manager.check_aura_procs(damage_info=damage_info, is_melee_swing=True)
-        self.aura_manager.check_aura_procs(damage_info=damage_info, is_melee_swing=True)
+        self.handle_melee_attack_procs(damage_info)
 
         self.send_attack_state_update(damage_info)
 
@@ -379,6 +378,10 @@ class UnitManager(ObjectManager):
         while self.extra_attacks > 0:
             self.attacker_state_update(self.combat_target, AttackTypes.BASE_ATTACK, True)
             self.extra_attacks -= 1
+
+    def handle_melee_attack_procs(self, damage_info):
+        damage_info.target.aura_manager.check_aura_procs(damage_info=damage_info, is_melee_swing=True)
+        self.aura_manager.check_aura_procs(damage_info=damage_info, is_melee_swing=True)
 
     def calculate_melee_damage(self, victim, attack_type):
         damage_info = DamageInfoHolder()

--- a/game/world/managers/objects/units/player/DuelManager.py
+++ b/game/world/managers/objects/units/player/DuelManager.py
@@ -35,7 +35,7 @@ class DuelManager(object):
     def request_duel(requester, target, arbiter):
         # If target is already dueling, fail Duel spell cast.
         if target.duel_manager:
-            return 0
+            return
 
         # If requester is already dueling, lose current duel before starting a new one.
         if requester.duel_manager:
@@ -57,12 +57,11 @@ class DuelManager(object):
                 entry.player.duel_manager = duel_manager
                 duel_manager.build_update(entry.player)
 
-            return 1
+            return
         else:
             packet = PacketWriter.get_packet(OpCode.SMSG_DUEL_COMPLETE, pack('<B', DuelComplete.DUEL_CANCELED_INTERRUPTED))
             requester.enqueue_packet(packet)
-
-            return -1
+            return
 
     # Only accept the trigger from the target
     def handle_duel_accept(self, player_mgr):

--- a/game/world/managers/objects/units/player/EnchantmentManager.py
+++ b/game/world/managers/objects/units/player/EnchantmentManager.py
@@ -61,7 +61,7 @@ class EnchantmentManager(object):
                 if slot > EnchantmentSlots.PermanentSlot:  # Temporary enchantments.
                     if update_slot != -1 and update_slot != slot:
                         continue
-                    duration = 0 if enchantment.duration <= 0 else int(enchantment.duration / 1000) * 60  # Minutes
+                    duration = 0 if enchantment.duration <= 0 else enchantment.duration
                     data = pack('<Q2IQ', item.guid, slot, duration, self.unit_mgr.guid)
                     self.unit_mgr.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_ITEM_ENCHANT_TIME_UPDATE, data))
 

--- a/game/world/managers/objects/units/player/EnchantmentManager.py
+++ b/game/world/managers/objects/units/player/EnchantmentManager.py
@@ -99,11 +99,10 @@ class EnchantmentManager(object):
                 continue
 
             # Check if player already has the triggered aura active.
-            if self.unit_mgr.aura_manager.has_aura_by_spell_id(effect_spell_value):
-                # Learn spell if needed and cast.
-                self.unit_mgr.spell_manager.learn_spell(effect_spell_value)
-                # TODO pass triggered?
-                self.unit_mgr.spell_manager.handle_cast_attempt(effect_spell_value, self.unit_mgr, SpellTargetMask.SELF)
+            if not self.unit_mgr.aura_manager.has_aura_by_spell_id(effect_spell_value):
+                self.unit_mgr.spell_manager.handle_cast_attempt(effect_spell_value,
+                                                                self.unit_mgr, SpellTargetMask.SELF,
+                                                                triggered=True)
 
         enchantment_type = ItemEnchantmentType.PROC_SPELL
         for enchantment in EnchantmentManager.get_enchantments_by_type(item, enchantment_type):

--- a/game/world/managers/objects/units/player/EnchantmentManager.py
+++ b/game/world/managers/objects/units/player/EnchantmentManager.py
@@ -1,4 +1,5 @@
 from struct import pack
+from typing import Tuple, Dict
 
 from network.packet.PacketWriter import PacketWriter
 from utils.constants.ItemCodes import InventorySlots, ItemEnchantmentType, EnchantmentSlots
@@ -13,6 +14,7 @@ MAX_ENCHANTMENTS = 5
 class EnchantmentManager(object):
     def __init__(self, unit_mgr):
         self.unit_mgr = unit_mgr
+        self._applied_proc_enchants: Dict[int, Tuple[int, int]] = {}  # enchantment id: (spell id, proc chance).
 
     # Load and apply enchantments from item_instance.
     def load_enchantments_for_item(self, item):
@@ -50,11 +52,7 @@ class EnchantmentManager(object):
         if slot != EnchantmentSlots.PermanentSlot:
             self.send_enchantments_durations(slot)
 
-        if EnchantmentManager.has_enchantments_effect_by_type(item, ItemEnchantmentType.BUFF_EQUIPPED):
-            if item.is_equipped():
-                self._handle_aura_proc(item)
-            else:
-                self._handle_aura_removal(item)
+        self._handle_equip_buffs(item, remove=not item.is_equipped())
 
     # Notify the client with the enchantment duration.
     def send_enchantments_durations(self, update_slot=-1):
@@ -70,14 +68,17 @@ class EnchantmentManager(object):
     def handle_equipment_change(self, item):
         if not item:
             return
-        # Remove auras if the item is no longer equipped.
-        if item.current_slot > InventorySlots.SLOT_TABARD:
-            if EnchantmentManager.has_enchantments_effect_by_type(item, ItemEnchantmentType.BUFF_EQUIPPED):
-                self._handle_aura_removal(item)
-        # Equipped.
-        else:
-            if EnchantmentManager.has_enchantments_effect_by_type(item, ItemEnchantmentType.BUFF_EQUIPPED):
-                self._handle_aura_proc(item)
+        was_removed = item.current_slot > InventorySlots.SLOT_TABARD
+        self._handle_equip_buffs(item, remove=was_removed)
+
+    def handle_melee_attack_procs(self, damage_info):
+        for proc_enchant in self._applied_proc_enchants.values():
+            proc_spell, proc_chance = proc_enchant
+            if not self.unit_mgr.stat_manager.roll_proc_chance(proc_chance):
+                continue
+
+            self.unit_mgr.spell_manager.handle_cast_attempt(proc_spell, damage_info.attacker,
+                                                            SpellTargetMask.UNIT, triggered=True)
 
     def _handle_aura_removal(self, item):
         enchantment_type = ItemEnchantmentType.BUFF_EQUIPPED
@@ -86,15 +87,35 @@ class EnchantmentManager(object):
             if effect_spell_value and self.unit_mgr.aura_manager.has_aura_by_spell_id(effect_spell_value):
                 self.unit_mgr.aura_manager.cancel_auras_by_spell_id(effect_spell_value)
 
-    def _handle_aura_proc(self, item):
+    def _handle_equip_buffs(self, item, remove=False):
         enchantment_type = ItemEnchantmentType.BUFF_EQUIPPED
         for enchantment in EnchantmentManager.get_enchantments_by_type(item, enchantment_type):
             effect_spell_value = enchantment.get_enchantment_effect_spell_by_type(enchantment_type)
+            if not effect_spell_value:
+                continue
+
+            if remove:
+                self.unit_mgr.aura_manager.cancel_auras_by_spell_id(effect_spell_value)
+                continue
+
             # Check if player already has the triggered aura active.
-            if effect_spell_value and not self.unit_mgr.aura_manager.has_aura_by_spell_id(effect_spell_value):
+            if self.unit_mgr.aura_manager.has_aura_by_spell_id(effect_spell_value):
                 # Learn spell if needed and cast.
                 self.unit_mgr.spell_manager.learn_spell(effect_spell_value)
+                # TODO pass triggered?
                 self.unit_mgr.spell_manager.handle_cast_attempt(effect_spell_value, self.unit_mgr, SpellTargetMask.SELF)
+
+        enchantment_type = ItemEnchantmentType.PROC_SPELL
+        for enchantment in EnchantmentManager.get_enchantments_by_type(item, enchantment_type):
+            if remove:
+                self._applied_proc_enchants.pop(enchantment.entry)
+                continue
+
+            effect_spell_value = enchantment.get_enchantment_effect_spell_by_type(enchantment_type)
+            proc_chance = enchantment.get_enchantment_effect_points_by_type(enchantment_type)
+            if not effect_spell_value or not proc_chance:
+                continue
+            self._applied_proc_enchants[enchantment.entry] = (effect_spell_value, proc_chance)
 
     @staticmethod
     def get_effect_value_for_enchantment_type(item, enchantment_type):

--- a/game/world/managers/objects/units/player/EnchantmentManager.py
+++ b/game/world/managers/objects/units/player/EnchantmentManager.py
@@ -108,7 +108,7 @@ class EnchantmentManager(object):
         enchantment_type = ItemEnchantmentType.PROC_SPELL
         for enchantment in EnchantmentManager.get_enchantments_by_type(item, enchantment_type):
             if remove:
-                self._applied_proc_enchants.pop(enchantment.entry)
+                self._applied_proc_enchants.pop(enchantment.entry, None)
                 continue
 
             effect_spell_value = enchantment.get_enchantment_effect_spell_by_type(enchantment_type)

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1274,6 +1274,11 @@ class PlayerManager(UnitManager):
         else:
             self.skill_manager.handle_defense_skill_gain_chance(damage_info)
 
+    # override
+    def handle_melee_attack_procs(self, damage_info):
+        super().handle_melee_attack_procs(damage_info)
+        self.enchantment_manager.handle_melee_attack_procs(damage_info)
+
     def _send_attack_swing_error(self, victim, opcode):
         data = pack('<2Q', self.guid, victim.guid if victim else 0)
         self.enqueue_packet(PacketWriter.get_packet(opcode, data))

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -375,15 +375,22 @@ class StatManager(object):
                         self.unit_mgr.is_in_feral_form():
                     continue
 
-                # Code below this check is weapon related, stop handling this item if it's not a weapon.
                 if item.current_slot != InventorySlots.SLOT_MAINHAND and \
                     item.current_slot != InventorySlots.SLOT_OFFHAND and \
                         item.current_slot != InventorySlots.SLOT_RANGED:
-                    continue
+                    continue  # Not a weapon.
 
+                # Handle weapon damage stats.
                 weapon_min_damage = int(item.item_template.dmg_min1)
                 weapon_max_damage = int(item.item_template.dmg_max1)
                 weapon_delay = item.item_template.delay
+
+                # Damage increase weapon enchants.
+                weapon_enchant_bonus = EnchantmentManager.get_effect_value_for_enchantment_type(
+                    item, ItemEnchantmentType.DAMAGE)
+
+                weapon_min_damage += weapon_enchant_bonus
+                weapon_max_damage += weapon_enchant_bonus
 
                 if item.current_slot == InventorySlots.SLOT_MAINHAND:
                     self.item_stats[UnitStats.MAIN_HAND_DAMAGE_MIN] = weapon_min_damage
@@ -760,12 +767,9 @@ class StatManager(object):
 
             # Check weapons enchantments.
             if school == SpellSchools.SPELL_SCHOOL_NORMAL:
-                off_hand = self.unit_mgr.inventory.get_offhand()
                 main_hand_bonus = EnchantmentManager.get_effect_value_for_enchantment_type(main_hand,
                                                                                            ItemEnchantmentType.DAMAGE)
-                off_hand_bonus = EnchantmentManager.get_effect_value_for_enchantment_type(off_hand,
-                                                                                          ItemEnchantmentType.DAMAGE)
-                flat_bonuses += main_hand_bonus + off_hand_bonus
+                flat_bonuses += main_hand_bonus
 
             percentual_bonuses = self.get_aura_stat_bonus(UnitStats.DAMAGE_DONE_SCHOOL, misc_value=school, percentual=True) * \
                 self.get_aura_stat_bonus(UnitStats.DAMAGE_DONE_WEAPON, misc_value=subclass_mask, percentual=True, misc_value_is_mask=True)

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -693,9 +693,16 @@ class StatManager(object):
     def send_melee_attributes(self):
         if self.unit_mgr.get_type_id() != ObjectTypeIds.ID_PLAYER:
             return
+
+        # Weapon enchant bonuses are included in the weapon's damage internally,
+        # but should be displayed as a bonus.
+
+        enchant_bonus = EnchantmentManager.get_effect_value_for_enchantment_type(self.unit_mgr.inventory.get_main_hand(),
+                                                                                 ItemEnchantmentType.DAMAGE)
+
         # For stat sheet
-        self.unit_mgr.set_melee_damage(self.get_total_stat(UnitStats.MAIN_HAND_DAMAGE_MIN),
-                                       self.get_total_stat(UnitStats.MAIN_HAND_DAMAGE_MAX))
+        self.unit_mgr.set_melee_damage(self.get_total_stat(UnitStats.MAIN_HAND_DAMAGE_MIN) - enchant_bonus,
+                                       self.get_total_stat(UnitStats.MAIN_HAND_DAMAGE_MAX) - enchant_bonus)
 
         self.unit_mgr.set_melee_attack_time(self.get_total_stat(UnitStats.MAIN_HAND_DELAY))
         self.unit_mgr.set_offhand_attack_time(self.get_total_stat(UnitStats.OFF_HAND_DELAY))


### PR DESCRIPTION
* Add basic handling for spell proc enchants
* Apply weapon damage enchants
* Use correct values for temporary enchant durations and simplify logic
* Simplify enchant aura handling
* Fix handling auras that don't break stealth
* Fix gathering profession failure check
* Move validation logic from spell effect handlers to validate cast
     * Most spell validation can and should be done before effect application in `validate_cast`. Validation at effect application can lead to one effect failing with others applying. 