### PR TITLE
Darkshore improvements

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8313,5 +8313,89 @@ begin not atomic
 
         insert into applied_updates values ('060820223');
     end if;
+
+    -- 07/08/2022 1
+    if (select count(*) from applied_updates where id='070820221') = 0 then
+
+        -- DARKSHORE
+
+        -- Moonstalker
+        UPDATE `creature_template`
+        SET `display_id1`=1043
+        WHERE `entry`=2069;
+
+        -- Moonstalker runt
+        UPDATE `creature_template`
+        SET `display_id1`=1008
+        WHERE `entry`=2070;
+
+        -- Moonstalker sire
+        UPDATE `creature_template`
+        SET `display_id1`=1055
+        WHERE `entry`=2237;
+
+        -- Blackwood totemic
+        UPDATE `creature_template`
+        SET `display_id1`=1011
+        WHERE `entry`=2169;
+
+        -- Blackwood ursa
+        UPDATE `creature_template`
+        SET `display_id1`=1011
+        WHERE `entry`=2170;
+
+        -- Blackwood shaman
+        UPDATE `creature_template`
+        SET `display_id1`=1011
+        WHERE `entry`=2171;
+
+        -- Blackwood windtalker
+        UPDATE `creature_template`
+        SET `display_id1`=1011
+        WHERE `entry`=2324;
+
+        -- Stormscale Sorceress
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=2182;
+
+        -- Stormscale Warrior
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=2183;
+
+        -- Encrusted Tide Crawler
+        UPDATE `creature_template`
+        SET `display_id1`=999
+        WHERE `entry`=2233;
+
+        -- Rabid Thistle bear
+        UPDATE `creature_template`
+        SET `display_id1`=1006
+        WHERE `entry`=2164;
+
+        -- Licillin, named imp
+        UPDATE `creature_template`
+        SET `display_id1`=1015
+        WHERE `entry`=2191;
+
+        -- Cracked Golem
+        UPDATE `creature_template`
+        SET `display_id1`=975
+        WHERE `entry`=2156;
+
+        -- Writhing Highborne
+        UPDATE `creature_template`
+        SET `display_id1`=146
+        WHERE `entry`=2177;
+
+        -- Wailing Highborne
+        UPDATE `creature_template`
+        SET `display_id1`=984
+        WHERE `entry`=2178;
+
+        insert into applied_updates values ('070820221');
+
+    end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8354,6 +8354,11 @@ begin not atomic
         SET `display_id1`=1011
         WHERE `entry`=2324;
 
+        -- Carnivous the breaker, named blackwood
+        UPDATE `creature_template`
+        SET `display_id1`=1012
+        WHERE `entry`=2186;
+
         -- Stormscale Sorceress
         UPDATE `creature_template`
         SET `display_id1`=4036

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8376,7 +8376,7 @@ begin not atomic
 
         -- Licillin, named imp
         UPDATE `creature_template`
-        SET `display_id1`=1015
+        SET `display_id1`=1017
         WHERE `entry`=2191;
 
         -- Cracked Golem


### PR DESCRIPTION
Darkshore
======

About
------

