### PR TITLE
Stranglethorn Improvements

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9525,6 +9525,11 @@ begin not atomic
         SET `display_id1`=791
         WHERE `entry`=1492;
 
+        -- Mok rash
+        UPDATE `creature_template`
+        SET `display_id1`=791
+        WHERE `entry`=1493;
+
         -- Skullsplitter warrior
         UPDATE `creature_template`
         SET `display_id1`=337

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9585,6 +9585,11 @@ begin not atomic
         SET `display_id1`=593
         WHERE `entry`=1059;
 
+        -- Skullsplitter Mogh the undiying
+        UPDATE `creature_template`
+        SET `display_id1`=593
+        WHERE `entry`=1060;
+
         -- Bloodscalp scout
         UPDATE `creature_template`
         SET `display_id1`=1113

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9547,7 +9547,7 @@ begin not atomic
 
         -- Skullsplitter Axe thrower
         UPDATE `creature_template`
-        SET `display_id1`=337
+        SET `display_id1`=317
         WHERE `entry`=696;
 
         -- Skullsplitter Mystic
@@ -9607,7 +9607,7 @@ begin not atomic
 
         -- Bloodscalp Axe thrower
         UPDATE `creature_template`
-        SET `display_id1`=692
+        SET `display_id1`=590
         WHERE `entry`=694;
 
         -- Bloodscalp Shaman

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9597,7 +9597,7 @@ begin not atomic
 
         -- Bloodscalp Axe thrower
         UPDATE `creature_template`
-        SET `display_id1`=1112
+        SET `display_id1`=692
         WHERE `entry`=694;
 
         -- Bloodscalp Shaman

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9647,7 +9647,7 @@ begin not atomic
 
         -- Lesser Water elemental
         UPDATE `creature_template`
-        SET `display_id1`=101
+        SET `display_id1`=110
         WHERE `entry`=691;
 
         -- Southern Sand crawler

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9690,12 +9690,22 @@ begin not atomic
         SET `display_id1`=1139
         WHERE `entry`=1381;
 
+        -- Nerist
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=1148;
+
+        -- Nerist spawn fix (he is off village)
+        UPDATE `spawns_creatures`
+        SET `position_x`=-12409.4599609375, `position_y`=160.59080505371094, `position_z`=3.423726797103882, `orientation`=6.048337459564209
+        WHERE `spawn_id`=360;
+
         -- Zudd
         UPDATE `creature_template`
         SET `display_id1`=1139
         WHERE `entry`=3624;
 
-        -- Zudd spawn fix (she is off village)
+        -- Zudd spawn fix (he is off village)
         UPDATE `spawns_creatures`
         SET `position_x`=-12401.384765625, `position_y`=222.0936737060547, `position_z`=1.9255071878433228, `orientation`=5.456151962280273
         WHERE `spawn_id`=667;
@@ -9715,7 +9725,7 @@ begin not atomic
         SET `display_id1`=1139
         WHERE `entry`=1404;
 
-        -- Kragg spawn fix (she is off village)
+        -- Kragg spawn fix (he is off village)
         UPDATE `spawns_creatures`
         SET `position_x`=-12393.9638671875, `position_y`=215.6564483642578, `position_z`=2.40732479095459, `orientation`=5.3226399421691895
         WHERE `spawn_id`=364;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9670,6 +9670,11 @@ begin not atomic
         SET `display_id1`=1139, `display_id2`=0
         WHERE `entry`=1064;
 
+        -- Mudduk
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=1382;
+
         -- Krakk
         UPDATE `creature_template`
         SET `display_id1`=1139

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9787,6 +9787,57 @@ begin not atomic
 
         -- ignore 2 grom gol braziers off village
         UPDATE `spawns_gameobjects` SET `ignored`=1 WHERE `spawn_id` IN (10722, 10723, 10076, 10069);
