### PR TITLE
Ashenvale Improvements

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7767,5 +7767,166 @@ begin not atomic
         insert into applied_updates values ('030820221');
 
     end if;
+
+    -- 04/08/2022 1
+    if (select count(*) from applied_updates where id='040820221') = 0 then
+        -- Foulweald Warrior
+        UPDATE `creature_template`
+        SET `display_id1`=937
+        WHERE `entry`=3743;
+
+        -- Foulweald Totemic
+        UPDATE `creature_template`
+        SET `display_id1`=1996
+        WHERE `entry`=3750;
+
+        -- Foulweald Shaman
+        UPDATE `creature_template`
+        SET `display_id1`=1996
+        WHERE `entry`=3748;
+
+        -- Foulweald Den Watcher
+        UPDATE `creature_template`
+        SET `display_id1`=937
+        WHERE `entry`=3746;
+
+        -- Shandethicket Stone Mover
+        UPDATE `creature_template`
+        SET `display_id1`=2023
+        WHERE `entry`=3782;
+
+        -- Xiavian Felsworn
+        UPDATE `creature_template`
+        SET `display_id1`=2880
+        WHERE `entry`=3755;
+
+        -- Xiavian Betrayer
+        UPDATE `creature_template`
+        SET `display_id1`=2878
+        WHERE `entry`=3754;
+
+        -- Xiavian Rogue
+        UPDATE `creature_template`
+        SET `display_id1`=2878
+        WHERE `entry`=3752;
+
+        -- Xiavian Hellcaller
+        UPDATE `creature_template`
+        SET `display_id1`=2880
+        WHERE `entry`=3757;
+
+        -- Felmusk Shadowstalker
+        UPDATE `creature_template`
+        SET `display_id1`=2875
+        WHERE `entry`=3763;
+
+        -- Felmusk Satyr
+        UPDATE `creature_template`
+        SET `display_id1`=2010
+        WHERE `entry`=3758;
+
+        -- Felmusk Felsworn
+        UPDATE `creature_template`
+        SET `display_id1`=2687
+        WHERE `entry`=3762;
+
+        -- Withered ancient
+        UPDATE `creature_template`
+        SET `display_id1`=2079
+        WHERE `entry`=3919;
+
+        -- Thistlefur Shaman
+        UPDATE `creature_template`
+        SET `display_id1`=2004
+        WHERE `entry`=3924;
+
+        -- Thistlefur Avenger
+        UPDATE `creature_template`
+        SET `display_id1`=2004
+        WHERE `entry`=3925;
+
+        -- Thistlefur Pathfinder
+        UPDATE `creature_template`
+        SET `display_id1`=2004
+        WHERE `entry`=3926;
+
+        -- Thistlefur Totemic
+        UPDATE `creature_template`
+        SET `display_id1`=2004
+        WHERE `entry`=3922;
+
+        -- Dark Strand Excavator
+        UPDATE `creature_template`
+        SET `display_id1`=1643, `display_id2`=0, `display_id3`=0
+        WHERE `entry`=3730;
+
+        -- Dark Strand Cultist
+        UPDATE `creature_template`
+        SET `display_id1`=1642, `display_id2`=0, `display_id3`=0
+        WHERE `entry`=3725;
+
+        -- Dark Strand Adept
+        UPDATE `creature_template`
+        SET `display_id1`=1643, `display_id2`=0
+        WHERE `entry`=3728;
+
+        -- Dark Strand Enforcer
+        UPDATE `creature_template`
+        SET `display_id1`=1643, `display_id2`=1478, `display_id3`=0
+        WHERE `entry`=3727;
+
+        -- Wrathtail Wave Rider
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=3713;
+
+        -- Wrathtail Sorceress
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=3717;
+
+        -- Wrathtail Sea Witch
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=3715;
+
+        -- Wrathtail Myrmidon
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=3711;
+
+        -- Wrathtail Razortail
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=3712;
+
+        -- Wrathtail Priestess
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=3944;
+
+        -- Ruuzel, named naga
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=3943;
+
+        -- Clattering Crawler
+        UPDATE `creature_template`
+        SET `display_id1`=2239
+        WHERE `entry`=3812;
+
+        -- Felslayer
+        UPDATE `creature_template`
+        SET `display_id1`=850
+        WHERE `entry`=3774;
+
+        -- Lesser Felguard (probably Burning Legionnaire)
+        UPDATE `creature_template`
+        SET `display_id1`=68
+        WHERE `entry`=3772;
+
+        insert into applied_updates values ('040820221');
+
+    end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7925,6 +7925,11 @@ begin not atomic
         SET `display_id1`=68
         WHERE `entry`=3772;
 
+        -- Mystlash hydra
+        UPDATE `creature_template`
+        SET `display_id1`=1993
+        WHERE `entry`=3721;
+
         insert into applied_updates values ('040820221');
 
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7922,7 +7922,7 @@ begin not atomic
 
         -- Lesser Felguard (probably Burning Legionnaire)
         UPDATE `creature_template`
