### PR TITLE
Crafting profession skill gain restrictions and correct max skill levels

### DIFF
--- a/game/world/managers/objects/spell/ExtendedSpellData.py
+++ b/game/world/managers/objects/spell/ExtendedSpellData.py
@@ -175,3 +175,33 @@ class SummonedObjectPositions:
     @staticmethod
     def get_position_in_front(caster_location):
         return caster_location.get_point_in_radius_and_angle(2, 0)
+
+
+class ProfessionInfo:
+    PROFESSION_MAX_SKILL_VALUES = {
+        164: (2018, 3100, 3538),  # Blacksmithing
+        165: (2108, 3104, 3811),  # Leatherworking
+        171: (2259, 3101, 3464),  # Alchemy
+        182: (2366, 2368, 3570),  # Herbalism
+        185: (2550, 3102, 3413),  # Cooking
+        186: (2575, 2576, 3564),  # Mining
+        197: (3908, 3909, 3910),  # Tailoring
+        202: (4036, 4037, 4038),  # Engineering
+        333: (7411, 7412, 7413),  # Enchanting
+        356: (7620, 7731, 7732)   # Fishing
+    }
+
+    @staticmethod
+    def get_max_skill_value(profession_spell_id, player):
+        prof_spells = ProfessionInfo.PROFESSION_MAX_SKILL_VALUES[profession_spell_id]
+        known = player.spell_manager.spells.keys() & prof_spells
+        if not known:
+            return 0
+        return (prof_spells.index(max(known)) + 1) * 75
+
+    @staticmethod
+    def get_profession_skill_id_for_spell(spell_id):
+        for profession_spell_id, prof_spells in ProfessionInfo.PROFESSION_MAX_SKILL_VALUES.items():
+            if spell_id in prof_spells:
+                return profession_spell_id
+        return 0

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -202,7 +202,7 @@ class SpellEffectHandler:
         target.inventory.add_item(effect.item_type, count=amount, created_by=caster.guid)
 
         # Craft Skill gain if needed.
-        target.skill_manager.handle_profession_skill_gain_chance(casting_spell.spell_entry.ID)
+        target.skill_manager.handle_profession_skill_gain(casting_spell.spell_entry.ID)
 
     @staticmethod
     def handle_teleport_units(casting_spell, effect, caster, target):
@@ -542,7 +542,7 @@ class SpellEffectHandler:
         owner_player.enchantment_manager.set_item_enchantment(target, enchantment_slot, effect.misc_value,
                                                               duration, charges)
 
-        caster.skill_manager.handle_profession_skill_gain_chance(casting_spell.spell_entry.ID)
+        caster.skill_manager.handle_profession_skill_gain(casting_spell.spell_entry.ID)
 
         # Save item.
         target.save()

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -140,7 +140,6 @@ class SpellEffectHandler:
                                                 bonus_points=bonus_points)
 
         caster.skill_manager.handle_gather_skill_gain(lock_result.skill_type,
-                                                      lock_result.skill_value,
                                                       lock_result.required_skill_value)
 
     @staticmethod

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -68,7 +68,13 @@ class SpellManager:
         if spell.Attributes & SpellAttributes.SPELL_ATTR_PASSIVE:
             self.apply_passive_spell_effects(spell)
 
-        # TODO Teach skill required as well like in CharCreateHandler
+        # If a profession spell is learned, grant the required skill.
+        # If the player already knows the skill, update max skill level.
+        related_profession_skill = ExtendedSpellData.ProfessionInfo.get_profession_skill_id_for_spell(spell_id)
+        if related_profession_skill:
+            if not self.caster.skill_manager.add_skill(related_profession_skill):
+                self.caster.skill_manager.update_skills_max_value()
+
         return True
 
     def unlearn_spell(self, spell_id) -> bool:

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -232,7 +232,6 @@ class SkillManager(object):
         for skill in RealmDatabaseManager.character_get_skills(self.player_mgr.guid):
             self.skills[skill.skill] = skill
         self.update_skills_max_value()
-        self.build_update()
 
     # Apply armor proficiencies and populate full_proficiency_masks.
     # noinspection PyUnusedLocal
@@ -333,6 +332,8 @@ class SkillManager(object):
                 new_max = self.get_max_rank(skill_id)
 
             self.set_skill(skill_id, skill.value, new_max)
+
+        self.build_update()
 
     def handle_weapon_skill_gain_chance(self, attack_type: AttackTypes):
         # Vanilla formulae.

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -433,6 +433,9 @@ class SkillManager(object):
 
         skill = self.skills[skill_id]
 
