### PR TITLE
Duskwood Improvements

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7988,6 +7988,12 @@ begin not atomic
         SET `display_id1`=200
         WHERE `entry`=203;
 
+        -- Town crier
+        UPDATE `creature_template`
+        SET `display_id1`=227
+        WHERE `entry`=468;
+
+
         insert into applied_updates values ('050820223');
 
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7993,6 +7993,21 @@ begin not atomic
         SET `display_id1`=227
         WHERE `entry`=468;
 
+        -- Defias night blade
+        UPDATE `creature_template`
+        SET `display_id1`=231
+        WHERE `entry`=909;
+
+        -- Defias night runner
+        UPDATE `creature_template`
+        SET `display_id1`=208
+        WHERE `entry`=215;
+
+        -- Defias enchanter
+        UPDATE `creature_template`
+        SET `display_id1`=263
+        WHERE `entry`=910;
+
 
         insert into applied_updates values ('050820223');
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7919,5 +7919,77 @@ begin not atomic
         insert into applied_updates values ('030820221');
 
     end if;
+
+    -- 04/08/2022 1
+    if (select count(*) from applied_updates where id='040820221') = 0 then
+
+        -- Barkeep Hann
+        UPDATE `creature_template`
+        SET `display_id1`=191
+        WHERE `entry`=274;
+
+        -- Commandant Althea Ebonlocke 
+        UPDATE `creature_template`
+        SET `display_id1`=224
+        WHERE `entry`=264;
+
+        -- Madame Eva
+        UPDATE `creature_template`
+        SET `display_id1`=225
+        WHERE `entry`=265;
+
+        -- Morg Gnarltree
+        UPDATE `creature_template`
+        SET `display_id1`=242
+        WHERE `entry`=226;
+
+        -- Felicia Maline (gryphon master)
+        UPDATE `creature_template`
+        SET `display_id1`=186
+        WHERE `entry`=2409;
+
+        -- Watcher Fraizer
+        UPDATE `creature_template`
+        SET `display_id1`=166
+        WHERE `entry`=2470;
+
+        -- Watcher Mocarski
+        UPDATE `creature_template`
+        SET `display_id1`=166
+        WHERE `entry`=827;
+
+        -- Nefaru (rare named worgen)
+        UPDATE `creature_template`
+        SET `display_id1`=522
+        WHERE `entry`=534;
+
+        -- Fenros (named worgen)
+        UPDATE `creature_template`
+        SET `display_id1`=736
+        WHERE `entry`=507;
+
+        -- Skeletal healer
+        UPDATE `creature_template`
+        SET `display_id1`=200
+        WHERE `entry`=787;
+
+        -- Skeletal fiend
+        UPDATE `creature_template`
+        SET `display_id1`=200
+        WHERE `entry`=531;
+
+        -- Skeletal horror
+        UPDATE `creature_template`
+        SET `display_id1`=200
+        WHERE `entry`=202;
+
+        -- Skeletal mage
+        UPDATE `creature_template`
+        SET `display_id1`=200
+        WHERE `entry`=203;
+
+        insert into applied_updates values ('040820221');
+
+    end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7958,12 +7958,12 @@ begin not atomic
         SET `display_id1`=166
         WHERE `entry`=827;
 
-        -- Nefaru (rare named worgen)
+        -- Nefaru (rare named worgen), same display as other worgen around him
         UPDATE `creature_template`
         SET `display_id1`=522
         WHERE `entry`=534;
 
-        -- Fenros (named worgen)
+        -- Fenros (named worgen), same display as other worgen around him
         UPDATE `creature_template`
         SET `display_id1`=736
         WHERE `entry`=507;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7920,8 +7920,8 @@ begin not atomic
 
     end if;
 
-    -- 04/08/2022 1
-    if (select count(*) from applied_updates where id='040820221') = 0 then
+    -- 05/08/2022 3
+    if (select count(*) from applied_updates where id='050820223') = 0 then
 
         -- Barkeep Hann
         UPDATE `creature_template`
@@ -7988,7 +7988,7 @@ begin not atomic
         SET `display_id1`=200
         WHERE `entry`=203;
 
-        insert into applied_updates values ('040820221');
+        insert into applied_updates values ('050820223');
 
     end if;
 end $

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8008,6 +8008,15 @@ begin not atomic
         SET `display_id1`=263
         WHERE `entry`=910;
 
+        -- Binder spawn, we move him a bit
+        UPDATE `spawns_creatures`
+        SET `position_x`=-10572.599609375, `position_y`=-1149.62841796875, `position_z`=26.46806526184082, `orientation`=5.387844562530518
+        WHERE `spawn_id`=400015;
+
+        -- Bartender spawn, we move him a bit
+        UPDATE `spawns_creatures`
+        SET `position_x`=-10509.090, `position_y`=-1159.387
+        WHERE `spawn_id`=4191;
 
         insert into applied_updates values ('050820223');
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -7995,17 +7995,17 @@ begin not atomic
 
         -- Defias night blade
         UPDATE `creature_template`
-        SET `display_id1`=231
+        SET `display_id1`=231, `display_id2`=0
         WHERE `entry`=909;
 
         -- Defias night runner
         UPDATE `creature_template`
-        SET `display_id1`=208
+        SET `display_id1`=208,`display_id2`=0
         WHERE `entry`=215;
 
         -- Defias enchanter
         UPDATE `creature_template`