-        SET `display_id1`=2727
+        SET `display_id1`=2727, `name`='Burning Legionnaire'
         WHERE `entry`=3772;
 
         -- Mystlash hydra

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7922,7 +7922,7 @@ begin not atomic
 
         -- Lesser Felguard (probably Burning Legionnaire)
         UPDATE `creature_template`
-        SET `display_id1`=68
+        SET `display_id1`=2727
         WHERE `entry`=3772;
 
         -- Mystlash hydra


### PR DESCRIPTION
Ashenvale
========

**Foulweald**

There are 2 possible models (except ear variation and the named) :  Blue or Brown
![Capture d’écran_2022-08-04_06-01-37](https://user-images.githubusercontent.com/72315006/182760350-4fd41af4-2d0b-4224-8a66-934cc2777ab5.png)

Vanilla Foolweald use blue model: 

![foolweald](https://user-images.githubusercontent.com/72315006/182760389-2cf2108a-82a7-4db3-b141-188ff9b9656a.jpg)
![followeald2](https://user-images.githubusercontent.com/72315006/182760393-b583e3ed-9793-4f7f-b9f1-04e95d64eea1.jpg)


So I used blue models for Foulweald mobs, the exact same as vanilla (including ear variation)

**Thistlefur**

Same as Foulweald, there are 2 possible models.

Vanilla Thistlefur use Brown models and white one (not part of 0.5.3)

![images_4457](https://user-images.githubusercontent.com/72315006/182760724-929216a6-e36b-421c-819a-72974bae2293.jpg)
![52617](https://user-images.githubusercontent.com/72315006/182760734-40adfa84-0e85-4976-81a8-cb740147ca04.jpg)

So I used brown models for Thistlefur,  I replaced white one with brown model.


**Xavian & Felmusk**
Satyr models with a lot of color variations are already present in 0.5.3
![Capture d’écran_2022-08-04_03-22-35](https://user-images.githubusercontent.com/72315006/182761234-2e5e1445-c2e0-4ff4-8d12-5fdb7e9c58e1.png)

I used exact same models than 1.12 for each mobs.

**Dark Strand**
Dark strand mobs use 3 different models for each mobs, I updated each Dark Strand mob to remove unavailable display id and add those screenshots show.
![Dark Strand Enforcer (Needs Texture)](https://user-images.githubusercontent.com/72315006/182761556-b8ec7c87-dd80-4902-a02d-de5f0e1eddf1.jpg)
![images_4410](https://user-images.githubusercontent.com/72315006/182761572-eb83c855-61e8-45aa-b0f6-7ef0f16ede16.jpg)
![images_4414](https://user-images.githubusercontent.com/72315006/182761575-6ddc87b0-746d-4406-8ad2-fbb288479af0.jpg)
![images_4441](https://user-images.githubusercontent.com/72315006/182763605-2e495ed9-c583-4882-8a9a-b5a6efb9619b.jpg)
![images_4423](https://user-images.githubusercontent.com/72315006/182761580-d884bb4b-afee-4eac-a4c6-1052b162ab4e.jpg)

**Wrathtail**
There is only one Naga display_id : 4036. There is no female models yet.
We replace display id of all Ashenvale Nagas mobs with this one. We have screenshot 
that show this display id used at ashenvale location.

![janvier2004-51](https://user-images.githubusercontent.com/72315006/182761771-e63e66ce-3590-43e1-82b4-ea987e0bcf56.jpg)


**Shadethicker Stone mover**
Same as vanilla display_id

**Withered Ancient**
![attachments_screenshot_OP04](https://user-images.githubusercontent.com/72315006/182761898-34660219-fa20-4eb6-9e4d-59634bd39a8c.jpg)

**Clattering crawler**
Same as vanilla, blue crab. 

**Burning Legionnaire (lesser felguard)**
It appears that Burning legionnaire doesnt exist in 1.12, instead there are Lesser felguard. Probably, this mob was renamed.
Lesser felguard model dosnt exist yet.
![Dead Burning Legionnaire](https://user-images.githubusercontent.com/72315006/182762355-99683537-419f-4920-bada-7b638f86d41c.jpg)
![Burning Legionnaire](https://user-images.githubusercontent.com/72315006/182762358-841d87e0-fd2d-4907-a8b7-4539c35f595c.jpg)

**Fel slayer**
![Dead Fel Slayer](https://user-images.githubusercontent.com/72315006/182762586-2fc6270f-09fd-46e9-ba48-1e579e297033.jpg)


**Mystlash hydra**
![Dead Hydra](https://user-images.githubusercontent.com/72315006/182763455-87feb3cc-748d-4048-a351-0642382def9f.jpg)


Notes
====

Here's a screenshot that probably show a part of Ashenvale mobs push 

![Capture d’écran_2022-08-04_06-25-04](https://user-images.githubusercontent.com/72315006/182762962-34c33bf1-2127-48f3-83ea-d9951b7a7b09.png)









