### PR TITLE
Pet level handling improvements

### DIFF
--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -442,6 +442,9 @@ class SpellEffectHandler:
 
         caster.pet_manager.summon_pet(effect.misc_value)
 
+        # Match summoner level for now. TODO This shouldn't be the case for hunter pets and displays as level up.
+        caster.pet_manager.set_active_pet_level(caster.level)
+
     @staticmethod
     def handle_summon_wild(casting_spell, effect, caster, target):
         creature_entry = effect.misc_value

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -442,9 +442,6 @@ class SpellEffectHandler:
 
         caster.pet_manager.summon_pet(effect.misc_value)
 
-        # Match summoner level for now. TODO This shouldn't be the case for hunter pets and displays as level up.
-        caster.pet_manager.set_active_pet_level(caster.level)
-
     @staticmethod
     def handle_summon_wild(casting_spell, effect, caster, target):
         creature_entry = effect.misc_value

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -899,7 +899,7 @@ class PlayerManager(UnitManager):
 
         # Reward kill experience to pet.
         if victim:
-            self.pet_manager.add_pet_experience(total_amount)
+            self.pet_manager.add_active_pet_experience(total_amount)
 
         if self.xp + total_amount >= self.next_level_xp:  # Level up!
             xp_to_level = self.next_level_xp - self.xp


### PR DESCRIPTION
* Restrict and update pet spells by their current level. Closes #397.
    * This is temporary behavior; pets should be taught the spells instead.
* Match summoned warlock pet level to the summoner's level. 
* Keep hunter pet level the same on tame and resummon.
    * This doesn't persist through relogs/restarts (#281).
* Add TODOs in PetManager on some existing issues.