### PR TITLE
Shapeshift and pet fixes

### DIFF
--- a/game/world/managers/objects/spell/AppliedAura.py
+++ b/game/world/managers/objects/spell/AppliedAura.py
@@ -58,7 +58,7 @@ class AppliedAura:
         return self.spell_effect.applied_aura_duration
 
     def get_effect_points(self):
-        return self.spell_effect.get_effect_points(self.source_spell.caster_effective_level) * self.applied_stacks
+        return self.spell_effect.get_effect_points() * self.applied_stacks
 
     def is_past_next_period(self) -> bool:
         return self.spell_effect.is_past_next_period()

--- a/game/world/managers/objects/spell/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/AuraEffectHandler.py
@@ -41,6 +41,7 @@ class AuraEffectHandler:
         model_info = ExtendedSpellData.ShapeshiftInfo.get_form_model_info(form, faction)
 
         # Shapeshifting can affect current power type and stats (druid shapeshift powers/attack values).
+        effect_target.spell_manager.update_shapeshift_passives()
         effect_target.update_power_type()
         effect_target.stat_manager.apply_bonuses()
 

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -446,7 +446,7 @@ class CastingSpell:
     def get_conjured_items(self):
         conjured_items = []
         for effect in self.get_effects():
-            item_count = abs(effect.get_effect_points(self.caster_effective_level))
+            item_count = abs(effect.get_effect_points())
             conjured_items.append([effect.item_type, item_count])
         return tuple(conjured_items)
 

--- a/game/world/managers/objects/spell/SpellEffect.py
+++ b/game/world/managers/objects/spell/SpellEffect.py
@@ -92,9 +92,9 @@ class SpellEffect:
     def is_periodic(self):
         return self.aura_period != 0
 
-    def get_effect_points(self, effective_level) -> int:
+    def get_effect_points(self) -> int:
         rolled_points = random.randint(1, self.die_sides + self.dice_per_level) if self.die_sides != 0 else 0
-        return self.base_points + int(self.real_points_per_level * effective_level) + rolled_points
+        return self.base_points + int(self.real_points_per_level * self.caster_effective_level) + rolled_points
 
     def get_effect_simple_points(self) -> int:
         return self.base_points + self.base_dice

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -36,7 +36,7 @@ class SpellEffectHandler:
         if not target.object_type_mask & ObjectTypeFlags.TYPE_UNIT:
             return
 
-        damage = effect.get_effect_points(casting_spell.caster_effective_level)
+        damage = effect.get_effect_points()
         caster.apply_spell_damage(target, damage, casting_spell)
 
     @staticmethod
@@ -44,7 +44,7 @@ class SpellEffectHandler:
         if not target.object_type_mask & ObjectTypeFlags.TYPE_UNIT:
             return
 
-        healing = effect.get_effect_points(casting_spell.caster_effective_level)
+        healing = effect.get_effect_points()
         caster.apply_spell_healing(target, healing, casting_spell)
 
     @staticmethod
@@ -71,7 +71,7 @@ class SpellEffectHandler:
                                                             target,
                                                             apply_bonuses=False)  # Bonuses are applied on spell damage.
 
-        damage = weapon_damage + effect.get_effect_points(casting_spell.caster_effective_level)
+        damage = weapon_damage + effect.get_effect_points()
         caster.apply_spell_damage(target, damage, casting_spell)
 
     @staticmethod
@@ -87,7 +87,7 @@ class SpellEffectHandler:
                                                             target,
                                                             apply_bonuses=False)  # Bonuses are applied on spell damage.
 
-        damage_bonus = effect.get_effect_points(casting_spell.caster_effective_level)
+        damage_bonus = effect.get_effect_points()
 
         # Overpower also uses combo points, but shouldn't scale.
         if caster.get_type_id() == ObjectTypeIds.ID_PLAYER and not casting_spell.is_overpower() and \
