### PR TITLE
Mulgore/Barrens/Durotar improvements

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7667,6 +7667,11 @@ begin not atomic
 
         -- # BARRENS
 
+        -- Razormane Nak (a named with no display id)
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3434;
+
         -- Razormane warfury
         UPDATE `creature_template`
         SET `display_id1`=1341

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7637,7 +7637,137 @@ begin not atomic
         WHERE `entry`=4949;
 
         insert into applied_updates values ('010820221');
+    end if;
 
+    -- 03/08/2022 1
+    if (select count(*) from applied_updates where id='030820221') = 0 then
+        -- # MULGORE
+
+        -- Windfury matriarch, screenshot
+        UPDATE `creature_template`
+        SET `display_id1`=1223
+        WHERE `entry`=2965;
+
+        -- # BARRENS
+
+        -- Razormane warfury
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3459;
+
+        -- Razormane seer
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3458;
+
+        -- Razormane hunter, screenshot
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3265;
+
+        -- Razormane mystic
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3271;
+
+        -- Razormane geomancer, screenshot
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3269;
+
+        -- Razormane thornweaver, screenshot
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3268;
+
+        -- Razormane water seeker, this one already got a display_id, but screenshot show another
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3267;
+
+        -- Razormane defender, this one already got a display_id, but screenshot show another
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3266;
+
+        -- Razormane stalker, this one already got a display_id, but screenshot show another
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3457;
+        
+
+        --
+
+        -- Bristleback thornweaver, screenshot
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3261;
+
+        -- Bristleback geomancer
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3263;
+
+        -- Bristleback hunter, screenshot
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3258;
+
+        -- Bristleback water seeker, this one already got a display_id, but screenshot show another
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3260;
+
+        -- Bristleback defender, this one already got a display_id, but screenshot show another
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3259;
+
+        --
+
+        -- Kolkar pack runner
+        UPDATE `creature_template`
+        SET `display_id1`=1347
+        WHERE `entry`=3274;
+
+        -- Kolkar marauder, screenshot
+        UPDATE `creature_template`
+        SET `display_id1`=1347
+        WHERE `entry`=3275;
+
+        -- Kolkar bloodcharger
+        UPDATE `creature_template`
+        SET `display_id1`=1347
+        WHERE `entry`=3397;
+
+        -- Kolkar stormer
+        UPDATE `creature_template`
+        SET `display_id1`=1347
+        WHERE `entry`=3273;
+
+        --
+
+        -- Lost Barrens Kodo, we scale it, a screenshot show how big he is
+        UPDATE `creature_template`
+        SET `display_id1`=1451, `scale`=1.3
+        WHERE `entry`=3234;
+
+        -- Sunscale scytheclaw, same display_id as 1.12 and all others raptors in barrens
+        UPDATE `creature_template`
+        SET `display_id1`=1747
+        WHERE `entry`=3256;
+
+        -- Wizzlecrank's shredder, screenshot
+        UPDATE `creature_template`
+        SET `display_id1`=1303
+        WHERE `entry`=3439;
+
+        -- Horde Guards, see issue discussion #332
+        UPDATE `creature_template`
+        SET `display_id1`=1908, `display_id2`=1909, `display_id3`=3772, `display_id4`=3773
+        WHERE `entry`=3501;
+
+        insert into applied_updates values ('030820221');
     end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7650,12 +7650,7 @@ begin not atomic
 
         -- # DUROTAR
 
-        -- Razormane battleguard,  this one already got a display_id, but screenshot show another
-        UPDATE `creature_template`
-        SET `display_id1`=1341
-        WHERE `entry`=3114;
-
-        -- Razormane battleguard, vanilla models not exist yet, he probably use same models as all Razormane
+        -- Razormane Dustrunner, screenshot
         UPDATE `creature_template`
         SET `display_id1`=1341
         WHERE `entry`=3113;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7648,6 +7648,28 @@ begin not atomic
         SET `display_id1`=1223
         WHERE `entry`=2965;
 
+        -- # DUROTAR
+
+        -- Razormane battleguard,  this one already got a display_id, but screenshot show another
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3114;
+
+        -- Razormane battleguard, vanilla models not exist yet, he probably use same models as all Razormane
+        UPDATE `creature_template`
+        SET `display_id1`=1341
+        WHERE `entry`=3113;
+
+        -- Kolkar drudge,  this one already got a display_id, but screenshot show another
+        UPDATE `creature_template`
+        SET `display_id1`=1258
+        WHERE `entry`=3119;
+
+        -- Kolkar outrunner
+        UPDATE `creature_template`
+        SET `display_id1`=1258
+        WHERE `entry`=3120;
+
         -- # BARRENS
 
         -- Razormane warfury


