### PR TITLE
/ Fixes.

### DIFF
--- a/database/world/WorldDatabaseManager.py
+++ b/database/world/WorldDatabaseManager.py
@@ -271,6 +271,17 @@ class WorldDatabaseManager(object):
 
     # Gameobject stuff.
 
+    class GameobjectTemplateHolder:
+        GAMEOBJECT_TEMPLATES: [int, GameobjectTemplate] = {}
+
+        @staticmethod
+        def load_gameobject_template(gameobject_template):
+            WorldDatabaseManager.GameobjectTemplateHolder.GAMEOBJECT_TEMPLATES[gameobject_template.entry] = gameobject_template
+
+        @staticmethod
+        def gameobject_get_by_entry(entry) -> Optional[GameobjectTemplate]:
+            return WorldDatabaseManager.GameobjectTemplateHolder.GAMEOBJECT_TEMPLATES.get(entry)
+
     @staticmethod
     def gameobject_get_all_spawns() -> [list[SpawnsGameobjects], scoped_session]:
         world_db_session = SessionHolder()

--- a/database/world/WorldDatabaseManager.py
+++ b/database/world/WorldDatabaseManager.py
@@ -283,6 +283,12 @@ class WorldDatabaseManager(object):
             return WorldDatabaseManager.GameobjectTemplateHolder.GAMEOBJECT_TEMPLATES.get(entry)
 
     @staticmethod
+    def gameobject_template_get_all():
+        world_db_session = SessionHolder()
+        res = world_db_session.query(GameobjectTemplate).all()
+        return res, world_db_session
+
+    @staticmethod
     def gameobject_get_all_spawns() -> [list[SpawnsGameobjects], scoped_session]:
         world_db_session = SessionHolder()
         res = world_db_session.query(SpawnsGameobjects).filter_by(ignored=0).all()

--- a/database/world/WorldModels.py
+++ b/database/world/WorldModels.py
@@ -986,7 +986,7 @@ class SpawnsGameobjects(Base):
     __tablename__ = 'spawns_gameobjects'
 
     spawn_id = Column(INTEGER(10), primary_key=True, comment='Global Unique Identifier')
-    spawn_entry = Column(ForeignKey('gameobject_template.entry', ondelete='CASCADE', onupdate='CASCADE'), nullable=False, index=True, server_default=text("'0'"), comment='Gameobject Identifier')
+    spawn_entry = Column(MEDIUMINT(8), nullable=False, server_default=text("'0'"), comment='Gameobject Template Id')
     spawn_map = Column(SMALLINT(5), nullable=False, index=True, server_default=text("'0'"), comment='Map Identifier')
     spawn_positionX = Column(Float, nullable=False, server_default=text("'0'"))
     spawn_positionY = Column(Float, nullable=False, server_default=text("'0'"))
@@ -1003,8 +1003,6 @@ class SpawnsGameobjects(Base):
     spawn_flags = Column(INTEGER(10), nullable=False, server_default=text("'0'"))
     spawn_visibility_mod = Column(Float, nullable=True, server_default=text("'0'"))
     ignored = Column(TINYINT(1), nullable=False, server_default=text("'0'"))
-
-    gameobject = relationship('GameobjectTemplate', lazy='joined')
 
 
 class NpcGossip(Base):

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -92,6 +92,7 @@ class WorldLoader:
                     gobject_instance=gobject_spawn
                 )
                 gobject_mgr.load()
+                WorldDatabaseManager.GameobjectTemplateHolder.load_gameobject_template(gobject_spawn.gameobject)
 
             count += 1
             Logger.progress('Spawning gameobjects...', count, length)

--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -322,9 +322,11 @@ class GameObjectManager(ObjectManager):
             if len(iron_clad_doors) > 0:
                 self.send_custom_animation(0)
                 iron_clad_doors[0].set_active()
+        # QuestID.
+        elif self.gobject_template.data1:
+            player.quest_manager.handle_goober_use(self, self.gobject_template.data1)
         else:
             Logger.warning(f'Unimplemented gameobject use for type Goober entry {self.entry} name {self.gobject_template.name}')
-        pass
 
     def use(self, player, target=None):
         if self.gobject_template.type == GameObjectTypes.TYPE_DOOR:
@@ -461,24 +463,26 @@ class GameObjectManager(ObjectManager):
 
             self.initialized = True
 