Here's a screenshot of linked display_id from Darkshore, this means that most of the models we want to find are probably close to this range.
![range](https://user-images.githubusercontent.com/72315006/183273385-ea5193fa-d90f-4a29-84c0-b54aa51b92e2.png)

Moonstalkers
------
![images_2254](https://user-images.githubusercontent.com/72315006/183273402-8a1ff5dc-213f-4a4f-aa8c-7daa9d9d1d15.jpg)
![images_7448](https://user-images.githubusercontent.com/72315006/183273456-384e827b-adbb-4f69-a513-65d0da9b7bed.jpg)
![world-of-warcraft-20040827051904772](https://user-images.githubusercontent.com/72315006/183273458-532db997-fefe-4c1c-9ba6-b2cded5047bf.jpg)

We retrieve them close to display_id range
![tiger](https://user-images.githubusercontent.com/72315006/183273475-725178aa-66d5-46ec-8ad4-677ee1b5b7a4.png)

We can see different scale for each models
![tigerscale](https://user-images.githubusercontent.com/72315006/183273483-27835334-5f3b-44dd-a1b9-2bea28303ad1.png)

So we replace display_id taking into account the level range for the scale.

Bears
----
![images_2336](https://user-images.githubusercontent.com/72315006/183273546-3d4f9af5-d740-4ca0-b7b4-9c67cf2e8f10.jpg)

There are 3 types of bears. We retrieve them close to display_id range
![bear](https://user-images.githubusercontent.com/72315006/183273569-4c493fe9-b847-4014-88a8-7906040609c9.png)

We can see different scale for each models
![bearscale](https://user-images.githubusercontent.com/72315006/183273579-13e4e7b2-79b5-4204-8a7a-d181edee47e8.png)

So we replace display_id taking into account the level range for the scale.

Blackwood
-----
![Cyclone](https://user-images.githubusercontent.com/72315006/183273600-a4fe1509-3239-4352-b7ab-01442924275b.jpg)
![images_7302](https://user-images.githubusercontent.com/72315006/183273605-4fc90640-a5c9-4457-be54-f0eff0313036.jpg)

There 3 models available, we retrieve them close to display_id range
![blackwood](https://user-images.githubusercontent.com/72315006/183273623-5f055eae-6b86-4463-9f0b-2c0d859019b9.png)

The last model has 1.5 scale, probably for a named.
![bl](https://user-images.githubusercontent.com/72315006/183278183-4ecf845c-01bb-485f-9df3-ced59571c1fb.png)



Basically, Bloodwood Pathfinder is the only use brown model, all others should use black one.

Later,  blizzard will replace ursa/shaman models with another black one, and windtalker will become blue.
That's why except Pathfinder, All bloodwolf missing their display_id.

I used display_id 1011 for all Bloodwolf, except pathfinder who dont need any modification. 

Carnivous the Breaker, named blackwood
-----

As we se above, display_id 1012 fit for a named.

Stormscale
-----
![images_4332](https://user-images.githubusercontent.com/72315006/183273818-445c8736-22f8-453c-8c43-3846d8e640ea.jpg)

Since there is only one naga model and no female version. All stormscale mobs should use 4036 display_id

I replace Stormscale Warrior and Sorceress with display_id 4036

Encrusted Tide Crawler
-----
![world-of-warcraft-20040827051906382](https://user-images.githubusercontent.com/72315006/183273892-0852fc05-c94c-4f16-b3ae-b4c3f930f3af.jpg)

We dont have any screenshot of it, but here's some evidences

All crabs that are close to display_id range
![cr2](https://user-images.githubusercontent.com/72315006/183273916-aa877f21-0a67-467c-9b2f-ec4fe880597e.png)
![crab1](https://user-images.githubusercontent.com/72315006/183273921-ec028d18-4d29-4a0a-bbbb-af0946efa39c.png)

All were used in darkshore except one totally unused : display_id 999

So i used display_id 999 for Encruded Tide Crawler.

Lucillin (named imp)
-----

We dont have any screenshot of it, but here's some evidences

All imp close to display_id range
![lucillin](https://user-images.githubusercontent.com/72315006/183273974-4b754472-99e6-4150-82c4-025b46e3c959.png)

1015 is used for mobs around him.
1016 & 1017 are unused

![lucillinscale](https://user-images.githubusercontent.com/72315006/183273994-c391f649-8526-49c7-a289-8b0f3cd5fabe.png)

1017 has 1.2 scale, that's make sense for a named.

I used display_id 1017 for Lucillin

Cracked Golem
----

There is only one Golem close to display_id range

![Capture d’écran_2022-08-07_05-37-06](https://user-images.githubusercontent.com/72315006/183274048-c147a69d-e4cb-4ac9-9f17-27288c1a2c19.png)

Blizzard will replace it later with another color variation (not part of 0.5.3), that's why he miss his display_id
![cracked](https://user-images.githubusercontent.com/72315006/183274110-65078e33-fc7d-40e5-afc2-9b6ff8db72cd.jpeg)

I used display_id 975 for cracked golem.

Writhing Highborne
-----
![Cycl2one](https://user-images.githubusercontent.com/72315006/183274130-d8ba3c37-9f48-4924-a8f8-186eb174c14a.jpg)

In 0.5.3, this mob probably dont use this model yet. There are 2 similar display_id in 0.5.3 set for this model :  146 (we can see it in duskwood) & 3942, so very far from darkshore range. Model we see on screenshot is probably the new one.

We can see 3 banshee models close to range
![W1](https://user-images.githubusercontent.com/72315006/183274196-26d7c12a-a847-4875-81b6-b5a0fa4464f3.png)
![w2](https://user-images.githubusercontent.com/72315006/183274198-aae065ac-1c60-4c3d-835e-bd208bf08700.png)

Probably, all three Highborne mobs should use banshee models in 0.5.3, but i used display_id 146 because of screenshot evidences.

Wailing Highborne
-----

Vanilla use this mob (not part of 0.5.3)
![13878](https://user-images.githubusercontent.com/72315006/183274256-9a09e4e8-0b3d-4308-a20f-e17c8fb945d6.jpg)

So for now, she should use default banshee model. I replace display_id with unused 984.







