### PR TITLE
Spell-related fixes

### DIFF
--- a/game/world/managers/objects/spell/AppliedAura.py
+++ b/game/world/managers/objects/spell/AppliedAura.py
@@ -14,6 +14,7 @@ class AppliedAura:
         self.interrupt_flags = casting_spell.spell_entry.AuraInterruptFlags
 
         self.proc_charges = casting_spell.spell_entry.ProcCharges if casting_spell.spell_entry.ProcCharges != 0 else -1
+        self.proc_flags = casting_spell.spell_entry.ProcFlags
 
         self.applied_stacks = 1
         self.can_stack = ExtendedSpellData.AuraDoseInfo.aura_can_stack(self.spell_id)

--- a/game/world/managers/objects/spell/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/AuraEffectHandler.py
@@ -495,6 +495,16 @@ class AuraEffectHandler:
                                                          percentual=False, misc_value=misc_value)
 
     @staticmethod
+    def handle_mod_attack_speed(aura, effect_target, remove):
+        if remove:
+            effect_target.stat_manager.remove_aura_stat_bonus(aura.index, percentual=True)
+            return
+        amount = aura.get_effect_points()
+        effect_target.stat_manager.apply_aura_stat_bonus(aura.index,
+                                                         UnitStats.MAIN_HAND_DELAY | UnitStats.OFF_HAND_DELAY,
+                                                         amount, percentual=True)
+
+    @staticmethod
     def handle_mod_parry_chance(aura, effect_target, remove):
         if remove:
             effect_target.stat_manager.remove_aura_stat_bonus(aura.index, percentual=False)
@@ -569,6 +579,8 @@ AURA_EFFECTS = {
     AuraTypes.SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED: AuraEffectHandler.handle_increase_mounted_speed,
     AuraTypes.SPELL_AURA_MOD_DECREASE_SPEED: AuraEffectHandler.handle_decrease_speed,
     AuraTypes.SPELL_AURA_MOD_INCREASE_SWIM_SPEED: AuraEffectHandler.handle_increase_swim_speed,
+    AuraTypes.SPELL_AURA_MOD_ATTACKSPEED: AuraEffectHandler.handle_mod_attack_speed,
+
 
     AuraTypes.SPELL_AURA_MOD_PARRY_PERCENT: AuraEffectHandler.handle_mod_parry_chance,
     AuraTypes.SPELL_AURA_MOD_DODGE_PERCENT: AuraEffectHandler.handle_mod_dodge_chance,

--- a/game/world/managers/objects/spell/AuraManager.py
+++ b/game/world/managers/objects/spell/AuraManager.py
@@ -169,7 +169,7 @@ class AuraManager:
             ProcFlags.SPELL_HIT: is_receiver and involved_cast,
         }
         for aura in list(self.active_auras.values()):
-            flags = aura.source_spell.spell_entry.ProcFlags
+            flags = aura.proc_flags
             if not flags:
                 continue
 

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -92,7 +92,7 @@ class SpellEffectHandler:
         # Overpower also uses combo points, but shouldn't scale.
         if caster.get_type_id() == ObjectTypeIds.ID_PLAYER and not casting_spell.is_overpower() and \
                 casting_spell.requires_combo_points():
-            damage_bonus *= caster.combo_points
+            damage_bonus *= casting_spell.spent_combo_points
 
         caster.apply_spell_damage(target, weapon_damage + damage_bonus, casting_spell)
 

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -925,8 +925,9 @@ class SpellManager:
 
         # Creature type check.
         if casting_spell.initial_target_is_unit_or_player():
-            req_creature_type = casting_spell.spell_entry.TargetCreatureType
-            if req_creature_type and validation_target.creature_type != req_creature_type:
+            req_creature_type_mask = casting_spell.spell_entry.TargetCreatureType
+            target_creature_type_mask = 1 << (validation_target.creature_type - 1)
+            if req_creature_type_mask and not req_creature_type_mask & target_creature_type_mask:
                 error = SpellCheckCastResult.SPELL_FAILED_TARGET_IS_PLAYER if \
                     validation_target.get_type_id() == ObjectTypeIds.ID_PLAYER \
                     else SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -279,7 +279,6 @@ class SpellManager:
 
         for effect in casting_spell.get_effects():
             if not update:
-                effect.duration_multiplier = max(1, casting_spell.spent_combo_points)
                 effect.start_aura_duration()
 
             if effect.effect_type in SpellEffectHandler.AREA_SPELL_EFFECTS:

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -924,7 +924,7 @@ class SpellManager:
                 return False
 
         # Creature type check.
-        if casting_spell.initial_target_is_unit_or_player():
+        if casting_spell.initial_target_is_unit_or_player() and validation_target is not self.caster:
             req_creature_type_mask = casting_spell.spell_entry.TargetCreatureType
             target_creature_type_mask = 1 << (validation_target.creature_type - 1)
             if req_creature_type_mask and not req_creature_type_mask & target_creature_type_mask:

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -1149,12 +1149,13 @@ class SpellManager:
         # Player only checks
         if self.caster.get_type_id() == ObjectTypeIds.ID_PLAYER:
             # Check if player has required combo points.