-    def query_details(self):
-        name_bytes = PacketWriter.string_to_bytes(self.gobject_template.name)
+    @staticmethod
+    def query_details(gobject_template=None, gameobject_mgr=None):
+        go_template = gameobject_mgr.gobject_template if gameobject_mgr else gobject_template
+        name_bytes = PacketWriter.string_to_bytes(go_template.name)
         data = pack(
             f'<3I{len(name_bytes)}ssss10I',
-            self.gobject_template.entry,
-            self.gobject_template.type,
-            self.current_display_id,
+            go_template.entry,
+            go_template.type,
+            gameobject_mgr.current_display_id if gameobject_mgr else go_template.display_id,
             name_bytes, b'\x00', b'\x00', b'\x00',
-            self.gobject_template.data0,
-            self.gobject_template.data1,
-            self.gobject_template.data2,
-            self.gobject_template.data3,
-            self.gobject_template.data4,
-            self.gobject_template.data5,
-            self.gobject_template.data6,
-            self.gobject_template.data7,
-            self.gobject_template.data8,
-            self.gobject_template.data9
+            go_template.data0,
+            go_template.data1,
+            go_template.data2,
+            go_template.data3,
+            go_template.data4,
+            go_template.data5,
+            go_template.data6,
+            go_template.data7,
+            go_template.data8,
+            go_template.data9
         )
         return PacketWriter.get_packet(OpCode.SMSG_GAMEOBJECT_QUERY_RESPONSE, data)
 

--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -123,7 +123,7 @@ class GameObjectManager(ObjectManager):
 
     @staticmethod
     def spawn(entry, location, map_id, summoner=None, spell_id=0, override_faction=0, despawn_time=1):
-        go_template = WorldDatabaseManager.gameobject_template_get_by_entry(entry)
+        go_template = WorldDatabaseManager.GameobjectTemplateHolder.gameobject_get_by_entry(entry)
 
         if not go_template:
             return None

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -274,6 +274,12 @@ class CastingSpell:
         unlock_effects = [SpellEffects.SPELL_EFFECT_OPEN_LOCK, SpellEffects.SPELL_EFFECT_OPEN_LOCK_ITEM]
         return any(effect.effect_type in unlock_effects for effect in self.get_effects())
 
+    def get_lock_effect(self):
+        unlock_effects = [SpellEffects.SPELL_EFFECT_OPEN_LOCK, SpellEffects.SPELL_EFFECT_OPEN_LOCK_ITEM]
+        for effect in self.get_effects():
+            if effect.effect_type in unlock_effects:
+                return effect
+
     def is_pickpocket_spell(self):
         return any(effect.effect_type == SpellEffects.SPELL_EFFECT_PICKPOCKET for effect in self.get_effects())
 

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -1189,6 +1189,7 @@ class SpellManager:
         if not self.caster.object_type_mask & ObjectTypeFlags.TYPE_UNIT:
             return
 
+        is_player = self.caster.get_type_id() == ObjectTypeIds.ID_PLAYER
         power_type = casting_spell.spell_entry.PowerType
         # Check if this spell should consume all power.
         if casting_spell.spell_entry.AttributesEx & SpellAttributesEx.SPELL_ATTR_EX_DRAIN_ALL_POWER:
@@ -1215,14 +1216,15 @@ class SpellManager:
                 casting_spell.requires_combo_points():
             self.caster.remove_combo_points()
 
-        for reagent_info in casting_spell.get_reagents():  # Reagents.
-            if reagent_info[0] == 0:
-                break
-            self.caster.inventory.remove_items(reagent_info[0], reagent_info[1])
+        if is_player:
+            for reagent_info in casting_spell.get_reagents():  # Reagents.
+                if reagent_info[0] == 0:
+                    break
+                self.caster.inventory.remove_items(reagent_info[0], reagent_info[1])
 
         # Ammo
         used_ammo_or_weapon = casting_spell.used_ranged_attack_item
-        if casting_spell.spell_attack_type == AttackTypes.RANGED_ATTACK and used_ammo_or_weapon:
+        if is_player and casting_spell.spell_attack_type == AttackTypes.RANGED_ATTACK and used_ammo_or_weapon:
             # Validation ensures that the initially selected ammo (used_ranged_attack_item) remains the same.
             ammo_class = used_ammo_or_weapon.item_template.class_
             ammo_subclass = used_ammo_or_weapon.item_template.subclass
@@ -1236,7 +1238,7 @@ class SpellManager:
                                                             used_ammo_or_weapon.item_instance.bag)
 
         # Spells cast with consumables.
-        if casting_spell.source_item and casting_spell.source_item.has_charges():
+        if is_player and casting_spell.source_item and casting_spell.source_item.has_charges():
             charges = casting_spell.source_item.get_charges(casting_spell.spell_entry.ID)
             if charges < 0:  # Negative charges remove items.
                 self.caster.inventory.remove_items(casting_spell.source_item.item_template.entry, 1)

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -930,8 +930,8 @@ class SpellManager:
                 return False
 
             # OPEN_LOCK spells can provide bonus skill.