### PR DESCRIPTION
### Fix issue #322 

Mulgore
======

**Windfury Matriarch** 
![images_6812](https://user-images.githubusercontent.com/72315006/182516919-c0eee813-8376-4f8b-bd3e-7ca0c235c299.jpg)

Durotar
======

**Razormane Dustrunner**
![shyso_4 20_18](https://user-images.githubusercontent.com/72315006/182720397-6b81c5a8-52bf-4e4c-8409-a3f18119ca39.jpg)

**Kolkar**
We have a screenshot of Kolkar Drudge with another display id (darker) that the actual one. Since Kolkar Outrunner display_id not exist in 0.5.3, they probably use the same.
![w2](https://user-images.githubusercontent.com/72315006/182720423-f9f0f87d-79f2-4385-9ffc-bf4294e1c1f4.jpeg)

Barrens
======

**Horde Guard**
See #322 issue discussion 

**Lost Barrens Kodo**
![7m_WoWScrnShot_041304_095315](https://user-images.githubusercontent.com/72315006/182517313-6090bab9-4d55-42d2-a94f-91b37e178c9a.jpg)

**Wizzlecrank**
His name is "Wizzlecrank" without "Shredder" on screenshot, on alpha core is "Wizzlecrank's shredder", dont know if I need to change it.
![Goblin Shreddar](https://user-images.githubusercontent.com/72315006/182517369-df9ada6f-2af6-4791-b3d4-abba9d4b5af6.jpg)

**Sunscale Scytheclaw**
Same display id as vanilla one, and same display id that others Barrens raptor.
![lashtail-2](https://user-images.githubusercontent.com/72315006/182520085-7d7ae0c8-6386-432b-b1ae-2c480c4f75cb.jpg)
![581561-534914_20040701_024](https://user-images.githubusercontent.com/72315006/182520135-62a28619-00a8-4aa3-9026-98fbf6e84768.jpg)


**Kolkar**
There are only 2 differents centaur models (color variation) in 0.5.3.
It appears that Kolkar mobs use same display_id for every type (Marauder, pack runner...). 
Later others models will be added (not present in 0.5.3), as we can see in the last centaur's screenshot
![septembre2003-85](https://user-images.githubusercontent.com/72315006/182517749-bfbb6570-f892-48f2-8cb4-2877e953f1c1.jpg)
![janvier2004-50](https://user-images.githubusercontent.com/72315006/182517796-98cc540a-94f1-4aed-8524-441a2b687dac.jpg)
![WoWScrnShot_050204_235324](https://user-images.githubusercontent.com/72315006/182518310-b3a68d7d-64a7-4ad7-a107-4c9a4ebd5244.jpg)
![mars2004-18](https://user-images.githubusercontent.com/72315006/182517827-98553886-dd4c-44b9-951d-50101999bdd9.jpg)



**Razormane & Britleback**
It appears that Razormane & Britleback mobs use same display id for every type (Geomancer, defender, hunter...)
All screenshots below show only one display id for differents mobs type.
![InWoW_1255](https://user-images.githubusercontent.com/72315006/182518092-a54cc215-6289-4bfd-b394-3c4e8de3cfae.jpg)
![images_2761](https://user-images.githubusercontent.com/72315006/182518159-b682ccba-e686-4041-bf84-277e5747a8ac.jpg)
![images_2762](https://user-images.githubusercontent.com/72315006/182518178-a0af4492-3854-4a49-b8cc-2cb97e7c1469.jpg)
![WoWScrnShot_050604_033313](https://user-images.githubusercontent.com/72315006/182518226-622e26a5-cafc-4789-9524-efce19781491.jpg)
![Rebirth Outcome](https://user-images.githubusercontent.com/72315006/182520191-2fea441f-4699-4f9e-8612-cf72159ddfc5.jpg)


Notes
=====
Here's a screenshot of display id that probably show a part of Barrens mobs push
![Capture d’écran_2022-08-03_02-00-22](https://user-images.githubusercontent.com/72315006/182519784-72e5f268-4706-4dac-afdd-f8763f4612c2.png)


