### PR TITLE
Silverpine improvements

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8788,11 +8788,6 @@ begin not atomic
 
         -- SILVERPINE
 
-        -- Worg
-        UPDATE `creature_template`
-        SET `display_id1`=246
-        WHERE `entry`=1765;
-
         -- Moonrage Whitescalp
         UPDATE `creature_template`
         SET `display_id1`=729

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8830,12 +8830,12 @@ begin not atomic
 
         -- Wolf
         UPDATE `creature_template`
-        SET `display_id1`=783
+        SET `display_id1`=781
         WHERE `entry`=1765;
 
         -- Mottled Wolf
         UPDATE `creature_template`
-        SET `display_id1`=802
+        SET `display_id1`=783
         WHERE `entry`=1766;
 
         -- Bloodsnut Wolf

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8828,6 +8828,21 @@ begin not atomic
         SET `display_id1`=863
         WHERE `entry`=1954;
 
+        -- Wolf
+        UPDATE `creature_template`
+        SET `display_id1`=783
+        WHERE `entry`=1765;
+
+        -- Mottled Wolf
+        UPDATE `creature_template`
+        SET `display_id1`=802
+        WHERE `entry`=1766;
+
+        -- Bloodsnut Wolf
+        UPDATE `creature_template`
+        SET `display_id1`=782
+        WHERE `entry`=1923;
+
         insert into applied_updates values ('090820221');
     end if;
 end $

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8813,11 +8813,6 @@ begin not atomic
         SET `display_id1`=858
         WHERE `entry`=1943;
 
-        -- Thule Ravenclaw
-        UPDATE `creature_template`
-        SET `display_id1`=859
-        WHERE `entry`=1947;
-
         -- Lake Skulker
         UPDATE `creature_template`
         SET `display_id1`=862

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8782,6 +8782,59 @@ begin not atomic
 
         insert into applied_updates values ('080820223');
     end if;
+
+    -- 09/08/2022 1
+    if (select count(*) from applied_updates where id='090820221') = 0 then
+
+        -- SILVERPINE
+
+        -- Worg
+        UPDATE `creature_template`
+        SET `display_id1`=246
+        WHERE `entry`=1765;
+
+        -- Moonrage Whitescalp
+        UPDATE `creature_template`
+        SET `display_id1`=729
+        WHERE `entry`=1769;
+
+        -- Rot Hide Plague Weaver
+        UPDATE `creature_template`
+        SET `display_id1`=858
+        WHERE `entry`=1940;
+
+        -- Rot Hide Brute
+        UPDATE `creature_template`
+        SET `display_id1`=858
+        WHERE `entry`=1939;
+
+        -- Rot Hide Mystic
+        UPDATE `creature_template`
+        SET `display_id1`=847
+        WHERE `entry`=1773;
+
+        -- Raging Rot Hide
+        UPDATE `creature_template`
+        SET `display_id1`=858
+        WHERE `entry`=1943;
+
+        -- Thule Ravenclaw
+        UPDATE `creature_template`
+        SET `display_id1`=859
+        WHERE `entry`=1947;
+
+        -- Lake Skulker
+        UPDATE `creature_template`
+        SET `display_id1`=862
+        WHERE `entry`=1953;
+
+        -- Elder Lake Skulker
+        UPDATE `creature_template`
+        SET `display_id1`=863
+        WHERE `entry`=1954;
+
+        insert into applied_updates values ('090820221');
+    end if;
 end $
 delimiter ;
 


### PR DESCRIPTION
Silverpine
=======

About
-----