+        
+
+        -- Kurzen Commando
+        UPDATE `creature_template`
+        SET `display_id1`=638
+        WHERE `entry`=938;
+
+        -- Kurzen Jungle Fighter
+        UPDATE `creature_template`
+        SET `display_id1`=638
+        WHERE `entry`=937;
+
+        -- Kurzen Elite
+        UPDATE `creature_template`
+        SET `display_id1`=637
+        WHERE `entry`=939;
+
+        -- Kurzen Medicine Man
+        UPDATE `creature_template`
+        SET `display_id1`=658
+        WHERE `entry`=940;
+
+        -- Kurzen Headshrinker
+        UPDATE `creature_template`
+        SET `display_id1`=658
+        WHERE `entry`=941;
+
+        -- Kurzen Witch Doctor
+        UPDATE `creature_template`
+        SET `display_id1`=658
+        WHERE `entry`=942;
+
+        -- Kurzen Wrangler
+        UPDATE `creature_template`
+        SET `display_id1`=638
+        WHERE `entry`=943;
+
+        -- Kurzen Subchief
+        UPDATE `creature_template`
+        SET `display_id1`=637
+        WHERE `entry`=978;
+
+        -- Kurzen Shadow Hunter
+        UPDATE `creature_template`
+        SET `display_id1`=638
+        WHERE `entry`=979;
+
+        -- Sergeant Malthus
+        UPDATE `creature_template`
+        SET `display_id1`=637
+        WHERE `entry`=814;
 
         insert into applied_updates values ('130820221');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9500,6 +9500,11 @@ begin not atomic
         SET `display_id1`=601
         WHERE `entry`=1550;
 
+        -- Stone maw basilisk
+        UPDATE `creature_template`
+        SET `display_id1`=601
+        WHERE `entry`=688;
+
         -- Lord Sakrasis
         UPDATE `creature_template`
         SET `display_id1`=4036

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9712,7 +9712,7 @@ begin not atomic
 
         -- Murkgill Lord
         UPDATE `creature_template`
-        SET `display_id1`=680
+        SET `display_id1`=664
         WHERE `entry`=4460;
 
         -- Murkgill Oracle
@@ -9722,7 +9722,7 @@ begin not atomic
 
         -- Murkgill Warrior
         UPDATE `creature_template`
-        SET `display_id1`=664
+        SET `display_id1`=680
         WHERE `entry`=4461;
 
         insert into applied_updates values ('130820221');

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9469,5 +9469,248 @@ begin not atomic
 
         insert into applied_updates values ('120820224');
     end if;