-            lock_effect = casting_spell.get_effect_by_type(SpellEffects.SPELL_EFFECT_OPEN_LOCK)
-            if lock_effect:
+            if casting_spell.is_unlocking_spell():
+                lock_effect = casting_spell.get_lock_effect()
                 bonus_skill = lock_effect.get_effect_simple_points()
 
                 # Skill checks and random failure chance.
@@ -946,12 +946,9 @@ class SpellManager:
                                                                                            validation_target.lock,
                                                                                            used_item=casting_spell.source_item,
                                                                                            bonus_skill=bonus_skill)
-
                 if unlock_result != SpellCheckCastResult.SPELL_NO_ERROR:
                     self.send_cast_result(casting_spell.spell_entry.ID, unlock_result)
                     return False
-            else:
-                Logger.warning(f'No lock effect found for casting spell {casting_spell.spell_entry.ID}.')
 
         # Special case of Ritual of Summoning.
         summoning_channel_id = 698

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -551,17 +551,19 @@ class CreatureManager(UnitManager):
 
             self.initialized = True
 
-    def query_details(self):
-        name_bytes = PacketWriter.string_to_bytes(self.creature_template.name)
-        subname_bytes = PacketWriter.string_to_bytes(self.creature_template.subname)
+    @staticmethod
+    def query_details(creature_template=None, creature_mgr=None):
+        template = creature_mgr.creature_template if creature_mgr else creature_template
+        name_bytes = PacketWriter.string_to_bytes(template.name)
+        subname_bytes = PacketWriter.string_to_bytes(template.subname)
         data = pack(
             f'<I{len(name_bytes)}ssss{len(subname_bytes)}s3I',
-            self.entry,
+            creature_mgr.entry if creature_mgr else template.entry,
             name_bytes, b'\x00', b'\x00', b'\x00',
             subname_bytes,
-            self.creature_template.static_flags,
-            self.creature_type,
-            self.creature_template.beast_family
+            template.static_flags,
+            creature_mgr.creature_type if creature_mgr else template.type,
+            template.beast_family
         )
         return PacketWriter.get_packet(OpCode.SMSG_CREATURE_QUERY_RESPONSE, data)
 

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -6,9 +6,11 @@ from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.WorldSessionStateHandler import WorldSessionStateHandler
 from game.world.managers.abstractions.Vector import Vector
 from game.world.managers.maps.MapManager import MapManager
+from game.world.managers.objects.gameobjects.GameObjectManager import GameObjectManager
 from game.world.managers.objects.item.ItemManager import ItemManager
 from game.world.managers.objects.loot.LootSelection import LootSelection
 from game.world.managers.objects.spell.ExtendedSpellData import ShapeshiftInfo
+from game.world.managers.objects.units.creature.CreatureManager import CreatureManager
 from game.world.managers.objects.units.player.ChannelManager import ChannelManager
 from game.world.managers.objects.units.player.EnchantmentManager import EnchantmentManager
 from game.world.managers.objects.units.player.SkillManager import SkillManager
@@ -387,7 +389,7 @@ class PlayerManager(UnitManager):
             active_objects[guid] = creature
             if guid not in self.known_objects or not self.known_objects[guid]:
                 # We don't know this creature, notify self with its update packet.
-                self.enqueue_packet(creature.query_details())
+                self.enqueue_packet(CreatureManager.query_details(creature_mgr=creature))
                 if creature.is_spawned:
                     self.enqueue_packet(creature.generate_create_packet(requester=self))
                     # Get partial movement packet if any.
@@ -410,7 +412,7 @@ class PlayerManager(UnitManager):
             active_objects[guid] = gobject
             if guid not in self.known_objects or not self.known_objects[guid]:
                 # We don't know this game object, notify self with its update packet.
-                self.enqueue_packet(gobject.query_details())
+                self.enqueue_packet(GameObjectManager.query_details(gameobject_mgr=gobject))
                 if gobject.is_spawned:
                     self.enqueue_packet(gobject.generate_create_packet(requester=self))
                     # We only consider 'known' if its spawned, the details query is still sent.

--- a/game/world/managers/objects/units/player/quest/ActiveQuest.py
+++ b/game/world/managers/objects/units/player/quest/ActiveQuest.py
@@ -210,17 +210,16 @@ class ActiveQuest:
         return True
 
     def requires_creature_or_go(self, world_object):
