### PR TITLE
Loch Modan/Dolanaar binders & Loch Modan Gryphon master fix

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9092,6 +9092,31 @@ begin not atomic
 
         insert into applied_updates values ('110820223');
     end if;
+    
+    -- 12/08/2022 1
+    if (select count(*) from applied_updates where id='120820221') = 0 then
+
+        -- LOCH MODAN Binder & Gryphon fix
+
+        -- Guffren Boulderbeard, old binder, we delelete it,  he is hand spawned
+        DELETE FROM `spawns_creatures`
+        WHERE `spawn_id`=400018;
+
+        -- Dolthar Stonefoot, new binder
+        INSERT INTO `spawns_creatures` VALUES (NULL, 2298, 0, 0, 0, 0, 0, 0, -5347.08544921875, -2883.7880859375, 343.3161315917969, 2.5038504600524902, 300, 300, 0, 100, 0, 0, 0, 0, 0);
+
+        -- Gryphon master loch modan
+        UPDATE `creature_template`
+        SET `display_id1`=1764
+        WHERE `entry`=1572;
+
+        -- DOLANAAR
+
+        -- Myielia, new binder
+        INSERT INTO `spawns_creatures` VALUES (NULL, 3778, 0, 0, 0, 1, 0, 0, 9868.9599609375, 929.1273803710938, 1309.1700439453125, 0.3094463348388672, 300, 300, 0, 100, 0, 0, 0, 0, 0);
+
+        insert into applied_updates values ('120820221');
+    end if;
 
 end $
 delimiter ;


### PR DESCRIPTION
**### Fix #454** 

Binders
======

Dolthar loch modan
--------
![album_1_028](https://user-images.githubusercontent.com/72315006/184237887-c82f6b89-1710-4b2a-8103-3399b00f4af5.jpg)

Zoom in, this guy is bald with a read beard.
![30 MARCH 04 azhar12](https://user-images.githubusercontent.com/72315006/184237909-093c6c0a-379f-42af-9e50-849d45ab4c17.jpg)

Myiela dolanaar
-------
![binders](https://user-images.githubusercontent.com/72315006/184237985-124539c2-9615-472b-9e54-092ab2b52e3f.png)
![bindersentry](https://user-images.githubusercontent.com/72315006/184237991-5a789288-562c-445e-8a20-ed927a26e0c4.png)

if 3777 is binder of Aldrassil and 3779 is binder of Darnassus, then 3778 is binder of Dolanaar


Gryphon
====

Thorgrum
-----
![30 MARCH 04 azhar12](https://user-images.githubusercontent.com/72315006/184238154-c02fd335-ceab-4dc8-bf85-3f14cbfe28e3.jpg)

