### PR TITLE
Hillsbrad improvements

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8790,7 +8790,7 @@ begin not atomic
 
         -- Hilsbrad sentry
         UPDATE `creature_template`
-        SET `display_id2`=0
+        SET `display_id2`=0, `display_id3`=0, `display_id4`=0
         WHERE `entry`=2270;
 
         -- Daggerspine Siren

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8782,6 +8782,44 @@ begin not atomic
 
         insert into applied_updates values ('080820223');
     end if;
+
+    -- 10/08/2022 1
+    if (select count(*) from applied_updates where id='100820221') = 0 then
+    
+        -- HILLSBRAD
+
+        -- Hilsbrad sentry
+        UPDATE `creature_template`
+        SET `display_id2`=0
+        WHERE `entry`=2270;
+
+        -- Daggerspine Siren
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=2271;
+
+        -- Daggerspine Shorehunter
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=2269;
+
+        -- Daggerspine Screamer
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=2270;
+
+        -- Daggerspine Shorestalker
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=2268;
+
+        -- Mudsnout Gnoll
+        UPDATE `creature_template`
+        SET `display_id1`=275
+        WHERE `entry`=2372;
+
+        insert into applied_updates values ('100820221');
+    end if;
 end $
 delimiter ;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8818,6 +8818,11 @@ begin not atomic
         SET `display_id1`=275
         WHERE `entry`=2372;
 
+        -- Melisara
+        UPDATE `creature_template`
+        SET `display_id1`=915
+        WHERE `entry`=2278;
+
         insert into applied_updates values ('100820221');
     end if;
 end $

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8796,22 +8796,22 @@ begin not atomic
         -- Daggerspine Siren
         UPDATE `creature_template`
         SET `display_id1`=4036
-        WHERE `entry`=2271;
+        WHERE `entry`=2371;
 
         -- Daggerspine Shorehunter
         UPDATE `creature_template`
         SET `display_id1`=4036
-        WHERE `entry`=2269;
+        WHERE `entry`=2369;
 
         -- Daggerspine Screamer
         UPDATE `creature_template`
         SET `display_id1`=4036
-        WHERE `entry`=2270;
+        WHERE `entry`=2370;
 
         -- Daggerspine Shorestalker
         UPDATE `creature_template`
         SET `display_id1`=4036
-        WHERE `entry`=2268;
+        WHERE `entry`=2368;
 
         -- Mudsnout Gnoll
         UPDATE `creature_template`


### PR DESCRIPTION
Hillsbrad
======

Naga
-----
![7m_horde_WoWScrnShot_042804_040827](https://user-images.githubusercontent.com/72315006/183765429-2051c0da-4c97-4c4c-b7d4-60520eab4b1c.jpg)

There is only one model in the whole set and no female. We apply display_id 4036 on all hillsbrad nagas.

Hillbrad Sentry
----
We remove unavailable display_id 2 3 4

Mudsnout Gnoll
----
![7m_horde_WoWScrnShot_042804_025925](https://user-images.githubusercontent.com/72315006/183765571-ac4be142-f745-451d-9947-2fd9d0fe4f92.jpg)

Here's all possible models
![Capture d’écran_2022-08-09_22-00-01](https://user-images.githubusercontent.com/72315006/183765639-34a62f98-85f8-4f0e-8112-eb79095d4ae6.png)
![Capture d’écran_2022-08-09_22-00-42](https://user-images.githubusercontent.com/72315006/183765647-6a3e1923-c41d-4b26-8a98-45ea7045e6d5.png)

We can see like a crowd on 493, 603, 662. We cant see it on target frame. We eliminate them.
So remaining choice are 275 & 494.

The other gnoll here (Mudsnout shaman) use 662 with scale 1.13, he is highest level than Mudsnout Gnoll.

So we choose display_id 275 with 1.0 scale.

Melisara
-----
![31 - H567RjI](https://user-images.githubusercontent.com/72315006/183781173-30448f88-c727-4242-9e31-6418903c5968.jpg)

We choose display_id 915 with 1.0 scale