-            if casting_spell.requires_combo_points() and \
-                    (casting_spell.initial_target.guid != self.caster.combo_target or
-                     # Doesn't have required combo points.
-                     self.caster.combo_points == 0):
-                self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_NO_COMBO_POINTS)
-                return False
+            if casting_spell.requires_combo_points():
+                combo_target = casting_spell.initial_target if \
+                    casting_spell.initial_target is not self.caster else casting_spell.targeted_unit_on_cast_start
+
+                if not combo_target or combo_target.guid != self.caster.combo_target or not self.caster.combo_points:
+                    self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_NO_COMBO_POINTS)
+                    return False
 
             # Check if player has required reagents.
             for reagent_info, count in casting_spell.get_reagents():

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -792,9 +792,7 @@ class SpellManager:
         if casting_spell.spell_entry.Targets == SpellTargetMask.ITEM and \
                 not casting_spell.initial_target_is_item() or \
                 (casting_spell.spell_entry.Targets == SpellTargetMask.UNIT_SELF and
-                 not casting_spell.initial_target_is_unit_or_player()) or \
-                (casting_spell.spell_entry.Targets == SpellTargetMask.DEST_LOCATION and
-                 not casting_spell.initial_target_is_terrain()):
+                 not casting_spell.initial_target_is_unit_or_player()):
             self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS)
             return False
 

--- a/game/world/managers/objects/units/player/EnchantmentManager.py
+++ b/game/world/managers/objects/units/player/EnchantmentManager.py
@@ -71,7 +71,8 @@ class EnchantmentManager(object):
     def handle_equipment_change(self, item):
         if not item:
             return
-        was_removed = item.current_slot > InventorySlots.SLOT_TABARD
+        was_removed = item.current_slot > InventorySlots.SLOT_TABARD or \
+            item.item_instance.bag != InventorySlots.SLOT_INBACKPACK
         self._handle_equip_buffs(item, remove=was_removed)
 
     def handle_melee_attack_procs(self, damage_info):

--- a/game/world/managers/objects/units/player/InventoryManager.py
+++ b/game/world/managers/objects/units/player/InventoryManager.py
@@ -296,9 +296,8 @@ class InventoryManager(object):
             dest_item.item_instance.slot = source_slot
 
         # Equipment-specific behaviour: binding, offhand unequip, equipment update packet etc.
-        if dest_container.is_backpack and \
-                (self.is_equipment_pos(source_bag, source_slot) or self.is_bag_pos(source_slot)) or \
-                (self.is_equipment_pos(dest_bag, dest_slot) or self.is_bag_pos(dest_slot)):  # Added equipment or bag
+        if (self.is_equipment_pos(source_bag, source_slot) or self.is_bag_pos(source_slot)) or \
+           (self.is_equipment_pos(dest_bag, dest_slot) or self.is_bag_pos(dest_slot)):  # Added equipment or bag
             self.handle_equipment_change(source_item, dest_item)
 
         # Finally, update items and client

--- a/game/world/managers/objects/units/player/InventoryManager.py
+++ b/game/world/managers/objects/units/player/InventoryManager.py
@@ -299,7 +299,8 @@ class InventoryManager(object):
         if (source_container.is_backpack and
                 (self.is_equipment_pos(source_bag, source_slot) or self.is_bag_pos(source_slot))) or \
            (dest_container.is_backpack and
-                (self.is_equipment_pos(dest_bag, dest_slot) or self.is_bag_pos(dest_slot))):  # Added equipment or bag
+                (self.is_equipment_pos(dest_bag, dest_slot) or self.is_bag_pos(dest_slot))):
+            # Added/removed equipment or bag.
             self.handle_equipment_change(source_item, dest_item)
 
         # Finally, update items and client

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -281,9 +281,9 @@ class StatManager(object):
 
     def remove_aura_stat_bonus(self, index: int, percentual=False):
         if percentual:
-            self.aura_stats_percentual.pop(index)
+            self.aura_stats_percentual.pop(index, None)
         else:
-            self.aura_stats_flat.pop(index)
+            self.aura_stats_flat.pop(index, None)
 
         self.apply_bonuses()
 

--- a/utils/constants/SpellCodes.py
+++ b/utils/constants/SpellCodes.py
@@ -515,6 +515,7 @@ class SpellImplicitTargets(IntEnum):
     TARGET_ALL_ENEMY_IN_AREA_INSTANT = 16
     TARGET_TABLE_X_Y_Z_COORDINATES = 17  # Used in teleport spells and some other
     TARGET_EFFECT_SELECT = 18  # Highly depends on the spell effect
+    TARGET_19 = 19  # Only used by "Zone Recall (OLD)"
     TARGET_AROUND_CASTER_PARTY = 20
     TARGET_SELECTED_FRIEND = 21
     TARGET_ALL_AROUND_CASTER = 22  # Used only in TargetA target selection dependent from TargetB


### PR DESCRIPTION
* Add missing target type for "Zone Recall (OLD)". Unhandled as the purpose of the spell is unclear.
* Add checks to aura stat modifier removal (crash fix)
* Fix edge cases with binding and enchants on equip
* Fix creature type check for spells (closes #435, closes #436, closes #437)
* Implement damage shield auras (closes #417, closes #445)
* Add basic chain damage handling (cleave/chain lightning etc.)
* Implement attack speed modifiers
* Fix self-cast finishing spells (Slice and Dice)
* Fix cast/aura duration for finishing spells