### PR TITLE
#394

### DIFF
--- a/game/world/WorldManager.py
+++ b/game/world/WorldManager.py
@@ -79,7 +79,9 @@ class WorldServerSessionHandler:
         while self.keep_alive:
             try:
                 data = self.outgoing_pending.get(block=True, timeout=None)
-                if data:  # Can be None if we shutdown the thread.
+                # We've been blocking, by now keep_alive might be false.
+                # data can be None if we shutdown the thread.
+                if data and self.keep_alive:
                     self.request.sendall(data)
             except OSError:
                 self.disconnect()
@@ -88,7 +90,8 @@ class WorldServerSessionHandler:
         try:
             while self.keep_alive:
                 reader = self.incoming_pending.get(block=True, timeout=None)
-                if reader:  # Can be None if we shutdown the thread.
+                # We've been blocking, by now keep_alive might be false.
+                if reader and self.keep_alive:  # Can be None if we shutdown the thread.
                     if reader.opcode:
                         handler, found = Definitions.get_handler_from_packet(self, reader.opcode)
                         if handler:

--- a/game/world/WorldManager.py
+++ b/game/world/WorldManager.py
@@ -119,8 +119,10 @@ class WorldServerSessionHandler:
                 else:
                     break
         except:
-            self.disconnect()
             Logger.error(traceback.format_exc())
+
+        # End this session.
+        self.disconnect()
 
     @staticmethod
     def opcode_requires_player(opcode):

--- a/game/world/WorldManager.py
+++ b/game/world/WorldManager.py
@@ -117,7 +117,7 @@ class WorldServerSessionHandler:
         self.keep_alive = False
 
         try:
-            if self.player_mgr:
+            if self.player_mgr and self.player_mgr.online:
                 self.player_mgr.logout()
         except AttributeError:
             pass

--- a/game/world/managers/objects/item/ItemManager.py
+++ b/game/world/managers/objects/item/ItemManager.py
@@ -106,13 +106,15 @@ class ItemManager(ObjectManager):
 
     def is_melee_weapon(self):
         return self.item_template.inventory_type == InventoryTypes.WEAPON or \
+               self.item_template.inventory_type == InventoryTypes.WEAPONMAINHAND or \
                self.item_template.inventory_type == InventoryTypes.WEAPONOFFHAND or \
                self.item_template.inventory_type == InventoryTypes.TWOHANDEDWEAPON
 
     def is_ranged_weapon(self):
         return self.item_template.inventory_type == InventoryTypes.RANGED or \
-               self.item_template.inventory_type == InventoryTypes.RANGEDRIGHT
-
+               self.item_template.inventory_type == InventoryTypes.RANGEDRIGHT or \ 
+               self.item_template.inventory_type == InventoryTypes.THROWN
+               
     def is_equipped(self):
         return self.current_slot < InventorySlots.SLOT_BAG1 and \
             self.item_instance.bag == InventorySlots.SLOT_INBACKPACK.value

--- a/game/world/managers/objects/item/ItemManager.py
+++ b/game/world/managers/objects/item/ItemManager.py
@@ -104,17 +104,6 @@ class ItemManager(ObjectManager):
             return self.item_template.inventory_type == InventoryTypes.BAG
         return False
 
-    def is_melee_weapon(self):
-        return self.item_template.inventory_type == InventoryTypes.WEAPON or \
-               self.item_template.inventory_type == InventoryTypes.WEAPONMAINHAND or \
-               self.item_template.inventory_type == InventoryTypes.WEAPONOFFHAND or \
-               self.item_template.inventory_type == InventoryTypes.TWOHANDEDWEAPON
-
-    def is_ranged_weapon(self):
-        return self.item_template.inventory_type == InventoryTypes.RANGED or \
-               self.item_template.inventory_type == InventoryTypes.RANGEDRIGHT or \ 
-               self.item_template.inventory_type == InventoryTypes.THROWN
-               
     def is_equipped(self):
         return self.current_slot < InventorySlots.SLOT_BAG1 and \
             self.item_instance.bag == InventorySlots.SLOT_INBACKPACK.value

--- a/game/world/managers/objects/item/ItemManager.py
+++ b/game/world/managers/objects/item/ItemManager.py
@@ -104,6 +104,15 @@ class ItemManager(ObjectManager):
             return self.item_template.inventory_type == InventoryTypes.BAG
         return False
 
+    def is_melee_weapon(self):
+        return self.item_template.inventory_type == InventoryTypes.WEAPON or \
+               self.item_template.inventory_type == InventoryTypes.WEAPONOFFHAND or \
+               self.item_template.inventory_type == InventoryTypes.TWOHANDEDWEAPON
+
+    def is_ranged_weapon(self):
+        return self.item_template.inventory_type == InventoryTypes.RANGED or \
+               self.item_template.inventory_type == InventoryTypes.RANGEDRIGHT
+
     def is_equipped(self):
         return self.current_slot < InventorySlots.SLOT_BAG1 and \
             self.item_instance.bag == InventorySlots.SLOT_INBACKPACK.value

--- a/game/world/managers/objects/spell/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/AuraEffectHandler.py
@@ -185,6 +185,16 @@ class AuraEffectHandler:
             effect_target.mirror_timers_manager.set_water_breathing(False)
 
     @staticmethod
+    def handle_mod_disarm(aura, effect_target, remove):
+        if not remove:
+            effect_target.unit_flags |= UnitFlags.UNIT_FLAG_DISARMED
+        else:
+            effect_target.unit_flags &= ~UnitFlags.UNIT_FLAG_DISARMED
+
+        effect_target.set_uint32(UnitFields.UNIT_FIELD_FLAGS, effect_target.unit_flags)
+        effect_target.stat_manager.apply_bonuses()
+
+    @staticmethod
     def handle_mod_stalked(aura, effect_target, remove):
         dyn_flags = effect_target.get_uint32(UnitFields.UNIT_DYNAMIC_FLAGS)
         if not remove:
