### PR TITLE
Teldrassil improvements

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7725,6 +7725,9 @@ begin not atomic
         SET `display_id1`=3025
         WHERE `entry`=1984;
 
+        -- Aelyssa binder spawn, screenshot
+        INSERT INTO `spawns_creatures` VALUES (NULL, 3777, 0, 0, 0, 1, 0, 0, 10382.2294921875, 799.4705810546875, 1318.2911376953125, 4.3283305168151855, 300, 300, 0, 100, 0, 0, 0, 0, 0);
+
         insert into applied_updates values ('020820221');
 
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7639,5 +7639,89 @@ begin not atomic
         insert into applied_updates values ('010820221');
 
     end if;
+    
+    -- 02/08/2022 1
+    if (select count(*) from applied_updates where id='020820221') = 0 then
+
+        -- TELDRASSILL
+
+        -- Bloodfeather Matriarch
+        UPDATE `creature_template`
+        SET `display_id1`=3021
+        WHERE `entry`=2021;
+
+        -- Bloodfeather Rogue
+        UPDATE `creature_template`
+        SET `display_id1`=3021
+        WHERE `entry`=2017;
+
+        -- Bloodfeather Wind Witch
+        UPDATE `creature_template`
+        SET `display_id1`=3021
+        WHERE `entry`=2020;
+
+        -- Bloodfeather Sorceress (this mob already has a display id, but we have screenshot that show a different one)
+        UPDATE `creature_template`
+        SET `display_id1`=3021
+        WHERE `entry`=2018;
+
+        -- Mangy Nightsaber - display_id 892 is unused
+        UPDATE `creature_template`
+        SET `display_id1`=892
+        WHERE `entry`=2032;
+
+        -- Nightsaber - display_id 892 is unused
+        UPDATE `creature_template`
+        SET `display_id1`=892
+        WHERE `entry`=2042;
+
+        -- Zenn Foulhoof (we have screenshot of him, see alpha archives, Teldrassil)
+        UPDATE `creature_template`
+        SET `display_id1`=2018
+        WHERE `entry`=2150;
+
+        -- Teldrassil Sentinel (There is only one display id of NE guard that is not used by a named NPC, same as Darnassus/Ashenvale guards)
+        UPDATE `creature_template`
+        SET `display_id1`=2306, `display_id2`=0, `display_id3`=0, `display_id4`=0
+        WHERE `entry`=3571;
+
+        -- Gnarlpine Warrior
+        UPDATE `creature_template`
+        SET `display_id1`=2001
+        WHERE `entry`=2008;
+
+        -- Gnarlpine Pathfinder
+        UPDATE `creature_template`
+        SET `display_id1`=2001
+        WHERE `entry`=2012;
+
+        -- Gnarlpine Defender
+        UPDATE `creature_template`
+        SET `display_id1`=2001
+        WHERE `entry`=2010;
+
+        -- Gnarlpine Ursa
+        UPDATE `creature_template`
+        SET `display_id1`=2001
+        WHERE `entry`=2006;
+
+        -- Gnarlpine Gardener
+        UPDATE `creature_template`
+        SET `display_id1`=2001
+        WHERE `entry`=2007;
+
+        -- Gnarlpine Avenger
+        UPDATE `creature_template`
+        SET `display_id1`=2001
+        WHERE `entry`=2013;
+
+        -- Timberling Bark Ripper (we have screenshot of him, see alpha archives, Teldrassil)
+        UPDATE `creature_template`
+        SET `display_id1`=3034
+        WHERE `entry`=2025;
+
+        insert into applied_updates values ('020820221');
+
+    end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7665,12 +7665,12 @@ begin not atomic
         SET `display_id1`=3021
         WHERE `entry`=2018;
 
-        -- Mangy Nightsaber - display_id 892 is unused
+        -- Mangy Nightsaber -Nightsaber - Same display id as all others Teldrassil Nightsaber
         UPDATE `creature_template`
         SET `display_id1`=3029
         WHERE `entry`=2032;
 
-        -- Nightsaber - display_id 892 is unused
+        -- Nightsaber - Same display id as all others Teldrassil Nightsaber
         UPDATE `creature_template`
         SET `display_id1`=3029
         WHERE `entry`=2042;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7667,12 +7667,12 @@ begin not atomic
 
         -- Mangy Nightsaber - display_id 892 is unused
         UPDATE `creature_template`
-        SET `display_id1`=892
+        SET `display_id1`=3029
         WHERE `entry`=2032;
 
         -- Nightsaber - display_id 892 is unused
         UPDATE `creature_template`
-        SET `display_id1`=892
+        SET `display_id1`=3029
         WHERE `entry`=2042;
 
         -- Zenn Foulhoof (we have screenshot of him, see alpha archives, Teldrassil)

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7720,6 +7720,11 @@ begin not atomic
         SET `display_id1`=3034
         WHERE `entry`=2025;
 
+        -- Yound Thistle Boar, screenshot
+        UPDATE `creature_template`
+        SET `display_id1`=3025
+        WHERE `entry`=1984;
+
         insert into applied_updates values ('020820221');
 
     end if;


### PR DESCRIPTION
Resolve part of #319. All screenshots mentioned bellow can be found in Alpha Archives, Teldrassil folder.

- **Bloodfeather** 

Bloodfeather type who miss display_id : Rogue, Mattriach, Wind Witch

We have screenshots that show bunch of Bloodfeathers, all with the same display_id (3021).
We also have a screenshot of a Bloodfeather Sorceress with display_id 3021 (1.12 use another display id for this mob)
In 0.5.3, all Bloodfeathers use the same display id, later blizzard will add color variation probably to help players.

- **Gnarlpine**

Gnarlpine type who miss display_id : Warrior, Defender, Ursa, Gardener, Avenger, Pathfinder

We have some screenshots that shows  Gnarlpine (Ambuser, shaman and also a named), all with the same display_id (brown gnarlpine)
Same as Bloodfeathers, in 0.5.3 all Gnarlpine probably use the same display_id and blizzard will update it later. 

- **Nightsaber**

Mangy Nightsaber and Nightsaber probably use display_id 3029, see Daribon comment.

- **Teldrassil Sentinel**

There is only one NE guard model that is not used by a named NPC : 2306. 
It's same model as Darnassus guard and Ashenvale guards. That's probably why Blizzard added more later.
We can see screenshots of Teldrassil Sentinel in Alpha archives, but models are not present in 0.5.3.

- **Zenn Foulhoof**

We have a screenshot

- **Timbering Bark Ripper**

We have a screenshot





