### PR TITLE
Arathi improvements

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9006,5 +9006,84 @@ begin not atomic
         insert into applied_updates values ('110820221');
     end if;
 
+    -- 10/08/2022 3
+    if (select count(*) from applied_updates where id='100820223') = 0 then
+    
+        -- Gnomeran transport. 'Vator2' (Elevator2)
+        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14139');
+        
+        insert into applied_updates values ('100820223');
+    end if;
+
+    -- 11/08/2022 2
+    if (select count(*) from applied_updates where id='110820222') = 0 then
+        -- Highland Strider
+        UPDATE `creature_template`
+        SET `display_id1`=961
+        WHERE `entry`=2559;
+
+        -- Young Mesa buzard
+        UPDATE `creature_template`
+        SET `display_id1`=388
+        WHERE `entry`=2578;
+
+        -- Shake O'breen
+        UPDATE `creature_template`
+        SET `display_id1`=797
+        WHERE `entry`=2610;
+
+        -- Blackwater Deckhand
+        UPDATE `creature_template`
+        SET `display_id1`=793
+        WHERE `entry`=2636;
+        
+        -- Daggerspine Raider
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=2595;
+
+        -- Daggerspine Sorceress
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=2596;
+
+        -- Prince Nazjak
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=2779;
+
+        -- Boulderfist Magus
+        UPDATE `creature_template`
+        SET `display_id1`=3190
+        WHERE `entry`=2567;
+        
+        -- Kor gresh Coldrage
+        UPDATE `creature_template`
+        SET `display_id1`=3191
+        WHERE `entry`=2793;
+
+        -- Cresting Exile
+        UPDATE `creature_template`
+        SET `display_id1`=110
+        WHERE `entry`=2761;
+
+        -- Rumbling Exile
+        UPDATE `creature_template`
+        SET `display_id1`=69
+        WHERE `entry`=2592;
+
+        -- Ruul Onestone
+        UPDATE `creature_template`
+        SET `display_id1`=1046
+        WHERE `entry`=2602;
+
+        -- Foulbelly
+        UPDATE `creature_template`
+        SET `display_id1`=3192
+        WHERE `entry`=2601;
+
+        insert into applied_updates values ('110820222');
+    end if;
+
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9006,15 +9006,6 @@ begin not atomic
         insert into applied_updates values ('110820221');
     end if;
 