@@ -101,7 +101,7 @@ class SpellEffectHandler:
         if not caster.object_type_mask & ObjectTypeFlags.TYPE_UNIT:
             return
 
-        caster.add_combo_points_on_target(target, effect.get_effect_points(casting_spell.caster_effective_level))
+        caster.add_combo_points_on_target(target, effect.get_effect_points())
 
     @staticmethod
     def handle_aura_application(casting_spell, effect, caster, target):
@@ -152,7 +152,7 @@ class SpellEffectHandler:
         if power_type != target.power_type:
             return
 
-        amount = effect.get_effect_points(casting_spell.caster_effective_level)
+        amount = effect.get_effect_points()
         target.receive_power(amount, power_type)
 
     @staticmethod
@@ -193,7 +193,7 @@ class SpellEffectHandler:
             target.inventory.send_equip_error(InventoryError.BAG_UNKNOWN_ITEM)
             return
 
-        amount = effect.get_effect_points(casting_spell.caster_effective_level)
+        amount = effect.get_effect_points()
         can_store_item = target.inventory.can_store_item(item_template, amount)
         if can_store_item != InventoryError.BAG_OK:
             target.inventory.send_equip_error(can_store_item)

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -935,6 +935,15 @@ class SpellManager:
                 self.send_cast_result(casting_spell.spell_entry.ID, error)
                 return False
 
+            # Taming level restriction.
+            tame_effect = casting_spell.get_effect_by_type(SpellEffects.SPELL_EFFECT_TAME_CREATURE)
+            if tame_effect:
+                max_tame_level = tame_effect.get_effect_points()
+                if validation_target.level > max_tame_level:
+                    self.send_cast_result(casting_spell.spell_entry.ID,
+                                          SpellCheckCastResult.SPELL_FAILED_LEVEL_REQUIREMENT)
+                    return False
+
         # Pickpocketing target validity check.
         if casting_spell.is_pickpocket_spell() and not validation_target.pickpocket_loot_manager:
             self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_TARGET_NO_POCKETS)

--- a/game/world/managers/objects/units/PetManager.py
+++ b/game/world/managers/objects/units/PetManager.py
@@ -9,6 +9,7 @@ from game.world.managers.objects.ai.AIFactory import AIFactory
 from game.world.managers.objects.ai.PetAI import PetAI
 from game.world.managers.objects.units.creature.CreatureManager import CreatureManager
 from network.packet.PacketWriter import PacketWriter
+from utils import Formulas
 from utils.constants import CustomCodes
 from utils.constants.OpCodes import OpCode
 from utils.constants.PetCodes import PetActionBarIndex, PetCommandState
@@ -18,16 +19,51 @@ from utils.constants.UpdateFields import UnitFields
 
 
 class PetData:
-    def __init__(self, name: str, template: CreatureTemplate, owner_guid, permanent: bool):
+    def __init__(self, name: str, template: CreatureTemplate, owner_guid,
+                 level: int, experience: int, permanent: bool):
         self.name = name
         self.creature_template = template
         self.owner_guid = owner_guid
         self.permanent = permanent
 
+        self._level = level
+        self._experience = experience
+        self.next_level_xp = PetData._get_xp_to_next_level_for(self._level)
+
         self.react_state = 1
         self.command_state = 1
 
         self.spells = self._get_default_spells()
+
+    def add_experience(self, xp_amount: int):
+        if self._experience + xp_amount < self.next_level_xp:  # Not enough xp to level up.
+            self._experience += xp_amount
+            return 0
+
+        # Level up.
+        xp_to_level = self.next_level_xp - self._experience
+        level_amount = 0
+        # Do the actual XP conversion into level(s).
+        while xp_amount >= xp_to_level:
+            level_amount += 1
+            xp_amount -= xp_to_level
+            xp_to_level = PetData._get_xp_to_next_level_for(self._level + level_amount)
+
+        self._experience = xp_amount  # Set the remaining amount XP as current.
+        self._level += level_amount
+        self.next_level_xp = PetData._get_xp_to_next_level_for(self._level + level_amount)
+
+        return level_amount
+
+    def get_experience(self):
+        return self._experience
+
+    def get_level(self):
+        return self._level
+
+    @staticmethod
+    def _get_xp_to_next_level_for(level: int) -> int:
+        return int(Formulas.PlayerFormulas.xp_to_level(level) / 4)
 
     def _get_default_spells(self) -> list[int]:
         creature_family = self.creature_template.beast_family