@@ -525,6 +535,7 @@ AURA_EFFECTS = {
     AuraTypes.SPELL_AURA_MOD_CHARM: AuraEffectHandler.handle_mod_charm,
     AuraTypes.SPELL_AURA_MOD_STALKED: AuraEffectHandler.handle_mod_stalked,
     AuraTypes.SPELL_AURA_WATER_BREATHING: AuraEffectHandler.handle_water_breathing,
+    AuraTypes.SPELL_AURA_MOD_DISARM: AuraEffectHandler.handle_mod_disarm,
 
     # Stat modifiers.
     AuraTypes.SPELL_AURA_MOD_RESISTANCE: AuraEffectHandler.handle_mod_resistance,

--- a/game/world/managers/objects/units/creature/ThreatManager.py
+++ b/game/world/managers/objects/units/creature/ThreatManager.py
@@ -73,7 +73,11 @@ class ThreatManager:
                 elif attacking_target == AttackingTarget.ATTACKING_TARGET_RANDOM:
                     return random.choice(relevant_holders).unit
                 elif attacking_target == AttackingTarget.ATTACKING_TARGET_RANDOMNOTTOP:
-                    return random.choice(relevant_holders[:-2]).unit if len(relevant_holders) > 1 else None
+                    # Only TOP available, return None.
+                    if len(relevant_holders) == 1:
+                        return None
+                    # Random, not top.
+                    return random.choice(relevant_holders[:-1]).unit
                 # Farthest or Nearest targets.
                 else:
                     surrounding_units = MapManager.get_surrounding_units(self.owner, include_players=True)

--- a/game/world/managers/objects/units/player/EnchantmentManager.py
+++ b/game/world/managers/objects/units/player/EnchantmentManager.py
@@ -16,8 +16,8 @@ MAX_ENCHANTMENTS = 5
 class EnchantmentManager(object):
     def __init__(self, unit_mgr):
         self.unit_mgr = unit_mgr
-        # enchantment id: (is_weapon, spell id, proc chance).
-        self._applied_proc_enchants: Dict[int, Tuple[bool, int, int]] = {}
+        # enchantment id: (item_slot, spell id, proc chance).
+        self._applied_proc_enchants: Dict[int, Tuple[int, int, int]] = {}
 
     # Load and apply enchantments from item_instance.
     def load_enchantments_for_item(self, item):
@@ -76,10 +76,11 @@ class EnchantmentManager(object):
 
     def handle_melee_attack_procs(self, damage_info):
         for proc_enchant in self._applied_proc_enchants.values():
-            is_weapon, proc_spell_id, proc_chance = proc_enchant
+            item_slot, proc_spell_id, proc_chance = proc_enchant
 
             # Skip weapon procs if disarmed.
-            if is_weapon and self.unit_mgr.unit_flags & UnitFlags.UNIT_FLAG_DISARMED:
+            is_main_hand = item_slot == InventorySlots.SLOT_MAINHAND
+            if is_main_hand and self.unit_mgr.unit_flags & UnitFlags.UNIT_FLAG_DISARMED:
                 continue
 
             if not self.unit_mgr.stat_manager.roll_proc_chance(proc_chance):
@@ -128,8 +129,7 @@ class EnchantmentManager(object):
             if not effect_spell_value or not proc_chance:
                 continue
 
-            is_weapon = item.is_melee_weapon() or item.is_ranged_weapon()
-            self._applied_proc_enchants[enchantment.entry] = (is_weapon, effect_spell_value, proc_chance)
+            self._applied_proc_enchants[enchantment.entry] = (item.current_slot, effect_spell_value, proc_chance)
 
     @staticmethod
     def get_effect_value_for_enchantment_type(item, enchantment_type):

--- a/game/world/managers/objects/units/player/EnchantmentManager.py
+++ b/game/world/managers/objects/units/player/EnchantmentManager.py
@@ -6,6 +6,7 @@ from network.packet.PacketWriter import PacketWriter
 from utils.constants.ItemCodes import InventorySlots, ItemEnchantmentType, EnchantmentSlots
 from utils.constants.OpCodes import OpCode
 from utils.constants.SpellCodes import SpellTargetMask
+from utils.constants.UnitCodes import UnitFlags
 from utils.constants.UpdateFields import ItemFields
 
 
@@ -15,7 +16,8 @@ MAX_ENCHANTMENTS = 5
 class EnchantmentManager(object):
     def __init__(self, unit_mgr):
         self.unit_mgr = unit_mgr
-        self._applied_proc_enchants: Dict[int, Tuple[int, int]] = {}  # enchantment id: (spell id, proc chance).
+        # enchantment id: (is_weapon, spell id, proc chance).
+        self._applied_proc_enchants: Dict[int, Tuple[bool, int, int]] = {}
 
     # Load and apply enchantments from item_instance.
     def load_enchantments_for_item(self, item):
@@ -74,7 +76,12 @@ class EnchantmentManager(object):
 
     def handle_melee_attack_procs(self, damage_info):
         for proc_enchant in self._applied_proc_enchants.values():
-            proc_spell_id, proc_chance = proc_enchant
+            is_weapon, proc_spell_id, proc_chance = proc_enchant
+
+            # Skip weapon procs if disarmed.
+            if is_weapon and self.unit_mgr.unit_flags & UnitFlags.UNIT_FLAG_DISARMED:
+                continue
+
             if not self.unit_mgr.stat_manager.roll_proc_chance(proc_chance):
                 continue
 
@@ -120,7 +127,9 @@ class EnchantmentManager(object):
             proc_chance = enchantment.get_enchantment_effect_points_by_type(enchantment_type)
             if not effect_spell_value or not proc_chance:
                 continue
-            self._applied_proc_enchants[enchantment.entry] = (effect_spell_value, proc_chance)
+
+            is_weapon = item.is_melee_weapon() or item.is_ranged_weapon()
+            self._applied_proc_enchants[enchantment.entry] = (is_weapon, effect_spell_value, proc_chance)
 
     @staticmethod
     def get_effect_value_for_enchantment_type(item, enchantment_type):

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1659,9 +1659,14 @@ class PlayerManager(UnitManager):
         return low_guid | HighGuid.HIGHGUID_PLAYER
 
     # override
-    def get_current_weapon_for_attack_type(self, attack_type: AttackTypes)  -> Optional[ItemManager]:
+    def get_current_weapon_for_attack_type(self, attack_type: AttackTypes) -> Optional[ItemManager]:
+        # Feral form attacks don't use a weapon.
         if self.is_in_feral_form():
-            return None  # Feral form attacks don't use a weapon.
+            return None
+
+        # Handle disarmed main hand.
+        if attack_type == AttackTypes.BASE_ATTACK & self.unit_flags & UnitFlags.UNIT_FLAG_DISARMED:
+            return None
 
         if attack_type == AttackTypes.BASE_ATTACK:
             return self.inventory.get_main_hand()

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -380,6 +380,11 @@ class StatManager(object):
                         self.unit_mgr.is_in_feral_form():
                     continue
 
+                # Main hand damage when disarmed.
+                if item.current_slot == InventorySlots.SLOT_MAINHAND and \
+                        self.unit_mgr.unit_flags & UnitFlags.UNIT_FLAG_DISARMED:
+                    continue
+
                 if item.current_slot != InventorySlots.SLOT_MAINHAND and \
                     item.current_slot != InventorySlots.SLOT_OFFHAND and \
                         item.current_slot != InventorySlots.SLOT_RANGED:

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -401,23 +401,22 @@ class StatManager(object):
 
                 weapon_min_damage += weapon_enchant_bonus
                 weapon_max_damage += weapon_enchant_bonus
-
-                if not self.unit_mgr.unit_flags & UnitFlags.UNIT_FLAG_DISARMED:
-                    if item.current_slot == InventorySlots.SLOT_MAINHAND:
-                        self.item_stats[UnitStats.MAIN_HAND_DAMAGE_MIN] = weapon_min_damage
-                        self.item_stats[UnitStats.MAIN_HAND_DAMAGE_MAX] = weapon_max_damage
-                        self.item_stats[UnitStats.MAIN_HAND_DELAY] = weapon_delay
-                        # Assuming only main hand affects weapon reach.
-                        self.weapon_reach = UnitFormulas.get_reach_for_weapon(item.item_template)
-                    elif item.current_slot == InventorySlots.SLOT_OFFHAND:
-                        dual_wield_penalty = 0.5
-                        self.item_stats[UnitStats.OFF_HAND_DAMAGE_MIN] = int(weapon_min_damage * dual_wield_penalty)
-                        self.item_stats[UnitStats.OFF_HAND_DAMAGE_MAX] = int(weapon_max_damage * dual_wield_penalty)
-                        self.item_stats[UnitStats.OFF_HAND_DELAY] = weapon_delay
-                    elif item.current_slot == InventorySlots.SLOT_RANGED:
-                        self.item_stats[UnitStats.RANGED_DAMAGE_MIN] = weapon_min_damage
-                        self.item_stats[UnitStats.RANGED_DAMAGE_MAX] = weapon_max_damage
-                        self.item_stats[UnitStats.RANGED_DELAY] = weapon_delay
+                
+                if item.current_slot == InventorySlots.SLOT_MAINHAND:
+                    self.item_stats[UnitStats.MAIN_HAND_DAMAGE_MIN] = weapon_min_damage
+                    self.item_stats[UnitStats.MAIN_HAND_DAMAGE_MAX] = weapon_max_damage
+                    self.item_stats[UnitStats.MAIN_HAND_DELAY] = weapon_delay
+                    # Assuming only main hand affects weapon reach.
+                    self.weapon_reach = UnitFormulas.get_reach_for_weapon(item.item_template)
+                elif item.current_slot == InventorySlots.SLOT_OFFHAND:
+                    dual_wield_penalty = 0.5
+                    self.item_stats[UnitStats.OFF_HAND_DAMAGE_MIN] = int(weapon_min_damage * dual_wield_penalty)
+                    self.item_stats[UnitStats.OFF_HAND_DAMAGE_MAX] = int(weapon_max_damage * dual_wield_penalty)
+                    self.item_stats[UnitStats.OFF_HAND_DELAY] = weapon_delay
+                elif item.current_slot == InventorySlots.SLOT_RANGED:
+                    self.item_stats[UnitStats.RANGED_DAMAGE_MIN] = weapon_min_damage
+                    self.item_stats[UnitStats.RANGED_DAMAGE_MAX] = weapon_max_damage
+                    self.item_stats[UnitStats.RANGED_DELAY] = weapon_delay
 
     def update_max_health(self):
         total_stamina = self.get_total_stat(UnitStats.STAMINA)

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -10,7 +10,7 @@ from utils.Logger import Logger
 from utils.constants.ItemCodes import InventorySlots, InventoryStats, ItemSubClasses, ItemEnchantmentType
 from utils.constants.MiscCodes import AttackTypes, HitInfo, ObjectTypeIds
 from utils.constants.SpellCodes import SpellSchools, ShapeshiftForms
-from utils.constants.UnitCodes import PowerTypes, Classes, Races
+from utils.constants.UnitCodes import PowerTypes, Classes, Races, UnitFlags
 
 
 # Stats that are modified by aura effects and items.
@@ -392,21 +392,22 @@ class StatManager(object):
                 weapon_min_damage += weapon_enchant_bonus
                 weapon_max_damage += weapon_enchant_bonus
 
-                if item.current_slot == InventorySlots.SLOT_MAINHAND:
-                    self.item_stats[UnitStats.MAIN_HAND_DAMAGE_MIN] = weapon_min_damage
-                    self.item_stats[UnitStats.MAIN_HAND_DAMAGE_MAX] = weapon_max_damage
-                    self.item_stats[UnitStats.MAIN_HAND_DELAY] = weapon_delay
-                    # Assuming only main hand affects weapon reach.
-                    self.weapon_reach = UnitFormulas.get_reach_for_weapon(item.item_template)
-                elif item.current_slot == InventorySlots.SLOT_OFFHAND:
-                    dual_wield_penalty = 0.5
-                    self.item_stats[UnitStats.OFF_HAND_DAMAGE_MIN] = int(weapon_min_damage * dual_wield_penalty)
-                    self.item_stats[UnitStats.OFF_HAND_DAMAGE_MAX] = int(weapon_max_damage * dual_wield_penalty)
-                    self.item_stats[UnitStats.OFF_HAND_DELAY] = weapon_delay
-                elif item.current_slot == InventorySlots.SLOT_RANGED:
-                    self.item_stats[UnitStats.RANGED_DAMAGE_MIN] = weapon_min_damage
-                    self.item_stats[UnitStats.RANGED_DAMAGE_MAX] = weapon_max_damage
-                    self.item_stats[UnitStats.RANGED_DELAY] = weapon_delay
+                if not self.unit_mgr.unit_flags & UnitFlags.UNIT_FLAG_DISARMED:
+                    if item.current_slot == InventorySlots.SLOT_MAINHAND:
+                        self.item_stats[UnitStats.MAIN_HAND_DAMAGE_MIN] = weapon_min_damage
+                        self.item_stats[UnitStats.MAIN_HAND_DAMAGE_MAX] = weapon_max_damage
+                        self.item_stats[UnitStats.MAIN_HAND_DELAY] = weapon_delay
+                        # Assuming only main hand affects weapon reach.
+                        self.weapon_reach = UnitFormulas.get_reach_for_weapon(item.item_template)
+                    elif item.current_slot == InventorySlots.SLOT_OFFHAND:
+                        dual_wield_penalty = 0.5
+                        self.item_stats[UnitStats.OFF_HAND_DAMAGE_MIN] = int(weapon_min_damage * dual_wield_penalty)
+                        self.item_stats[UnitStats.OFF_HAND_DAMAGE_MAX] = int(weapon_max_damage * dual_wield_penalty)
+                        self.item_stats[UnitStats.OFF_HAND_DELAY] = weapon_delay
+                    elif item.current_slot == InventorySlots.SLOT_RANGED:
+                        self.item_stats[UnitStats.RANGED_DAMAGE_MIN] = weapon_min_damage
+                        self.item_stats[UnitStats.RANGED_DAMAGE_MAX] = weapon_max_damage
+                        self.item_stats[UnitStats.RANGED_DELAY] = weapon_delay
 
     def update_max_health(self):
         total_stamina = self.get_total_stat(UnitStats.STAMINA)

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -326,6 +326,11 @@ class StatManager(object):
         if self.unit_mgr.get_type_id() != ObjectTypeIds.ID_PLAYER:
             self.weapon_reach = self.unit_mgr.weapon_reach
             min_damage, max_damage = unpack('<2H', pack('<I', self.unit_mgr.damage))
+
+            # TODO, how to calculate unit damage when disarmed.
+            if self.unit_mgr.unit_flags & UnitFlags.UNIT_FLAG_DISARMED:
+                max_damage = min_damage
+                
             self.item_stats[UnitStats.MAIN_HAND_DAMAGE_MIN] = min_damage
             self.item_stats[UnitStats.MAIN_HAND_DAMAGE_MAX] = max_damage
             self.item_stats[UnitStats.MAIN_HAND_DELAY] = self.unit_mgr.base_attack_time

--- a/game/world/managers/objects/units/player/quest/QuestManager.py
+++ b/game/world/managers/objects/units/player/quest/QuestManager.py
@@ -18,7 +18,7 @@ from utils.constants import UnitCodes
 from utils.constants.ItemCodes import InventoryError
 from utils.constants.SpellCodes import SpellTargetMask
 from utils.constants.MiscCodes import QuestGiverStatus, QuestState, QuestFailedReasons, QuestMethod, \
-    QuestFlags, GameObjectTypes, ObjectTypeIds, HighGuid, Emotes
+    QuestFlags, GameObjectTypes, ObjectTypeIds, HighGuid
 from utils.constants.UpdateFields import PlayerFields
 
 # Terminology:

--- a/game/world/opcode_handling/handlers/HandlerValidator.py
+++ b/game/world/opcode_handling/handlers/HandlerValidator.py
@@ -1,0 +1,18 @@
+from utils.Logger import Logger
+from utils.constants.OpCodes import OpCode
+
+
+class HandlerValidator:
+
+    @staticmethod
+    def validate_session(world_session, opcode):
+        if not world_session:
+            Logger.error(f'OpCode {OpCode(opcode).name}, Session was None.')
+            return None, -1
+
+        if not world_session.player_mgr:
+            Logger.error(f'OpCode {OpCode(opcode).name}, Session: {world_session.client_address} had None PlayerMgr'
+                         f' instance. Disconnecting.')
+            return None, -1
+
+        return world_session.player_mgr, 0

--- a/game/world/opcode_handling/handlers/quest/QuestConfirmAcceptHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestConfirmAcceptHandler.py
@@ -1,6 +1,5 @@
 from struct import unpack
 from network.packet.PacketWriter import PacketWriter, OpCode
-from utils.Logger import Logger
 
 
 class QuestConfirmAcceptHandler(object):
@@ -8,11 +7,6 @@ class QuestConfirmAcceptHandler(object):
     @staticmethod
     def handle(world_session, socket, reader):
         player_mgr = world_session.player_mgr
-        # No player linked to session requester.
-        if not player_mgr:
-            Logger.warning('QuestConfirmAcceptHandler received with null player_mgr.')
-            return 0
-
         if len(reader.data) >= 4:  # Avoid handling empty quest confirm accept packet.
             quest_id = unpack('<I', reader.data[:4])[0]
             if player_mgr.quest_manager.is_quest_log_full():

--- a/game/world/opcode_handling/handlers/quest/QuestConfirmAcceptHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestConfirmAcceptHandler.py
@@ -1,4 +1,6 @@
 from struct import unpack
+
+from game.world.opcode_handling.handlers.HandlerValidator import HandlerValidator
 from network.packet.PacketWriter import PacketWriter, OpCode
 
 
@@ -6,7 +8,11 @@ class QuestConfirmAcceptHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        player_mgr = world_session.player_mgr
+        # Validate world session.
+        player_mgr, res = HandlerValidator.validate_session(world_session, reader.opcode)
+        if not player_mgr:
+            return res
+
         if len(reader.data) >= 4:  # Avoid handling empty quest confirm accept packet.
             quest_id = unpack('<I', reader.data[:4])[0]
             if player_mgr.quest_manager.is_quest_log_full():

--- a/game/world/opcode_handling/handlers/quest/QuestConfirmAcceptHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestConfirmAcceptHandler.py
@@ -1,15 +1,22 @@
 from struct import unpack
 from network.packet.PacketWriter import PacketWriter, OpCode
+from utils.Logger import Logger
 
 
 class QuestConfirmAcceptHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
+        player_mgr = world_session.player_mgr
+        # No player linked to session requester.
+        if not player_mgr:
+            Logger.warning('QuestConfirmAcceptHandler received with null player_mgr.')
+            return 0
+
         if len(reader.data) >= 4:  # Avoid handling empty quest confirm accept packet.
             quest_id = unpack('<I', reader.data[:4])[0]
-            if world_session.player_mgr.quest_manager.is_quest_log_full():
-                world_session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_QUESTLOG_FULL))
+            if player_mgr.quest_manager.is_quest_log_full():
+                player_mgr.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_QUESTLOG_FULL))
             else:
-                world_session.player_mgr.quest_manager.handle_accept_quest(quest_id, 0, shared=True)  # We have no npc guid.
+                player_mgr.quest_manager.handle_accept_quest(quest_id, 0, shared=True)  # We have no npc guid.
         return 0

--- a/game/world/opcode_handling/handlers/quest/QuestGiverAcceptQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverAcceptQuestHandler.py
@@ -1,6 +1,7 @@
 from struct import unpack
 from game.world.managers.objects.ObjectManager import ObjectManager
 from game.world.managers.maps.MapManager import MapManager
+from game.world.opcode_handling.handlers.HandlerValidator import HandlerValidator
 from network.packet.PacketWriter import PacketWriter, OpCode
 from utils.constants.MiscCodes import HighGuid
 from utils.Logger import Logger
@@ -10,7 +11,11 @@ class QuestGiverAcceptQuestHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        player_mgr = world_session.player_mgr
+        # Validate world session.
+        player_mgr, res = HandlerValidator.validate_session(world_session, reader.opcode)
+        if not player_mgr:
+            return res
+
         if len(reader.data) >= 12:  # Avoid handling empty quest giver accept quest packet.
             guid, quest_id = unpack('<QI', reader.data[:12])
             high_guid = ObjectManager.extract_high_guid(guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverAcceptQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverAcceptQuestHandler.py
@@ -10,6 +10,12 @@ class QuestGiverAcceptQuestHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
+        player_mgr = world_session.player_mgr
+        # No player linked to session requester.
+        if not player_mgr:
+            Logger.warning('QuestGiverAcceptQuestHandler received with null player_mgr.')
+            return 0
+
         if len(reader.data) >= 12:  # Avoid handling empty quest giver accept quest packet.
             guid, quest_id = unpack('<QI', reader.data[:12])
             high_guid = ObjectManager.extract_high_guid(guid)
@@ -17,20 +23,20 @@ class QuestGiverAcceptQuestHandler(object):
 
             quest_giver = None
             if high_guid == HighGuid.HIGHGUID_UNIT:
-                quest_giver = MapManager.get_surrounding_unit_by_guid(world_session.player_mgr, guid)
+                quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
             elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
-                quest_giver = MapManager.get_surrounding_gameobject_by_guid(world_session.player_mgr, guid)
+                quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
             elif high_guid == HighGuid.HIGHGUID_ITEM:
                 is_item = True
-                quest_giver = world_session.player_mgr.inventory.get_item_by_guid(guid)
+                quest_giver = player_mgr.inventory.get_item_by_guid(guid)
 
             if not quest_giver:
                 Logger.error(f'Error in CMSG_QUESTGIVER_ACCEPT_QUEST, could not find quest giver with guid of: {guid}')
                 return 0
-            elif not is_item and world_session.player_mgr.is_enemy_to(quest_giver):
+            elif not is_item and player_mgr.is_enemy_to(quest_giver):
                 return 0
-            elif world_session.player_mgr.quest_manager.is_quest_log_full():
-                world_session.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_QUESTLOG_FULL))
+            elif player_mgr.quest_manager.is_quest_log_full():
+                player_mgr.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_QUESTLOG_FULL))
             else:
-                world_session.player_mgr.quest_manager.handle_accept_quest(quest_id, guid, shared=False)
+                player_mgr.quest_manager.handle_accept_quest(quest_id, guid, shared=False)
         return 0

--- a/game/world/opcode_handling/handlers/quest/QuestGiverAcceptQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverAcceptQuestHandler.py
@@ -11,11 +11,6 @@ class QuestGiverAcceptQuestHandler(object):
     @staticmethod
     def handle(world_session, socket, reader):
         player_mgr = world_session.player_mgr
-        # No player linked to session requester.
-        if not player_mgr:
-            Logger.warning('QuestGiverAcceptQuestHandler received with null player_mgr.')
-            return 0
-
         if len(reader.data) >= 12:  # Avoid handling empty quest giver accept quest packet.
             guid, quest_id = unpack('<QI', reader.data[:12])
             high_guid = ObjectManager.extract_high_guid(guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverChooseRewardHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverChooseRewardHandler.py
@@ -10,11 +10,6 @@ class QuestGiverChooseRewardHandler(object):
     @staticmethod
     def handle(world_session, socket, reader):
         player_mgr = world_session.player_mgr
-        # No player linked to session requester.
-        if not player_mgr:
-            Logger.warning('QuestGiverChooseRewardHandler received with null player_mgr.')
-            return 0
-
         if len(reader.data) >= 16:  # Avoid handling empty quest giver choose reward packet.
             guid, quest_id, item_choice = unpack('<Q2I', reader.data[:16])
             high_guid = ObjectManager.extract_high_guid(guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverChooseRewardHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverChooseRewardHandler.py
@@ -1,5 +1,6 @@
 from struct import unpack
 from game.world.managers.objects.ObjectManager import ObjectManager
+from game.world.opcode_handling.handlers.HandlerValidator import HandlerValidator
 from utils.constants.MiscCodes import HighGuid
 from game.world.managers.maps.MapManager import MapManager
 from utils.Logger import Logger
@@ -9,7 +10,11 @@ class QuestGiverChooseRewardHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        player_mgr = world_session.player_mgr
+        # Validate world session.
+        player_mgr, res = HandlerValidator.validate_session(world_session, reader.opcode)
+        if not player_mgr:
+            return res
+
         if len(reader.data) >= 16:  # Avoid handling empty quest giver choose reward packet.
             guid, quest_id, item_choice = unpack('<Q2I', reader.data[:16])
             high_guid = ObjectManager.extract_high_guid(guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverChooseRewardHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverChooseRewardHandler.py
@@ -9,7 +9,12 @@ class QuestGiverChooseRewardHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        # CGPlayer_C::GetQuestReward
+        player_mgr = world_session.player_mgr
+        # No player linked to session requester.
+        if not player_mgr:
+            Logger.warning('QuestGiverChooseRewardHandler received with null player_mgr.')
+            return 0
+
         if len(reader.data) >= 16:  # Avoid handling empty quest giver choose reward packet.
             guid, quest_id, item_choice = unpack('<Q2I', reader.data[:16])
             high_guid = ObjectManager.extract_high_guid(guid)
@@ -17,19 +22,19 @@ class QuestGiverChooseRewardHandler(object):
 
             quest_giver = None
             if high_guid == HighGuid.HIGHGUID_UNIT:
-                quest_giver = MapManager.get_surrounding_unit_by_guid(world_session.player_mgr, guid)
+                quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
             elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
-                quest_giver = MapManager.get_surrounding_gameobject_by_guid(world_session.player_mgr, guid)
+                quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
             elif high_guid == HighGuid.HIGHGUID_ITEM:
                 is_item = True
-                quest_giver = world_session.player_mgr.inventory.get_item_by_guid(guid)
+                quest_giver = player_mgr.inventory.get_item_by_guid(guid)
 
             if not quest_giver:
                 Logger.error(f'Error in CMSG_QUESTGIVER_COMPLETE_QUEST, could not find quest giver with guid of: {guid}')
                 return 0
 
-            if not is_item and world_session.player_mgr.is_enemy_to(quest_giver):
+            if not is_item and player_mgr.is_enemy_to(quest_giver):
                 return 0
 
-            world_session.player_mgr.quest_manager.handle_choose_reward(quest_giver, quest_id, item_choice)
+            player_mgr.quest_manager.handle_choose_reward(quest_giver, quest_id, item_choice)
         return 0

--- a/game/world/opcode_handling/handlers/quest/QuestGiverCompleteQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverCompleteQuestHandler.py
@@ -9,6 +9,12 @@ class QuestGiverCompleteQuestHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
+        player_mgr = world_session.player_mgr
+        # No player linked to session requester.
+        if not player_mgr:
+            Logger.warning('QuestGiverCompleteQuestHandler received with null player_mgr.')
+            return 0
+
         if len(reader.data) >= 12:  # Avoid handling empty quest giver complete quest packet.
             guid, quest_id = unpack('<QI', reader.data[:12])
             high_guid = ObjectManager.extract_high_guid(guid)
@@ -16,18 +22,18 @@ class QuestGiverCompleteQuestHandler(object):
 
             quest_giver = None
             if high_guid == HighGuid.HIGHGUID_UNIT:
-                quest_giver = MapManager.get_surrounding_unit_by_guid(world_session.player_mgr, guid)
+                quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
             elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
-                quest_giver = MapManager.get_surrounding_gameobject_by_guid(world_session.player_mgr, guid)
+                quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
             elif high_guid == HighGuid.HIGHGUID_ITEM:
                 is_item = True
-                quest_giver = world_session.player_mgr.inventory.get_item_by_guid(guid)
+                quest_giver = player_mgr.inventory.get_item_by_guid(guid)
 
             if not quest_giver:
                 Logger.error(f'Error in CMSG_QUESTGIVER_COMPLETE_QUEST, could not find quest giver with guid of: {guid}')
                 return 0
-            if not is_item and world_session.player_mgr.is_enemy_to(quest_giver):
+            if not is_item and player_mgr.is_enemy_to(quest_giver):
                 return 0
 
-            world_session.player_mgr.quest_manager.handle_complete_quest(quest_id, guid)
+            player_mgr.quest_manager.handle_complete_quest(quest_id, guid)
         return 0

--- a/game/world/opcode_handling/handlers/quest/QuestGiverCompleteQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverCompleteQuestHandler.py
@@ -1,6 +1,7 @@
 from struct import unpack
 from game.world.managers.objects.ObjectManager import ObjectManager
 from game.world.managers.maps.MapManager import MapManager
+from game.world.opcode_handling.handlers.HandlerValidator import HandlerValidator
 from utils.Logger import Logger
 from utils.constants.MiscCodes import HighGuid
 
@@ -9,7 +10,11 @@ class QuestGiverCompleteQuestHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        player_mgr = world_session.player_mgr
+        # Validate world session.
+        player_mgr, res = HandlerValidator.validate_session(world_session, reader.opcode)
+        if not player_mgr:
+            return res
+
         if len(reader.data) >= 12:  # Avoid handling empty quest giver complete quest packet.
             guid, quest_id = unpack('<QI', reader.data[:12])
             high_guid = ObjectManager.extract_high_guid(guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverCompleteQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverCompleteQuestHandler.py
@@ -10,11 +10,6 @@ class QuestGiverCompleteQuestHandler(object):
     @staticmethod
     def handle(world_session, socket, reader):
         player_mgr = world_session.player_mgr
-        # No player linked to session requester.
-        if not player_mgr:
-            Logger.warning('QuestGiverCompleteQuestHandler received with null player_mgr.')
-            return 0
-
         if len(reader.data) >= 12:  # Avoid handling empty quest giver complete quest packet.
             guid, quest_id = unpack('<QI', reader.data[:12])
             high_guid = ObjectManager.extract_high_guid(guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverHelloHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverHelloHandler.py
@@ -9,6 +9,12 @@ class QuestGiverHelloHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
+        player_mgr = world_session.player_mgr
+        # No player linked to session requester.
+        if not player_mgr:
+            Logger.warning('QuestGiverHelloHandler received with null player_mgr.')
+            return 0
+
         if len(reader.data) >= 8:  # Avoid handling empty quest giver hello packet.
             guid = unpack('<Q', reader.data[:8])[0]
             high_guid = ObjectManager.extract_high_guid(guid)
@@ -16,23 +22,23 @@ class QuestGiverHelloHandler(object):
 
             quest_giver = None
             if high_guid == HighGuid.HIGHGUID_UNIT:
-                quest_giver = MapManager.get_surrounding_unit_by_guid(world_session.player_mgr, guid)
+                quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
             elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
-                quest_giver = MapManager.get_surrounding_gameobject_by_guid(world_session.player_mgr, guid)
+                quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
             elif high_guid == HighGuid.HIGHGUID_ITEM:
                 is_item = True
-                quest_giver = world_session.player_mgr.inventory.get_item_by_guid(guid)
+                quest_giver = player_mgr.inventory.get_item_by_guid(guid)
 
             if not quest_giver:
                 Logger.error(f'Error in CMSG_QUESTGIVER_HELLO, could not find quest giver with guid of: {guid}')
                 return 0
-            if not is_item and world_session.player_mgr.is_enemy_to(quest_giver):
+            if not is_item and player_mgr.is_enemy_to(quest_giver):
                 return 0
 
             # TODO: Stop the npc if it's moving
             # TODO: Remove feign death from player
             # TODO: If the gossip menu is already open, do nothing
-            if quest_giver.is_within_interactable_distance(world_session.player_mgr):
-                world_session.player_mgr.quest_manager.handle_quest_giver_hello(quest_giver, guid)
+            if quest_giver.is_within_interactable_distance(player_mgr):
+                player_mgr.quest_manager.handle_quest_giver_hello(quest_giver, guid)
 
         return 0

--- a/game/world/opcode_handling/handlers/quest/QuestGiverHelloHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverHelloHandler.py
@@ -10,11 +10,6 @@ class QuestGiverHelloHandler(object):
     @staticmethod
     def handle(world_session, socket, reader):
         player_mgr = world_session.player_mgr
-        # No player linked to session requester.
-        if not player_mgr:
-            Logger.warning('QuestGiverHelloHandler received with null player_mgr.')
-            return 0
-
         if len(reader.data) >= 8:  # Avoid handling empty quest giver hello packet.
             guid = unpack('<Q', reader.data[:8])[0]
             high_guid = ObjectManager.extract_high_guid(guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverHelloHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverHelloHandler.py
@@ -1,6 +1,7 @@
 from struct import unpack
 from game.world.managers.objects.ObjectManager import ObjectManager
 from game.world.managers.maps.MapManager import MapManager
+from game.world.opcode_handling.handlers.HandlerValidator import HandlerValidator
 from utils.constants.MiscCodes import HighGuid
 from utils.Logger import Logger
 
@@ -9,7 +10,11 @@ class QuestGiverHelloHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        player_mgr = world_session.player_mgr
+        # Validate world session.
+        player_mgr, res = HandlerValidator.validate_session(world_session, reader.opcode)
+        if not player_mgr:
+            return res
+
         if len(reader.data) >= 8:  # Avoid handling empty quest giver hello packet.
             guid = unpack('<Q', reader.data[:8])[0]
             high_guid = ObjectManager.extract_high_guid(guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverQueryQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverQueryQuestHandler.py
@@ -2,6 +2,7 @@ from struct import unpack
 from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.managers.maps.MapManager import MapManager
 from game.world.managers.objects.ObjectManager import ObjectManager
+from game.world.opcode_handling.handlers.HandlerValidator import HandlerValidator
 from utils.Logger import Logger
 from utils.constants.MiscCodes import HighGuid
 
@@ -10,7 +11,11 @@ class QuestGiverQueryQuestHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        player_mgr = world_session.player_mgr
+        # Validate world session.
+        player_mgr, res = HandlerValidator.validate_session(world_session, reader.opcode)
+        if not player_mgr:
+            return res
+
         if len(reader.data) >= 8:  # Avoid handling empty quest giver query quest packet.
             guid, quest_entry = unpack('<QL', reader.data[:12])
             high_guid = ObjectManager.extract_high_guid(guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverQueryQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverQueryQuestHandler.py
@@ -11,11 +11,6 @@ class QuestGiverQueryQuestHandler(object):
     @staticmethod
     def handle(world_session, socket, reader):
         player_mgr = world_session.player_mgr
-        # No player linked to session requester.
-        if not player_mgr:
-            Logger.warning('QuestGiverQueryQuestHandler received with null player_mgr.')
-            return 0
-
         if len(reader.data) >= 8:  # Avoid handling empty quest giver query quest packet.
             guid, quest_entry = unpack('<QL', reader.data[:12])
             high_guid = ObjectManager.extract_high_guid(guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverRemoveQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverRemoveQuestHandler.py
@@ -1,11 +1,18 @@
 from struct import unpack
+from utils.Logger import Logger
 
 
 class QuestGiverRemoveQuestHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
+        player_mgr = world_session.player_mgr
+        # No player linked to session requester.
+        if not player_mgr:
+            Logger.warning('QuestGiverRemoveQuestHandler received with null player_mgr.')
+            return 0
+
         if len(reader.data) >= 1:  # Avoid handling empty quest giver remove quest packet.
             slot = unpack('<B', reader.data[:1])[0]
-            world_session.player_mgr.quest_manager.handle_remove_quest(slot)
+            player_mgr.quest_manager.handle_remove_quest(slot)
         return 0

--- a/game/world/opcode_handling/handlers/quest/QuestGiverRemoveQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverRemoveQuestHandler.py
@@ -1,11 +1,17 @@
 from struct import unpack
 
+from game.world.opcode_handling.handlers.HandlerValidator import HandlerValidator
+
 
 class QuestGiverRemoveQuestHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        player_mgr = world_session.player_mgr
+        # Validate world session.
+        player_mgr, res = HandlerValidator.validate_session(world_session, reader.opcode)
+        if not player_mgr:
+            return res
+
         if len(reader.data) >= 1:  # Avoid handling empty quest giver remove quest packet.
             slot = unpack('<B', reader.data[:1])[0]
             player_mgr.quest_manager.handle_remove_quest(slot)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverRemoveQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverRemoveQuestHandler.py
@@ -1,5 +1,4 @@
 from struct import unpack
-from utils.Logger import Logger
 
 
 class QuestGiverRemoveQuestHandler(object):
@@ -7,11 +6,6 @@ class QuestGiverRemoveQuestHandler(object):
     @staticmethod
     def handle(world_session, socket, reader):
         player_mgr = world_session.player_mgr
-        # No player linked to session requester.
-        if not player_mgr:
-            Logger.warning('QuestGiverRemoveQuestHandler received with null player_mgr.')
-            return 0
-
         if len(reader.data) >= 1:  # Avoid handling empty quest giver remove quest packet.
             slot = unpack('<B', reader.data[:1])[0]
             player_mgr.quest_manager.handle_remove_quest(slot)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverRequestReward.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverRequestReward.py
@@ -9,6 +9,12 @@ class QuestGiverRequestReward(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
+        player_mgr = world_session.player_mgr
+        # No player linked to session requester.
+        if not player_mgr:
+            Logger.warning('QuestGiverRequestReward received with null player_mgr.')
+            return 0
+
         if len(reader.data) >= 12:  # Avoid handling empty quest giver request reward packet.
             guid, quest_id = unpack('<QI', reader.data[:12])
             high_guid = ObjectManager.extract_high_guid(guid)
@@ -16,19 +22,19 @@ class QuestGiverRequestReward(object):
 
             quest_giver = None
             if high_guid == HighGuid.HIGHGUID_UNIT:
-                quest_giver = MapManager.get_surrounding_unit_by_guid(world_session.player_mgr, guid)
+                quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
             elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
-                quest_giver = MapManager.get_surrounding_gameobject_by_guid(world_session.player_mgr, guid)
+                quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
             elif high_guid == HighGuid.HIGHGUID_ITEM:
                 is_item = True
-                quest_giver = world_session.player_mgr.inventory.get_item_by_guid(guid)
+                quest_giver = player_mgr.inventory.get_item_by_guid(guid)
 
             if not quest_giver:
                 Logger.error(f'Error in CMSG_QUESTGIVER_REQUEST_REWARD, could not find quest giver with guid: {guid}')
                 return 0
 
-            if not is_item and world_session.player_mgr.is_enemy_to(quest_giver):
+            if not is_item and player_mgr.is_enemy_to(quest_giver):
                 return 0
 
-            world_session.player_mgr.quest_manager.handle_request_reward(guid, quest_id)
+            player_mgr.quest_manager.handle_request_reward(guid, quest_id)
         return 0

--- a/game/world/opcode_handling/handlers/quest/QuestGiverRequestReward.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverRequestReward.py
@@ -10,11 +10,6 @@ class QuestGiverRequestReward(object):
     @staticmethod
     def handle(world_session, socket, reader):
         player_mgr = world_session.player_mgr
-        # No player linked to session requester.
-        if not player_mgr:
-            Logger.warning('QuestGiverRequestReward received with null player_mgr.')
-            return 0
-
         if len(reader.data) >= 12:  # Avoid handling empty quest giver request reward packet.
             guid, quest_id = unpack('<QI', reader.data[:12])
             high_guid = ObjectManager.extract_high_guid(guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverRequestReward.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverRequestReward.py
@@ -1,5 +1,6 @@
 from struct import unpack
 from game.world.managers.objects.ObjectManager import ObjectManager
+from game.world.opcode_handling.handlers.HandlerValidator import HandlerValidator
 from utils.constants.MiscCodes import HighGuid
 from game.world.managers.maps.MapManager import MapManager
 from utils.Logger import Logger
@@ -9,7 +10,11 @@ class QuestGiverRequestReward(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        player_mgr = world_session.player_mgr
+        # Validate world session.
+        player_mgr, res = HandlerValidator.validate_session(world_session, reader.opcode)
+        if not player_mgr:
+            return res
+
         if len(reader.data) >= 12:  # Avoid handling empty quest giver request reward packet.
             guid, quest_id = unpack('<QI', reader.data[:12])
             high_guid = ObjectManager.extract_high_guid(guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverStatusHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverStatusHandler.py
@@ -10,11 +10,6 @@ class QuestGiverStatusHandler(object):
     @staticmethod
     def handle(world_session, socket, reader):
         player_mgr = world_session.player_mgr
-        # No player linked to session requester.
-        if not player_mgr:
-            Logger.warning('QuestGiverHelloHandler received with null player_mgr.')
-            return 0
-
         if len(reader.data) >= 8:  # Avoid handling empty quest giver status packet.
             guid = unpack('<Q', reader.data[:8])[0]
             high_guid = ObjectManager.extract_high_guid(guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverStatusHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverStatusHandler.py
@@ -1,6 +1,7 @@
 from struct import unpack
 from game.world.managers.objects.ObjectManager import ObjectManager
 from game.world.managers.maps.MapManager import MapManager
+from game.world.opcode_handling.handlers.HandlerValidator import HandlerValidator
 from utils.Logger import Logger
 from utils.constants.MiscCodes import HighGuid, ObjectTypeIds
 
@@ -9,7 +10,11 @@ class QuestGiverStatusHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        player_mgr = world_session.player_mgr
+        # Validate world session.
+        player_mgr, res = HandlerValidator.validate_session(world_session, reader.opcode)
+        if not player_mgr:
+            return res
+
         if len(reader.data) >= 8:  # Avoid handling empty quest giver status packet.
             guid = unpack('<Q', reader.data[:8])[0]
             high_guid = ObjectManager.extract_high_guid(guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverStatusHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverStatusHandler.py
@@ -9,25 +9,31 @@ class QuestGiverStatusHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
+        player_mgr = world_session.player_mgr
+        # No player linked to session requester.
+        if not player_mgr:
+            Logger.warning('QuestGiverHelloHandler received with null player_mgr.')
+            return 0
+
         if len(reader.data) >= 8:  # Avoid handling empty quest giver status packet.
             guid = unpack('<Q', reader.data[:8])[0]
             high_guid = ObjectManager.extract_high_guid(guid)
 
             quest_giver = None
             if high_guid == HighGuid.HIGHGUID_UNIT:
-                quest_giver = MapManager.get_surrounding_unit_by_guid(world_session.player_mgr, guid)
+                quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
             elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
-                quest_giver = MapManager.get_surrounding_gameobject_by_guid(world_session.player_mgr, guid)
+                quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
             elif high_guid == HighGuid.HIGHGUID_ITEM:
-                quest_giver = world_session.player_mgr.inventory.get_item_by_guid(guid)
+                quest_giver = player_mgr.inventory.get_item_by_guid(guid)
 
             if not quest_giver:
                 Logger.error(f'Error in CMSG_QUESTGIVER_STATUS_QUERY, could not find quest giver with guid of: {guid}')
                 return 0
 
             # Only units are able to provide quest status.
-            if world_session.player_mgr and quest_giver.get_type_id() == ObjectTypeIds.ID_UNIT:
-                quest_giver_status = world_session.player_mgr.quest_manager.get_dialog_status(quest_giver)
-                world_session.player_mgr.quest_manager.send_quest_giver_status(guid, quest_giver_status)
+            if player_mgr and quest_giver.get_type_id() == ObjectTypeIds.ID_UNIT:
+                quest_giver_status = player_mgr.quest_manager.get_dialog_status(quest_giver)
+                player_mgr.quest_manager.send_quest_giver_status(guid, quest_giver_status)
 
         return 0

--- a/game/world/opcode_handling/handlers/quest/QuestQueryHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestQueryHandler.py
@@ -1,18 +1,11 @@
 from struct import unpack
 from database.world.WorldDatabaseManager import WorldDatabaseManager
-from utils.Logger import Logger
-
 
 class QuestQueryHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
         player_mgr = world_session.player_mgr
-        # No player linked to session requester.
-        if not player_mgr:
-            Logger.warning('QuestQueryHandler received with null player_mgr.')
-            return 0
-
         if len(reader.data) >= 4:  # Avoid handling empty quest query packet.
             quest_id = unpack('<I', reader.data[:4])[0]
             quest_template = WorldDatabaseManager.QuestTemplateHolder.quest_get_by_entry(quest_id)

--- a/game/world/opcode_handling/handlers/quest/QuestQueryHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestQueryHandler.py
@@ -1,11 +1,17 @@
 from struct import unpack
 from database.world.WorldDatabaseManager import WorldDatabaseManager
+from game.world.opcode_handling.handlers.HandlerValidator import HandlerValidator
+
 
 class QuestQueryHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        player_mgr = world_session.player_mgr
+        # Validate world session.
+        player_mgr, res = HandlerValidator.validate_session(world_session, reader.opcode)
+        if not player_mgr:
+            return res
+
         if len(reader.data) >= 4:  # Avoid handling empty quest query packet.
             quest_id = unpack('<I', reader.data[:4])[0]
             quest_template = WorldDatabaseManager.QuestTemplateHolder.quest_get_by_entry(quest_id)

--- a/game/world/opcode_handling/handlers/quest/QuestQueryHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestQueryHandler.py
@@ -1,17 +1,24 @@
 from struct import unpack
 from database.world.WorldDatabaseManager import WorldDatabaseManager
+from utils.Logger import Logger
 
 
 class QuestQueryHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
+        player_mgr = world_session.player_mgr
+        # No player linked to session requester.
+        if not player_mgr:
+            Logger.warning('QuestQueryHandler received with null player_mgr.')
+            return 0
+
         if len(reader.data) >= 4:  # Avoid handling empty quest query packet.
             quest_id = unpack('<I', reader.data[:4])[0]
             quest_template = WorldDatabaseManager.QuestTemplateHolder.quest_get_by_entry(quest_id)
             if not quest_template:
                 return 0
 
-            world_session.player_mgr.quest_manager.send_quest_query_response(quest_template)
+            player_mgr.quest_manager.send_quest_query_response(quest_template)
 
         return 0


### PR DESCRIPTION
/ Fixes #394.
/ Fixes crash - QuestHandlers, PlayerMgr instance validation prior to handler execution.
/ Fixes crash - Validate summoner upon use_ritual.
/ Fixes to sockets that might've lead to processing packets even after session disconnect() was called.
/ Avoid duplicate calls to player logout(), do so if online flag is On.