-    -- 10/08/2022 3
-    if (select count(*) from applied_updates where id='100820223') = 0 then
-    
-        -- Gnomeran transport. 'Vator2' (Elevator2)
-        UPDATE `spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '14139');
-        
-        insert into applied_updates values ('100820223');
-    end if;
-
     -- 11/08/2022 2
     if (select count(*) from applied_updates where id='110820222') = 0 then
         -- Highland Strider

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9058,6 +9058,11 @@ begin not atomic
         SET `display_id1`=110
         WHERE `entry`=2761;
 
+        -- Air Exile
+        UPDATE `creature_template`
+        SET `display_id1`=69
+        WHERE `entry`=2762;
+
         -- Rumbling Exile
         UPDATE `creature_template`
         SET `display_id1`=69

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9070,11 +9070,10 @@ begin not atomic
 
         -- Foulbelly
         UPDATE `creature_template`
-        SET `display_id1`=3192
+        SET `display_id1`=1054
         WHERE `entry`=2601;
 
         insert into applied_updates values ('110820222');
     end if;
-
 end $
 delimiter ;


### PR DESCRIPTION
Arathi
=====

Highland Strider
----------
![581549-534914_20040701_012](https://user-images.githubusercontent.com/72315006/184040135-464e484e-b81a-4d33-b4e9-07bf5d78629b.jpg)

We use 0.8 scale that seems to fit the most with screenshot, display_id 961

Young Mesa buzzard
-------

He is the weakest buzzard in arathi. Here's other models used in arathi.
![Capture d’écran_2022-08-11_00-12-35](https://user-images.githubusercontent.com/72315006/184040328-4217a199-439c-4f7c-9cf0-ce18e842d0e8.png)
Probably, in 0.5.3 he should use same as Mesa Buzzard, and that's probably why blizzard will update it later, but no evidences here.
To respect scale by level, we try to find another same model with a lower scale.
![buzard](https://user-images.githubusercontent.com/72315006/184040437-69bfd07b-9111-4e1c-a3de-1a50285d3062.png)

We use display_id 388 with 1.1 scale. 


Foulbelly
-------
![screenhot_betatest_486_stormgarde_013](https://user-images.githubusercontent.com/72315006/184040567-f33f93cf-fd5c-4325-9f22-20b1ae611d88.jpg)

Arathi stormgard ogre push
![Capture d’écran_2022-08-11_07-23-30](https://user-images.githubusercontent.com/72315006/184069572-ad17c29e-1296-4aaa-b973-8f72cd54f1f3.png)
![Capture d’écran_2022-08-11_07-22-44](https://user-images.githubusercontent.com/72315006/184069576-eaaa9c25-fda1-4e1e-8de2-c313ad432423.png)


Since he is a named, we use model with the highest scale for this mob
Probably, the other named in this area  Or'Kalar should use one of these display_id (1124 ?), but no clear evidences yet.

Ruul Onestone
-----
![screenhot_betatest_486_stormgarde_022](https://user-images.githubusercontent.com/72315006/184040722-06001a2d-4db1-40ec-9358-bbda2fd01a68.jpg)

There is only one model with a white bag : 1046. He is part of ogres we see above

Nagas
----
![images_3616](https://user-images.githubusercontent.com/72315006/184042570-c0a40507-3fc2-47dd-bf54-94afa01aeb05.jpg)

We apply the only naga model for 0.5.3 : display_id 4036 for Daggerspire Sorceress & Raider
We include Prince Nazjak, named naga too

Elementals
----
![shyso_5 16_18](https://user-images.githubusercontent.com/72315006/184041113-4a54a113-2879-4a56-8b31-1d1b35d00a5a.jpg)


There are 4 type of elemental in Arathi : water, air, fire, earth

Fire already has is final model with 0.75 scale
All others miss their display_id

Since there is no 0.75 scaled model for others elementals, I assume they used 1.0 scale placeholder, and replaced it later.
We use display_id 101 for water and 69 for earth. Since there is no air elemental in 0.5.3, we dont know what can replace it.

Boulderfist Magus
-----

Here is arathi linked boulderfist ogre push (except casters model, others are already used in arathi)
![Capture d’écran_2022-08-10_23-50-57](https://user-images.githubusercontent.com/72315006/184041291-0aaf6920-e700-47a8-a4e1-4d2b1454886a.png)
![ogre](https://user-images.githubusercontent.com/72315006/184041322-7e4e24cc-f9d2-4f48-8fd3-6d48177a25a7.png)

Vanilla model : 
![6168](https://user-images.githubusercontent.com/72315006/184041654-f361dc31-00cb-4417-afa0-8cd911791912.gif)

Since there is no level variation from others mobs around, we choose  display_id 3190 with 1.1 scale (we will see why after)

Kor gresh Coldrage
-----
The named Boulderfist, here vanilla model
![6168](https://user-images.githubusercontent.com/72315006/184041573-871303a8-b221-491a-bb9d-64ee6a106674.gif)

We choose display_id 3191 with 1.2 scale.

Shake O'breen
-------

This guy should use captain placeholder (only one color varation avalaible in 0.5.3)
![797](https://user-images.githubusercontent.com/72315006/184041959-d679e38c-3f61-4974-a4f7-4b4e3b301bb7.png)

Vanilla model here :
![224604](https://user-images.githubusercontent.com/72315006/184041831-f5c613a0-09d7-4a98-a224-3206767c3f03.jpg)

Blackwater Deckhand
-------
This guy should use pirate placeholder
![793](https://user-images.githubusercontent.com/72315006/184041945-ed24d900-1aee-4845-8ad1-2f9575815fd6.png)


Vanilla model here : 
![36958](https://user-images.githubusercontent.com/72315006/184041917-01395d69-10ca-453a-93f4-23c2d180634c.jpg)

