### PR TITLE
Adjust creature spell ranks for damage spells to match caster level

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7919,5 +7919,40 @@ begin not atomic
         insert into applied_updates values ('030820221');
 
     end if;
+
+    -- 05/08/2022 1
+    if (select count(*) from applied_updates where id='050820221') = 0 then
+        -- Fireball Rank 3 -> Rank 1
+        UPDATE `creature_spells` SET `spellId_1` = 133 WHERE `entry` IN (17320, 15070, 4760, 8810, 20180);
+        -- Fireball Rank 3 -> Rank 2
+        UPDATE `creature_spells` SET `spellId_1` = 143 WHERE `entry` IN (85030, 32690, 5890, 6190, 4410, 21920, 21600);
+
+        -- Fire Blast Rank 3 -> Rank 2
+        UPDATE `creature_spells` SET `spellId_1` = 2137 WHERE `entry` = 17320;
+
+        -- Frost Nova Rank 2 -> Rank 1
+        UPDATE `creature_spells` SET `spellId_1` = 122 WHERE `entry` IN (17680, 32600, 19580, 1270, 37170, 34360);
+
+        -- Frostbolt Rank 2 -> Rank 1
+        UPDATE `creature_spells` SET `spellId_1` = 116 WHERE `entry` IN (15220, 4740, 29640, 15390, 18670);
+
+        -- Lightning Bolt Rank 3 -> Rank 1
+        UPDATE `creature_spells` SET `spellId_1` = 403 WHERE `entry` IN (29530, 13970, 20120);
+        -- Lightning Bolt Rank 3 -> Rank 2
+        UPDATE `creature_spells` SET `spellId_1` = 529 WHERE `entry` IN (31180, 11660, 32730);
+
+        -- ZZOldKick Rank 1 -> Kick Rank 2
+        UPDATE `creature_spells` SET `spellId_1` = 6554 WHERE `entry` = 65540;
+
+        -- Shadow Bolt Rank 4 -> Rank 1
+        UPDATE `creature_spells` SET `spellId_1` = 686 WHERE `entry` = 20030;
+        -- Shadow Bolt Rank 4 -> Rank 2
+        UPDATE `creature_spells` SET `spellId_1` = 695 WHERE `entry` IN (31980, 58220);
+        -- Shadow Bolt Rank 4 -> Rank 3
+        UPDATE `creature_spells` SET `spellId_1` = 705 WHERE `entry` IN (32030, 113240, 19150, 37280);
+
+        insert into applied_updates values ('050820221');
+
+    end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7954,5 +7954,28 @@ begin not atomic
         insert into applied_updates values ('050820221');
 
     end if;
+
+    -- 05/08/2022 2
+    if (select count(*) from applied_updates where id='050820222') = 0 then
+        -- Fireball Rank 3 -> Rank 2
+        UPDATE `creature_spells` SET `spellId_2` = 143 WHERE `entry` IN (21910, 17260, 119170, 39910);
+        UPDATE `creature_spells` SET `spellId_3` = 143 WHERE `entry` IN (19140, 119170, 44180, 4500, 5990, 5990, 32630);
+
+        -- Lightning Bolt Rank 3 -> Rank 1
+        UPDATE `creature_spells` SET `spellId_2` = 403 WHERE `entry` IN (15440, 29630);
+        -- Lightning Bolt Rank 3 -> Rank 2
+        UPDATE `creature_spells` SET `spellId_2` = 529 WHERE `entry` IN (15440, 29630, 29650, 20210, 57850, 4560, 19110, 10650, 113190, 95230, 119130);
+
+        -- Shadow Bolt Rank 4 -> Rank 2
+        UPDATE `creature_spells` SET `spellId_2` = 695 WHERE `entry` = 11240;
+        -- Shadow Bolt Rank 4 -> Rank 3
+        UPDATE `creature_spells` SET `spellId_2` = 705 WHERE `entry` = 32040;
+
+        -- zzOLDArcane Missiles Effect -> Arcane Missiles Effect Rank 1
+        UPDATE `creature_spells` SET `spellId_2` = 7268, `spellId_3` = 7268 WHERE `entry` = 103580;
+
+        insert into applied_updates values ('050820222');
+
+    end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7923,7 +7923,7 @@ begin not atomic
     -- 05/08/2022 1
     if (select count(*) from applied_updates where id='050820221') = 0 then
         -- Fireball Rank 3 -> Rank 1
-        UPDATE `creature_spells` SET `spellId_1` = 133 WHERE `entry` IN (17320, 15070, 4760, 8810, 20180);
+        UPDATE `creature_spells` SET `spellId_1` = 133 WHERE `entry` IN (15070, 4760, 8810, 20180);
         -- Fireball Rank 3 -> Rank 2
         UPDATE `creature_spells` SET `spellId_1` = 143 WHERE `entry` IN (85030, 32690, 5890, 6190, 4410, 21920, 21600);
 


### PR DESCRIPTION
* Queried and adjusted damage spells only (Effect ID 2, only checking Effect_1).
    * Spells with other effects may still be too powerful, but the most noticeable issues should be gone.
* Not all changed spells have been tested, but characteristics such as effects, descriptions and spell names have been checked to match.
* Can provide full queries/other data if someone is interested in continuing this work for other types of creature spells.
* closes #369, closes #374.

(Disgusting) query for searching the described spells. Change the spell id in `sp.id = cs.spellid_1` to compare against other creature spell entry spells.
`[alpha_world]> select ct.entry, ct.spell_list_id, ct.name, ct.level_min, sp.SpellLevel, cs.spellid_1, cs.spellid_2, cs.spellid_3, sp.name_enus, sp.namesubtext_enus, sp.effect_1, sp.effectbasepoints_1 from creature_template as ct, creature_spells as cs, alpha_dbc.spell as sp where sp.id = cs.spellid_1 and cs.entry = ct.spell_list_id and spell_list_id != 0 and ct.level_min < 26 and ct.level_min <= sp.spellLevel and sp.effect_1 = 2 order by sp.name_enus, ct.level_min;`