+        
+    -- 13/08/2022 1
+    if (select count(*) from applied_updates where id='130820221') = 0 then
+
+        -- STRONGLETHORN
+
+        -- Jungle stalker
+        UPDATE `creature_template`
+        SET `display_id1`=615
+        WHERE `entry`=687;
+
+        -- Thethis (named raptor)
+        UPDATE `creature_template`
+        SET `display_id1`=615
+        WHERE `entry`=730;
+
+        -- Cold Eye Basilisk
+        UPDATE `creature_template`
+        SET `display_id1`=601
+        WHERE `entry`=690;
+
+        -- Trashtrail basilisk
+        UPDATE `creature_template`
+        SET `display_id1`=601
+        WHERE `entry`=1550;
+
+        -- Lord Sakrasis
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=2541;
+
+        -- Zanzil naga
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=1491;
+
+        -- Naga explorer
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=1907;
+
+        -- Gorlash
+        UPDATE `creature_template`
+        SET `display_id1`=791
+        WHERE `entry`=1492;
+
+        -- Skullsplitter warrior
+        UPDATE `creature_template`
+        SET `display_id1`=337
+        WHERE `entry`=667;
+
+        -- Skullsplitter hunter
+        UPDATE `creature_template`
+        SET `display_id1`=337
+        WHERE `entry`=669;
+
+        -- Skullsplitter witch doctor
+        UPDATE `creature_template`
+        SET `display_id1`=692
+        WHERE `entry`=670;
+
+        -- Skullsplitter spiritchaser
+        UPDATE `creature_template`
+        SET `display_id1`=692
+        WHERE `entry`=672;
+
+        -- Skullsplitter Axe thrower
+        UPDATE `creature_template`
+        SET `display_id1`=337
+        WHERE `entry`=696;
+
+        -- Skullsplitter Mystic
+        UPDATE `creature_template`
+        SET `display_id1`=337
+        WHERE `entry`=780;
+
+        -- Skullsplitter Scout
+        UPDATE `creature_template`
+        SET `display_id1`=337
+        WHERE `entry`=782;
+
+        -- Skullsplitter Headhunter
+        UPDATE `creature_template`
+        SET `display_id1`=337
+        WHERE `entry`=781;
+
+        -- Skullsplitter Berserker
+        UPDATE `creature_template`
+        SET `display_id1`=692
+        WHERE `entry`=783;
+
+        -- Skullsplitter Beastmaster
+        UPDATE `creature_template`
+        SET `display_id1`=692
+        WHERE `entry`=784;
+
+        -- Skullsplitter Anathek Spiritchaser
+        UPDATE `creature_template`
+        SET `display_id1`=593
+        WHERE `entry`=1059;
+
+        -- Bloodscalp scout
+        UPDATE `creature_template`
+        SET `display_id1`=1113
+        WHERE `entry`=588;
+
+        -- Bloodscalp hunter
+        UPDATE `creature_template`
+        SET `display_id1`=1113
+        WHERE `entry`=595;
+
+        -- Bloodscalp berserker
+        UPDATE `creature_template`
+        SET `display_id1`=1152
+        WHERE `entry`=597;
+
+        -- Bloodscalp headhunter
+        UPDATE `creature_template`
+        SET `display_id1`=1152
+        WHERE `entry`=671;
+
+        -- Bloodscalp Witch doctor
+        UPDATE `creature_template`
+        SET `display_id1`=1115
+        WHERE `entry`=660;
+
+        -- Bloodscalp Axe thrower
+        UPDATE `creature_template`
+        SET `display_id1`=1112
+        WHERE `entry`=694;
+
+        -- Bloodscalp Shaman
+        UPDATE `creature_template`
+        SET `display_id1`=1112
+        WHERE `entry`=697;
+
+        -- Bloodscalp Beastmaster
+        UPDATE `creature_template`
+        SET `display_id1`=590
+        WHERE `entry`=699;
+
+        -- Bloodscalp Mystic
+        UPDATE `creature_template`
+        SET `display_id1`=1114
+        WHERE `entry`=701;
+
+        -- Bloodscalp Warrior
+        UPDATE `creature_template`
+        SET `display_id1`=1112
+        WHERE `entry`=587;
+
+        -- Bloodscalp Scavenger
+        UPDATE `creature_template`
+        SET `display_id1`=1112
+        WHERE `entry`=702;
+
+        -- Nezzliok, named bloodscalp
+        UPDATE `creature_template`
+        SET `display_id1`=591
+        WHERE `entry`=1062;
+
+        -- Gan Zulah, named chief bloodscalp
+        UPDATE `creature_template`
+        SET `display_id1`=693
+        WHERE `entry`=1061;
+
+        -- Lesser Water elemental
+        UPDATE `creature_template`
+        SET `display_id1`=101
+        WHERE `entry`=691;
+
+        -- Southern Sand crawler
+        UPDATE `creature_template`
+        SET `display_id1`=1000
+        WHERE `entry`=2544;        
+
+        -- Bloodsail warlock
+        UPDATE `creature_template`
+        SET `display_id1`=795, `display_id2`=0
+        WHERE `entry`=1564;
+
+        -- Gyll (flymaster)
+        UPDATE `creature_template`
+        SET `display_id1`=1140
+        WHERE `entry`=2859;
+
+        -- Grom-gol grunt
+        UPDATE `creature_template`
+        SET `display_id1`=1139, `display_id2`=0
+        WHERE `entry`=1064;
+
+        -- Krakk
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=1381;
+
+        -- Vharr
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=1146;
+
+        -- Uthok
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=1149;
+        
+        -- Kragg
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=1404;
+
+        -- Brawn
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=1385;
+
+        -- Kragg
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=2465;
+
+        -- Kim weelay
+        UPDATE `creature_template`
+        SET `display_id1`=1478
+        WHERE `entry`=2519;
+
+        -- Nimboya
+        UPDATE `creature_template`
+        SET `display_id1`=1478
+        WHERE `entry`=2497;
+
+        -- Nimboya
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=2465;
+
+        -- Corporal Kaleb
+        UPDATE `creature_template`
+        SET `display_id1`=459
+        WHERE `entry`=770;
+
+        insert into applied_updates values ('130820221');
+    end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9675,10 +9675,30 @@ begin not atomic
         SET `display_id1`=1139
         WHERE `entry`=1382;
 
+        -- Hragran 
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=1147;
+
+        -- Hram spawn fix (she is off village)
+        UPDATE `spawns_creatures`
+        SET `position_x`=-12398.7314453125, `position_y`=213.96031188964844, `position_z`=2.310176372528076, `orientation`=5.71769380569458
+        WHERE `spawn_id`=691;
+
         -- Krakk
         UPDATE `creature_template`
         SET `display_id1`=1139
         WHERE `entry`=1381;
+
+        -- Zudd
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=3624;
+
+        -- Zudd spawn fix (she is off village)
+        UPDATE `spawns_creatures`
+        SET `position_x`=-12401.384765625, `position_y`=222.0936737060547, `position_z`=1.9255071878433228, `orientation`=5.456151962280273
+        WHERE `spawn_id`=667;
 
         -- Vharr
         UPDATE `creature_template`
@@ -9739,6 +9759,9 @@ begin not atomic
         UPDATE `creature_template`
         SET `display_id1`=680
         WHERE `entry`=4461;
