### PR TITLE
Wetlands improvements

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8783,8 +8783,8 @@ begin not atomic
         insert into applied_updates values ('080820223');
     end if;
 
-        -- 10/08/2022 1
-    if (select count(*) from applied_updates where id='100820221') = 0 then
+        -- 10/08/2022 2
+    if (select count(*) from applied_updates where id='100820222') = 0 then
     
         -- WETLANDS
 
@@ -8863,7 +8863,7 @@ begin not atomic
         SET `display_id1`=682
         WHERE `entry`=1033;
 
-        insert into applied_updates values ('100820221');
+        insert into applied_updates values ('100820222');
     end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8863,6 +8863,11 @@ begin not atomic
         SET `display_id1`=682
         WHERE `entry`=1033;
 
+        -- Bart Tidewater
+        UPDATE `creature_template`
+        SET `display_id1`=127
+        WHERE `entry`=1481;
+
         insert into applied_updates values ('100820222');
     end if;
 end $

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8782,6 +8782,89 @@ begin not atomic
 
         insert into applied_updates values ('080820223');
     end if;
+
+        -- 10/08/2022 1
+    if (select count(*) from applied_updates where id='100820221') = 0 then
+    
+        -- WETLANDS
+
+        -- Captain Stoutfist
+        UPDATE `creature_template`
+        SET `display_id1`=1764
+        WHERE `entry`=2104;
+
+        -- Dragonmaw raider
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=1034;
+
+        -- Dragonmaw swamprunner
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=1035;
+
+        -- Dragonmaw bonewarder
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=1057;
+
+        -- Dragonmaw shadowwarder
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=1038;
+
+        -- Dragonmaw centurion
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=1036;
+
+        -- Draonmaw Battlemaster
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=1037;
+
+        -- Red Whelp
+        UPDATE `creature_template`
+        SET `display_id1`=956
+        WHERE `entry`=1042;
+
+        -- Flamesnorting Whelp
+        UPDATE `creature_template`
+        SET `display_id1`=956
+        WHERE `entry`=1044;
+
+        -- Red Wyrmkin
+        UPDATE `creature_template`
+        SET `display_id1`=363
+        WHERE `entry`=1046;
+
+        -- Red Scaleban
+        UPDATE `creature_template`
+        SET `display_id1`=686
+        WHERE `entry`=1047;
+
+        -- Wyrmkin firebrand
+        UPDATE `creature_template`
+        SET `display_id1`=687
+        WHERE `entry`=1049;
+
+        -- Scaleban royal guard
+        UPDATE `creature_template`
+        SET `display_id1`=687
+        WHERE `entry`=1050;
+
+        -- Crimson ooze
+        UPDATE `creature_template`
+        SET `display_id1`=681
+        WHERE `entry`=1031;
+        
+        -- Monstrous ooze
+        UPDATE `creature_template`
+        SET `display_id1`=682
+        WHERE `entry`=1033;
+
+        insert into applied_updates values ('100820221');
+    end if;
 end $
 delimiter ;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -8865,7 +8865,7 @@ begin not atomic
 
         -- Bart Tidewater
         UPDATE `creature_template`
-        SET `display_id1`=127
+        SET `display_id1`=797
         WHERE `entry`=1481;
 
         insert into applied_updates values ('100820222');


### PR DESCRIPTION
Wetlands
======

Captain Stoutfist
----
![images_6224](https://user-images.githubusercontent.com/72315006/183769071-fb14e10c-bb2e-4c47-9443-0d1bc0525db3.jpg)

Dragonmaw
-----
![janvier2004-52](https://user-images.githubusercontent.com/72315006/183769101-911926e8-069a-4285-87fa-c7e70b52cc75.jpg)

There is only one model : display_id 1139
![Capture d’écran_2022-08-09_23-04-40](https://user-images.githubusercontent.com/72315006/183769137-7ac5cdfd-2c0c-42bd-bbd2-493dfc7e0b50.png)

We change  display_id of all these guys with 1139

Should we include the named 2091 Chef Nek'rosh ?

Whelp
-----
![images_5919](https://user-images.githubusercontent.com/72315006/183769281-1b84f7fc-7639-468a-acbc-4b6ad9d6d683.jpg)

There are only 2 red whelp model on the whole set.
![Capture d’écran_2022-08-09_22-43-06](https://user-images.githubusercontent.com/72315006/183769314-58a3a095-8541-4110-b1fa-692837a4b45d.png)
![Capture d’écran_2022-08-09_22-43-39](https://user-images.githubusercontent.com/72315006/183769318-ec60af36-634c-4ebe-af8a-85f36b2a360c.png)

We change display_id of Red Whelp/Flamesnorthing Whelp with display_id 956


Wyrm
----
![images_5934](https://user-images.githubusercontent.com/72315006/183769416-db04dfb8-7dca-419e-a3d9-33786c806444.jpg)


All red wyrms models
![Capture d’écran_2022-08-09_22-50-18](https://user-images.githubusercontent.com/72315006/183769467-bf33dc3d-e6ed-4ec2-a2fb-f18893ec7081.png)
![Capture d’écran_2022-08-09_22-50-48](https://user-images.githubusercontent.com/72315006/183769483-2a5bde6a-8ef9-43dc-b7e5-377958afdb7a.png)

We apply right display_id in taking account of level range. We also use 1.5, it's make sense, some of these mobs are 60+

Ooze
----
![ingame-268](https://user-images.githubusercontent.com/72315006/183769648-1c38007e-ee32-49cc-a259-bc1802bd6229.jpg)
![WoWScrnShot_051004_022350](https://user-images.githubusercontent.com/72315006/183769666-b52931ff-1983-4ceb-988b-9c2eef73ff5c.jpg)
![wow_prerelease_222](https://user-images.githubusercontent.com/72315006/183769680-1b80934f-dadf-45e4-88ff-768c7b510210.jpg)

All ooze models
![Capture d’écran_2022-08-10_00-03-09](https://user-images.githubusercontent.com/72315006/183769749-1cbf955f-5e63-4d68-a7f7-1906762eb706.png)
![Capture d’écran_2022-08-09_22-36-50](https://user-images.githubusercontent.com/72315006/183769761-724910c1-b428-495f-afe6-9f377fdd427d.png)

We choose red one 681 for Crimson Ooze with 1.3 scale. 
We can see on screenshot that Monstrous ooze is a bigger than Crimson ooze, so we choose 682 with 1.5 scale

Bart Tidewater
----

This guy probably should use captain placeholder (there is only one color for 0.5.3)
![127](https://user-images.githubusercontent.com/72315006/183801195-5514dad4-fa8a-4832-ac8b-99baf931c501.png)

Vanilla model here
![4429](https://user-images.githubusercontent.com/72315006/183801259-3ad08e4f-2965-49c5-80cd-d8d1d9d67a3d.gif)