Here's a sample of Silverpine linked display_id, the whole range is very wide on this area.
![range](https://user-images.githubusercontent.com/72315006/183565406-34f6a976-4fca-483e-8d59-978b4a2a2388.png)
We can probably see here : Rot hide mobs, Raging Rot hide, Elder lake skulker, Lake Skulker, murloc mobs

Moonrage Whitscalp
---
![WoW_042904_007a_1083293197-816845](https://user-images.githubusercontent.com/72315006/183565705-a14bfdfd-d5df-4e61-b190-0b95daced08b.jpg)

He is the weakest mob of Moonrage, we choose display_id 729 with 0.9 scale.

Lake Skulker
----
![worldofwarcraft_042604_014](https://user-images.githubusercontent.com/72315006/183566889-30f2511c-c44a-455c-b72d-217c7ec10f46.jpg)

There are 2 mobs : Lake Skulker, Elder Lake Skulker. 
Elder Lake skulker miss his display_id.
![lake](https://user-images.githubusercontent.com/72315006/183566653-c29bbb74-a267-4ab8-95ee-a6ca08f17ac0.png)
![lakescale](https://user-images.githubusercontent.com/72315006/183566734-a5a942c5-fcf8-4bda-8807-138c3d4d40c3.png)

We sure of these display_id cause Lake Skulker use 863. But on screenshot, he is small.
Probably, on 0.5.3, Lake Skulker use 862, and Elder Lake Skulker use 863.
Later, blizzard will update Elder and for some reason, Lake skulker will take 863 display_id ?

It's make sense but maybe we need to wait for more evidences ?

I choose 862 for lake skulker, and 863 for elder lake.

Worg
----

In 0.5.3, worg seems to use wolf display_id
![images_3837](https://user-images.githubusercontent.com/72315006/183590735-fdbabcbd-1137-4cfc-b378-693ef8e6cc3e.jpg)

In background top left
![134 - 3VgZYXO](https://user-images.githubusercontent.com/72315006/183590787-f9330011-edbc-4a2d-88f9-e98736648e90.jpg)

There are 3 type of worgs in Silverpine : 

- Worg (low, no display_id)
- Mottled Worg (medium)
- Bloodsnout Worg(high)

There are a lot of wolf display_id in close to our range
![Capture d’écran_2022-08-09_09-25-39](https://user-images.githubusercontent.com/72315006/183591296-c04c5ce3-eee3-4030-92b7-e5f0598bd66e.png)
![Capture d’écran_2022-08-09_09-33-13](https://user-images.githubusercontent.com/72315006/183591310-8cb97b1e-3e64-4616-b492-af0b2b9aa4e6.png)

On screenshot 1 we see Bloodsnout, he is big, so : display_id 782 scale 1.1
On screenshot 2 we see Mottled, the grey one : display_id 783 scale 0.9
Probably normal Worg should be scaled 0.8 or 0.9 :  best bet seeems black one 0.8 scale, so display_id 781

Does it seem to match ?

Rot Hide
----
![worldofwarcraft_042604_011](https://user-images.githubusercontent.com/72315006/183568323-4a0bc3d3-27b6-471f-9ded-eba5ac56df3f.jpg)
![images_3905](https://user-images.githubusercontent.com/72315006/183568362-b59727fd-71bb-408b-9e19-48db3ac4bd88.jpg)
![7m_horde_WoWScrnShot_042304_210501](https://user-images.githubusercontent.com/72315006/183568338-e0bf19ec-70c6-40f0-998a-673a7407c8fb.jpg)

![Capture d’écran_2022-08-09_10-27-09](https://user-images.githubusercontent.com/72315006/183601994-c54f48f1-393e-455d-8060-acc88ec4edec.png)

![rothide](https://user-images.githubusercontent.com/72315006/183568298-4983c450-f1a8-4e70-ae03-7045261d0e8b.png)

We use appropriate scale for each level range, except scale 1.5.

Thule Ravenclaw
----

He is basically the named Rot Hide at fenris location, it's seems logical to apply model with 1.5 scale on him,  display_id 859 is totaly unused.

But this guy has a human model in vanilla : 
![75606](https://user-images.githubusercontent.com/72315006/183568735-e41bce53-7e52-414d-83b6-b47692928523.jpg)
![20981-thule-ravenclaw](https://user-images.githubusercontent.com/72315006/183569084-50d3de9c-01a0-4810-85c9-ee0165e23256.jpg)

We have no real evidences here, but why is there such a scale ? 1.5 is surely for a named. Maybe I missed another named in Silverpine ?

Should we wait for more evidences ?

I choose 859 for Thule Ravenclaw