+
+        -- ignore 2 grom gol braziers off village
+        UPDATE `spawns_gameobjects` SET `ignored`=1 WHERE `spawn_id` IN (10722, 10723, 10076, 10069);
 
         insert into applied_updates values ('130820221');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9477,8 +9477,13 @@ begin not atomic
 
         -- Jungle stalker
         UPDATE `creature_template`
-        SET `display_id1`=615
+        SET `display_id1`=322
         WHERE `entry`=687;
+
+        -- Young Jungle stalker
+        UPDATE `creature_template`
+        SET `display_id1`=648
+        WHERE `entry`=854;
 
         -- Thethis (named raptor)
         UPDATE `creature_template`

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9682,7 +9682,7 @@ begin not atomic
 
         -- Hram spawn fix (she is off village)
         UPDATE `spawns_creatures`
-        SET `position_x`=-12398.7314453125, `position_y`=213.96031188964844, `position_z`=2.310176372528076, `orientation`=5.71769380569458
+        SET `position_x`=-12404.002, `position_y`=205.076, `position_z`=2.410176372528076, `orientation`=0.117
         WHERE `spawn_id`=691;
 
         -- Krakk
@@ -9714,6 +9714,11 @@ begin not atomic
         UPDATE `creature_template`
         SET `display_id1`=1139
         WHERE `entry`=1404;
+
+        -- Kragg spawn fix (she is off village)
+        UPDATE `spawns_creatures`
+        SET `position_x`=-12393.9638671875, `position_y`=215.6564483642578, `position_z`=2.40732479095459, `orientation`=5.3226399421691895
+        WHERE `spawn_id`=364;
 
         -- Brawn
         UPDATE `creature_template`

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9710,6 +9710,21 @@ begin not atomic
         SET `display_id1`=459
         WHERE `entry`=770;
 
+        -- Murkgill Lord
+        UPDATE `creature_template`
+        SET `display_id1`=680
+        WHERE `entry`=4460;
+
+        -- Murkgill Oracle
+        UPDATE `creature_template`
+        SET `display_id1`=679
+        WHERE `entry`=4459;
+
+        -- Murkgill Warrior
+        UPDATE `creature_template`
+        SET `display_id1`=664
+        WHERE `entry`=4461;
+
         insert into applied_updates values ('130820221');
     end if;
 end $


### PR DESCRIPTION
STV
===