-        SET `display_id1`=263
+        SET `display_id1`=263, `display_id2`=0
         WHERE `entry`=910;
 
         -- Binder spawn, we move him a bit


### PR DESCRIPTION
Duskwood
========

About
----

In this area, a lot of npc/mobs have a really low entry (approx 200-800).
It appears that Duskwood will be updated in 0.5.4, and lot of npc/mobs will get new models.
In 0.5.3, most of them still have very old models.

Barkeep Hann
-----
![Dancer_SS0410-03](https://user-images.githubusercontent.com/72315006/182983885-ca879012-e5cd-4654-8746-c8933d2a5a1a.jpg)

Madame Eva
-----
See target frame
![DwarfMageCastingBlizzard](https://user-images.githubusercontent.com/72315006/182983940-6e8e5f9f-9aec-4ff6-8071-68bbec3a8f28.jpg)
![225](https://user-images.githubusercontent.com/72315006/183017283-fbe57753-2018-4f99-aaa8-77fd14d93027.png)



Commandant Althea Ebonlocke 
-----
![130](https://user-images.githubusercontent.com/72315006/182983914-e4a23122-b675-4cd7-ba67-e03c569b4879.jpg)
![224](https://user-images.githubusercontent.com/72315006/182984159-9e66fd93-cdaa-44a5-99fe-dfaa04c95536.png)

Very difficult to be sure just with this screenshot, here's more evidences

This display id seems placeholder for important female NPC, like Grand Admiral Jes Teres in SW
![unknown](https://user-images.githubusercontent.com/72315006/182984236-2d9e09da-0cc2-4855-adab-5554e56ecbba.png)

We can see here that Madame Eva and Commandant Althea have linked display_id and entry which reinforce this assumption.
![Capture d’écran_2022-08-05_01-38-49](https://user-images.githubusercontent.com/72315006/182984326-f39e95d8-12ad-439b-a66e-5d826284d14d.png)
![Capture d’écran_2022-08-05_01-41-30](https://user-images.githubusercontent.com/72315006/182984332-b0936603-8941-413c-9aa1-b7a7f824889e.png)


Morg Gnarltree
----

On same screenshot
![130](https://user-images.githubusercontent.com/72315006/182984529-1d306122-1b0b-4fb3-91ff-7c85b73c988f.jpg)

We can barely see a NPC, he seems to wear a black belt and black wrist. His entry and display_id make sens : Entry 226, display_id : 242.

![242](https://user-images.githubusercontent.com/72315006/182984602-594fe7f8-8dae-42c1-9ace-523b046bf302.png)

Felicia Maline (gryphon master)
----

See target frame
![Dancer_SS0409-02](https://user-images.githubusercontent.com/72315006/182984835-e125161a-2961-41b8-b634-e565c662995a.jpg)
![186](https://user-images.githubusercontent.com/72315006/183017345-5ba67ad8-9260-43b9-aa67-f96c2d248e86.png)

Watchers
------

It appears that 166 display_id is placeholder for watchers
![Capture d’écran_2022-08-05_00-43-59](https://user-images.githubusercontent.com/72315006/182984935-bf163e08-f18c-4a83-9f1f-8489cdbe1ed2.png)

Some already has unique display_id in 0.5.3, but some dont. Here's screenshot from models get updated
![Capture d’écran_2022-08-05_02-36-21](https://user-images.githubusercontent.com/72315006/182985039-a7628008-8d14-47fa-ad2d-ad982e44e30e.png)

I replaced watchers who miss display_id with 166.

Town Crier
-----

As Watchers, there are unused crier in database, placeholder seems to be 227 display_id.  it's also possible these unused crier was spawned in 0.5.3.
![crier](https://user-images.githubusercontent.com/72315006/183007210-5b69b9a8-8a05-4eb8-b59d-20bef7250d32.png)

I replaced town crier who miss display_id with 227.


Nefaru & Fenros
-------

There are 2 named worgen with no display id, we replace display_id with worgen models around.

Skeletal
------

There is only one Skelet model for now (except color variation), the "only bones" model doesnt exist yet. All skeletal mobs should use 200 display_id, as Skeletal warrior. Here's a screenshot of this model in Duskwood
![004](https://user-images.githubusercontent.com/72315006/182985331-71fc298c-da30-479d-815f-9ce8eb95363e.jpg)

Defias
----
(JUST SOME INFOS, NO MODIFICATION DONE FOR DEFIAS)

Defias mobs probably should use old defias models, but we dont have any infos about colors. We will see at the end a sample of Duskwood mobs push where we see some defias. Should we update it or wait for more evidences ?
![081 - m9rgrec](https://user-images.githubusercontent.com/72315006/182989329-29559ed6-35ed-400a-9ea6-60a2902e6b79.jpg)


Notes
-------

Here's a screenshot probably showing a part of Duskwood push (except some)
![Capture d’écran_2022-08-05_01-12-45](https://user-images.githubusercontent.com/72315006/182985840-b3b0ac48-61c5-42d5-95c8-d21d8742c54c.png)

We can see here : Barkeep, Madame Eva, female commandant, Worgen, skeletal, gryphon master, defias, town crier and probably more.
Missing display id still unresolved will probably use models we can see on this or near this range.


Spawn
-----

Some NPC location could be improved, for example : binder, or bardenter. Screenshots show a bit different exact location for some NPC. Should we update it ?