-        req_creatures_or_gos = QuestHelpers.generate_req_creature_or_go_list(self.quest)
-
         # Creatures > 0, Gameobjects < 0.
         entry = world_object.entry if world_object.get_type_id() != ObjectTypeIds.ID_GAMEOBJECT else -world_object.entry
-
+        
+        req_creatures_or_gos = QuestHelpers.generate_req_creature_or_go_list(self.quest)
         required = entry in req_creatures_or_gos
         if required:
             index = req_creatures_or_gos.index(entry)
-            required_kills = QuestHelpers.generate_req_creature_or_go_count_list(self.quest)[index]
-            current_kills = eval(f'self.db_state.mobcount{index + 1}')
-            return current_kills < required_kills
+            required_qty = QuestHelpers.generate_req_creature_or_go_count_list(self.quest)[index]
+            current_qty = eval(f'self.db_state.mobcount{index + 1}')
+            return current_qty < required_qty
         return False
 
     def still_needs_item(self, item_entry):

--- a/game/world/managers/objects/units/player/quest/ActiveQuest.py
+++ b/game/world/managers/objects/units/player/quest/ActiveQuest.py
@@ -102,16 +102,21 @@ class ActiveQuest:
         self.owner.give_xp([xp], notify=False)
         return xp
 
-    def update_creature_go_count(self, creature, value):
-        creature_go_index = QuestHelpers.generate_req_creature_or_go_list(self.quest).index(creature.entry)
+    def update_creature_go_count(self, world_object, value):
+        # Creatures > 0, Gameobjects < 0.
+        entry = world_object.entry if world_object.get_type_id() != ObjectTypeIds.ID_GAMEOBJECT else -world_object.entry
+
+        creature_go_index = QuestHelpers.generate_req_creature_or_go_list(self.quest).index(entry)
         required = QuestHelpers.generate_req_creature_or_go_count_list(self.quest)[creature_go_index]
         current = self._get_db_mob_or_go_count(creature_go_index)
         # Current < Required is already validated on requires_creature_or_go().
         self._update_db_creature_go_count(creature_go_index, 1)  # Update db memento
-        # Notify the current objective count to the player.
-        data = pack('<4IQ', self.db_state.quest, creature.entry, current + value, required, creature.guid)
-        packet = PacketWriter.get_packet(OpCode.SMSG_QUESTUPDATE_ADD_KILL, data)
-        self.owner.enqueue_packet(packet)
+
+        # Notify the current objective count to the player if this was a kill.
+        if world_object.get_type_id() != ObjectTypeIds.ID_GAMEOBJECT:
+            data = pack('<4IQ', self.db_state.quest, world_object.entry, current + value, required, world_object.guid)
+            packet = PacketWriter.get_packet(OpCode.SMSG_QUESTUPDATE_ADD_KILL, data)
+            self.owner.enqueue_packet(packet)
         # Check if this makes it complete.
         if self.can_complete_quest():
             self.update_quest_state(QuestState.QUEST_REWARD)
@@ -204,11 +209,15 @@ class ActiveQuest:
         # TODO: Check ReqMoney
         return True
 
-    def requires_creature_or_go(self, creature_entry):
+    def requires_creature_or_go(self, world_object):
         req_creatures_or_gos = QuestHelpers.generate_req_creature_or_go_list(self.quest)
-        required = creature_entry in req_creatures_or_gos
+
+        # Creatures > 0, Gameobjects < 0.
+        entry = world_object.entry if world_object.get_type_id() != ObjectTypeIds.ID_GAMEOBJECT else -world_object.entry
+
+        required = entry in req_creatures_or_gos
         if required:
-            index = req_creatures_or_gos.index(creature_entry)
+            index = req_creatures_or_gos.index(entry)
             required_kills = QuestHelpers.generate_req_creature_or_go_count_list(self.quest)[index]
             current_kills = eval(f'self.db_state.mobcount{index + 1}')
             return current_kills < required_kills
@@ -266,7 +275,7 @@ class ActiveQuest:
         req_creature_or_go = QuestHelpers.generate_req_creature_or_go_list(self.quest)
         req_creature_or_go_count = QuestHelpers.generate_req_creature_or_go_count_list(self.quest)
         for index, creature_or_go in enumerate(req_creature_or_go):
-            if req_creature_or_go[index] > 0:
+            if req_creature_or_go[index] != 0:
                 current_count = eval(f'self.db_state.mobcount{index + 1}')
                 required = req_creature_or_go_count[index]
                 # Consider how many bits the previous creature required.
@@ -278,7 +287,7 @@ class ActiveQuest:
                     else:  # Fill remaining 0s (Missing kills)
                         total_count += 0 << (1 * i) + offset
 