+        if skill.value >= skill.max:
+            return False
+
         gray_threshold = skill_line_ability.TrivialSkillLineRankHigh
         yellow_threshold = skill_line_ability.TrivialSkillLineRankLow
         chance = SkillManager._get_skill_gain_chance(skill.value, gray_threshold,
@@ -447,16 +450,18 @@ class SkillManager(object):
         gather_skill_gain_factor = 1  # TODO, configurable.
         if skill_type not in self.skills:
             return
-        raw_skill_value = self.skills[skill_type].value
+        skill = self.skills[skill_type]
+        if skill.value >= skill.max:
+            return False
 
-        chance = SkillManager._get_skill_gain_chance(raw_skill_value,
+        chance = SkillManager._get_skill_gain_chance(skill.value,
                                                      required_skill_value + 100,
                                                      required_skill_value + 50,
                                                      required_skill_value + 25)
 
         if skill_type == SkillTypes.MINING:
             mining_skill_chance_steps = 75  # TODO, configurable.
-            chance = chance >> int(raw_skill_value / mining_skill_chance_steps)
+            chance = chance >> int(skill.value / mining_skill_chance_steps)
 
         self._roll_profession_skill_gain_chance(skill_type, chance, gather_skill_gain_factor)
 

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -290,11 +290,11 @@ class SkillManager(object):
     def add_skill(self, skill_id):
         # Skill already learned.
         if skill_id in self.skills:
-            return
+            return False
 
         skill = DbcDatabaseManager.SkillHolder.skill_get_by_id(skill_id)
         if not skill:
-            return
+            return False
 
         start_rank_value = 1
         if skill.CategoryID == SkillCategories.MAX_SKILL:
@@ -310,6 +310,7 @@ class SkillManager(object):
 
         self.skills[skill_id] = skill_to_set
         self.build_update()
+        return True
 
     def set_skill(self, skill_id, current_value, max_value=-1):
         if skill_id not in self.skills:

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -837,7 +837,7 @@ class StatManager(object):
         if attacker_level == -1:
             attacker_level = self.unit_mgr.level
         if attacker_rating == -1:  # Use max defense skill since it follows the same values as max weapon skill
-            attacker_rating = SkillManager.get_max_rank(attacker_level, SkillTypes.DEFENSE)
+            attacker_rating = attacker_level * 5
 
         if self.unit_mgr.get_type_id() == ObjectTypeIds.ID_PLAYER:
             # TODO It's unclear what the block skill is used for based on patch notes.
@@ -845,7 +845,7 @@ class StatManager(object):
             # This way, block chance will be affected by block skill instead of defense skill like in vanilla.
             own_defense_rating = self.unit_mgr.skill_manager.get_total_skill_value(SkillTypes.DEFENSE if not use_block else SkillTypes.BLOCK)
         else:
-            own_defense_rating = SkillManager.get_max_rank(self.unit_mgr.level, SkillTypes.DEFENSE)
+            own_defense_rating = self.unit_mgr.level * 5
 
         return own_defense_rating - attacker_rating
 

--- a/game/world/managers/objects/units/player/trade/TradeData.py
+++ b/game/world/managers/objects/units/player/trade/TradeData.py
@@ -53,7 +53,7 @@ class TradeData(object):
                                                              self.proposed_enchantment.duration,
                                                              self.proposed_enchantment.charges)
 
-        self.player.skill_manager.handle_profession_skill_gain_chance(self.proposed_enchantment.spell_id)
+        self.player.skill_manager.handle_profession_skill_gain(self.proposed_enchantment.spell_id)
 
     def set_item(self, slot, item):
         if self.items[slot] and self.items[slot] == item:

--- a/game/world/opcode_handling/handlers/player/PlayerLoginHandler.py
+++ b/game/world/opcode_handling/handlers/player/PlayerLoginHandler.py
@@ -59,6 +59,7 @@ class PlayerLoginHandler(object):
         world_session.player_mgr.skill_manager.load_proficiencies()
         world_session.player_mgr.skill_manager.load_skills()
         world_session.player_mgr.spell_manager.load_spells()
+        world_session.player_mgr.skill_manager.update_skills_max_value()  # Can depend on learned spells.
 
         world_session.player_mgr.deathbind = RealmDatabaseManager.character_get_deathbind(world_session.player_mgr.guid)
         world_session.player_mgr.friends_manager.load_from_db(RealmDatabaseManager.character_get_social(world_session.player_mgr.guid))


### PR DESCRIPTION
* Add checks for player skill and required skill for profession crafts. Closes #357
* Fix profession skills going over their maximum level
* Learn profession skills when learning the related spell
* Add correct handling for profession skill max values
    * Max profession level now depends on the learned spell (Apprentice/Journeyman/Expert)
* Use base skill value for gathering skill gain
* Simplify/rename some skill-related methods