@@ -83,7 +119,7 @@ class PetManager:
 
         self._tame_creature(creature)
         creature.leave_combat(force=True)
-        index = self.add_pet(creature.creature_template, lifetime_sec)
+        index = self.add_pet(creature.creature_template, creature.level, lifetime_sec)
         self._set_active_pet(index, creature)
 
     def _set_active_pet(self, pet_index: int, creature: CreatureManager):
@@ -95,10 +131,11 @@ class PetManager:
         self.active_pet = ActivePet(pet_index, creature)
         self._send_pet_spell_info()
 
-    def add_pet(self, creature_template: CreatureTemplate, lifetime_sec=-1) -> int:
+    def add_pet(self, creature_template: CreatureTemplate, level: int, lifetime_sec=-1) -> int:
         # TODO: default name by beast_family - resolve id reference.
 
-        pet = PetData(creature_template.name, creature_template, self.owner.guid, permanent=lifetime_sec == -1)
+        pet = PetData(creature_template.name, creature_template, self.owner.guid, level,
+                      0, permanent=lifetime_sec == -1)
         self.pets.append(pet)
         return len(self.pets) - 1
 
@@ -196,6 +233,21 @@ class PetManager:
 
         else:
             self.get_active_pet_info().react_state = action_id
+
+    def add_pet_experience(self, experience: int):
+        active_pet_info = self.get_active_pet_info()
+        if not active_pet_info or self.owner.level <= active_pet_info.get_level():
+            return
+
+        level_gain = active_pet_info.add_experience(experience)
+        pet_creature = self.active_pet.creature
+        pet_creature.set_uint32(UnitFields.UNIT_FIELD_PETEXPERIENCE, active_pet_info.get_experience())
+        if not level_gain:
+            return
+
+        pet_creature.level += level_gain
+        pet_creature.set_uint32(UnitFields.UNIT_FIELD_LEVEL, pet_creature.level)
+        pet_creature.set_uint32(UnitFields.UNIT_FIELD_PETNEXTLEVELEXP, active_pet_info.next_level_xp)
 
     def get_active_pet_command_state(self):
         pet_info = self.get_active_pet_info()

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -1092,6 +1092,11 @@ class UnitManager(ObjectManager):
     def has_form(self, shapeshift_form):
         return self.shapeshift_form == shapeshift_form
 
+    def form_matches_mask(self, shapeshift_mask):
+        if not self.shapeshift_form:
+            return False
+        return (1 << (self.shapeshift_form - 1)) & shapeshift_mask
+
     def is_in_feral_form(self):
         return self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BEAR) or self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_CAT)
 

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -897,6 +897,10 @@ class PlayerManager(UnitManager):
             data += amount_bytes
             self.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_LOG_XPGAIN, data))
 
+        # Reward kill experience to pet.
+        if victim:
+            self.pet_manager.add_pet_experience(total_amount)
+
         if self.xp + total_amount >= self.next_level_xp:  # Level up!
             xp_to_level = self.next_level_xp - self.xp
             level_amount = 0


### PR DESCRIPTION
* Apply shapeshift-restricted passives on shapeshift change. Closes #385 
    * Shapeshift passives aren't linked in the database. It's likely that they were taught with the forms via a quest. 
    * Bear form passive is taught by "Strength of the Bear" (1938), Cat Form passive by "Feline Quickness" (3031).
* Add level restriction to pet taming.
* Implement tamed pet experience gain.