-                # Debug, enable this to take a look on whats happening at bit level.
-                # Logger.debug(f'{bin(mob_kills)[2:].zfill(32)}')
+                # Debug, enable this to take a look on what's happening at bit level.
+                # Logger.debug(f'{bin(total_count)[2:].zfill(32)}')
 
         return total_count

--- a/game/world/managers/objects/units/player/quest/QuestHelpers.py
+++ b/game/world/managers/objects/units/player/quest/QuestHelpers.py
@@ -10,7 +10,7 @@ class QuestHelpers:
     @staticmethod
     def is_instant_with_no_requirements(quest_template):
         return QuestHelpers.is_instant_complete_quest(quest_template) and \
-               not QuestHelpers.has_item_requirements(quest_template)
+               not QuestHelpers.requires_items_or_gos(quest_template)
 
     @staticmethod
     def is_quest_repeatable(quest_template):

--- a/game/world/opcode_handling/handlers/gameobject/GameObjectQueryHandler.py
+++ b/game/world/opcode_handling/handlers/gameobject/GameObjectQueryHandler.py
@@ -12,15 +12,18 @@ class GameObjectQueryHandler(object):
         if len(reader.data) >= 12:  # Avoid handling empty gameobject query packet.
             entry, guid = unpack('<IQ', reader.data[:12])
             if guid > 0:
-                gobject_mgr = MapManager.get_surrounding_gameobject_by_guid(world_session.player_mgr, guid)
-                if not gobject_mgr:
-                    gobject_spawn, session = WorldDatabaseManager.gameobject_spawn_get_by_guid(guid)
-                    if gobject_spawn and gobject_spawn.gameobject.entry == entry:
-                        gobject_mgr = GameObjectManager(
-                            gobject_template=gobject_spawn.gameobject
-                        )
-                    session.close()
+                player_mgr = world_session.player_mgr
+                gobject_mgr = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
                 if gobject_mgr:
-                    world_session.enqueue_packet(gobject_mgr.query_details())
+                    player_mgr.enqueue_packet(GameObjectManager.query_details(gameobject_mgr=gobject_mgr))
+                    return 0
+
+                gobject_spawn, session = WorldDatabaseManager.gameobject_spawn_get_by_guid(guid)
+                if gobject_spawn and gobject_spawn.gameobject.entry == entry:
+                    go_template = WorldDatabaseManager.GameobjectTemplateHolder.gameobject_get_by_entry(entry)
+                    if go_template:
+                        player_mgr.enqueue_packet(GameObjectManager.query_details(gobject_template=go_template))
+
+                session.close()
 
         return 0

--- a/game/world/opcode_handling/handlers/npc/CreatureQueryHandler.py
+++ b/game/world/opcode_handling/handlers/npc/CreatureQueryHandler.py
@@ -12,15 +12,18 @@ class CreatureQueryHandler(object):
         if len(reader.data) >= 12:  # Avoid handling empty creature query packet.
             entry, guid = unpack('<IQ', reader.data[:12])
             if guid > 0:
-                creature_mgr = MapManager.get_surrounding_unit_by_guid(world_session.player_mgr, guid)
-                if not creature_mgr:
-                    creature_spawn, session = WorldDatabaseManager.creature_spawn_get_by_guid(guid)
-                    if creature_spawn and creature_spawn.creature_template.entry == entry:
-                        creature_mgr = CreatureManager(
-                            creature_template=creature_spawn.creature_template
-                        )
-                    session.close()
+                player_mgr = world_session.player_mgr
+                creature_mgr = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
                 if creature_mgr:
-                    world_session.enqueue_packet(creature_mgr.query_details())
+                    player_mgr.enqueue_packet(CreatureManager.query_details(creature_mgr=creature_mgr))
+                    return 0
+
+                creature_spawn, session = WorldDatabaseManager.gameobject_spawn_get_by_guid(guid)
+                if creature_spawn and creature_spawn.creature_template.entry == entry:
+                    creature_template = WorldDatabaseManager.CreatureTemplateHolder.creature_get_by_entry(entry)
+                    if creature_template:
+                        player_mgr.enqueue_packet(CreatureManager.query_details(creature_template=creature_template))
+
+                session.close()
 
         return 0


### PR DESCRIPTION
/ Quests - Fix #345
/ Stop creating GameObjectManager & CreatureManager instances for detail queries.
/ Quests - Fix null objectives if the required creature or go was out of range (Unknown to the player)
/ Quests - Fix bug that prevented request items text to be sent when asking the npc for details on accepted quests.
/ Quests - Play player emote when talking to quest givers. (quest details or quest list)