Gyll
----
![7m_horde_WoWScrnShot_042004_224800](https://user-images.githubusercontent.com/72315006/184459241-216f7830-0809-49a9-aec5-6209e415db7a.jpg)

Corporal Kaleb
----
![18](https://user-images.githubusercontent.com/72315006/184459298-dd7fe6ef-ab11-4302-b6fa-69c8135262d7.jpg)

Basilisk
----

Since Stranglethorn is an early zone, basilisk should be present at begining of display_id set.
Here's what we find
![basil](https://user-images.githubusercontent.com/72315006/184459378-f7c986a2-f404-427d-8a99-2ab0a4172837.png)

All those are way too big, the only one at begining of the set and with a normal scale is 601 (used by another basilisk here). we choose 601 for  Cold eye & trashtrail basilisk.

Gorlash & Mokrash
----
![Big Ugly Giant](https://user-images.githubusercontent.com/72315006/184459717-487dffb0-81ff-42d7-a799-f0fc8d6f24e9.jpg)

Naga
----

All nagas should use 4036, we apply it on Naga explorer, Zanzil naga, Lord Sakrasis

Raptor
----

We miss display_id of Jungle stlaker and Thetis, we have no infos about it. On area, there is Young Jungle stalker with a display_id
This display_id 615 is way too big scaled for Young Jungle Stalker.

Probably, Jungle Stlaker and Thethis will use same colors as Young Jungle Stalker. We cant be sure about colors, there are too many raptors in range. But that's maybe why blizzard will update it later to add more color variations.

We can see 3 models that's seems to fit the most, all others are too small or too big.

![Capture d’écran_2022-08-13_04-14-50](https://user-images.githubusercontent.com/72315006/184464804-8d251abd-cfb6-462c-956a-49c8f7989772.png)
![Capture d’écran_2022-08-13_04-11-19](https://user-images.githubusercontent.com/72315006/184464809-9569f1b2-05ed-4b4e-b926-aa91cf3538f7.png)

We apply display_id in taking account of level range. The biggest for named


Bloodsail Warlock
-----
Here's the push on those mobs
![Capture d’écran_2022-08-13_02-28-24](https://user-images.githubusercontent.com/72315006/184459962-0b7fe469-552f-4abe-af90-08256bdfe9c8.png)

Only caster models is unused. In vanilla, blizzard will update only this one. So it's pretty obvious that Bloodsail Warlock should use this display_id.

Troll
----

In 0.5.3, there are actually 3 types of troll : Frostmane (white), Skullsplitter (blue), Bloodscalp (red)
![337](https://user-images.githubusercontent.com/72315006/184460053-9cdeca3f-3f9c-4411-893d-a7390be1ca60.png)
![195](https://user-images.githubusercontent.com/72315006/184460061-66e2f248-0fd7-4d3a-a1a2-167169d8b987.png)
![1111](https://user-images.githubusercontent.com/72315006/184460065-99009781-81a6-4ef7-b233-79416a8a5a1f.png)

There is a lot of display_id and scale but not so many models. 

Bloodscalp
![Capture d’écran_2022-08-13_02-36-12](https://user-images.githubusercontent.com/72315006/184460667-7ca66516-2ab8-4dfc-b73d-19f1762ae577.png)

Model 1:  Beastmaster, Axe thrower (we probably see him on screenshot with tauren below)
Model 2 : Named
Model 3 : Berserker
Model 4 : All others
Model 5 : Witch doctor

We use appropriate scale for each level range.

Skullsplitter
![Capture d’écran_2022-08-13_02-41-32](https://user-images.githubusercontent.com/72315006/184460874-fe8ffdda-b102-4b77-b943-cf62568055cf.png)

Same here, except there is no model with mask (cant find it in the whole set), we will use model 2 instead for Skullsplitter WItch Doctor, like Zanzil Wich Doctor who use it.

We use appropriate scale for each level range.

Here's some screenshots
![mars2002-09](https://user-images.githubusercontent.com/72315006/184460936-efe96da3-0d90-4028-aa61-033c05416e1b.jpg)
![Capture d’écran_2022-08-12_19-18-55](https://user-images.githubusercontent.com/72315006/184460942-ce74e5ac-9e8f-4d77-9067-680ea6a7853a.png)
![gencon24](https://user-images.githubusercontent.com/72315006/184460959-db61d814-5fa1-4f4d-8e07-df77a241ebe2.jpg)
![novembre2002-19](https://user-images.githubusercontent.com/72315006/184461267-c1ba32b4-b595-4c73-add2-9a3ffb192ad2.jpg)


Grom gol
-----
Here, we can see all mobs with placeholder orc display_id. This model is not part of 0.5.3
![album_1_051](https://user-images.githubusercontent.com/72315006/184460999-2aefb84f-fac1-4ed1-9ca9-753c102ee051.jpg)
![E3-72](https://user-images.githubusercontent.com/72315006/184465642-c8f970e2-6077-47d1-b922-7fc8da4759bb.jpg)



Probably it was overwrited by this one, this model is known to be a placeholder.
![1139](https://user-images.githubusercontent.com/72315006/184461027-064eda30-7a58-46ad-81f5-66d8e8859c52.png)


See here (at right, orc arm)
![PinkTroll](https://user-images.githubusercontent.com/72315006/184461049-07acc12c-cb94-4f82-81f8-8718e2cd8c3f.jpg)

Probably, NPC & gromgol guards should use 1191 (orc placeholder) & the 2 trolls should use 1478 (unutextured troll)

Here's an old screenshot that shows 2 trolls using placeholder model, and probably get updated with 1478 later.
![king_day03_1245](https://user-images.githubusercontent.com/72315006/184461110-84b18614-c6d4-49ee-9a7d-fad5e22b5143.JPG)

Some mobs have bad spawn in Gromgol. We correct some we can saw on screenshot


Murlocs
-----
We can probably see here stv murlocs push
![Capture d’écran_2022-08-13_03-46-39](https://user-images.githubusercontent.com/72315006/184463986-b8fd79a1-7113-41ce-8019-c75093e9d0d9.png)
![Capture d’écran_2022-08-13_03-47-00](https://user-images.githubusercontent.com/72315006/184463989-be3bda37-7d37-4071-a1c7-0ebb4a3c6fdb.png)

Basically, all those mobs should use violet murlocs except oracle who should use default blue one. Vanilla do like that but with another color variation for oracle (not present yet)

One of those mobs already use 652. We apply right model with best scale possible for each mobs.


Kurzen
-----

(NO MODIFICATIONS DONE, JUST SOME INFOS)

Here's probably kurzen mobs placeholder, 637 is used by named
![Capture d’écran_2022-08-13_03-09-44](https://user-images.githubusercontent.com/72315006/184462835-04b5c458-f12e-45db-a5e2-71c7c400c06d.png)


