### PR TITLE
Fixes.

### DIFF
--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -370,7 +370,7 @@ class Cell:
             if world_object:
                 player.update_world_object_on_me(world_object, has_changes, has_inventory_changes)
             else:
-                player.update_known_world_objects()
+                player.pending_update_world_objects = True
 
     def remove(self, world_object):
         if world_object.get_type_id() == ObjectTypeIds.ID_PLAYER:

--- a/game/world/managers/objects/item/EnchantmentHolder.py
+++ b/game/world/managers/objects/item/EnchantmentHolder.py
@@ -27,6 +27,12 @@ class EnchantmentHolder(object):
             self.effect_spell = self.spell_item_enchantment_entry.EffectArg_1
             self.aura_id = self.spell_item_enchantment_entry.ItemVisual
 
+    def flush(self):
+        self.effect = 0
+        self.effect_points = 0
+        self.effect_spell = 0
+        self.aura_id = 0
+
     def has_enchantment_effect(self, enchantment_type: [ItemEnchantmentType]):
         return enchantment_type == self.effect
 

--- a/game/world/managers/objects/units/PetManager.py
+++ b/game/world/managers/objects/units/PetManager.py
@@ -80,8 +80,8 @@ class PetData:
             created_by_spell=self.summon_spell_id,
             level=self._level,
             xp=self._experience,
-            react_state=self.react_state,
-            command_state=self.command_state,
+            react_state=int(self.react_state),
+            command_state=int(self.command_state),
             loyalty=0,  # TODO Loyalty/training
             loyalty_points=0,
             training_points=0,

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -810,8 +810,8 @@ class CreatureManager(UnitManager):
         if target and self.combat_target != target:
             self.attack(target)
         # No target at all, leave combat, reset aggro.
-        elif not target:
-            self.leave_combat()
+        elif not target and self.combat_target:
+            self.leave_combat(force=True)
             return
 
         super().attack_update(elapsed)

--- a/game/world/managers/objects/units/creature/ThreatManager.py
+++ b/game/world/managers/objects/units/creature/ThreatManager.py
@@ -138,7 +138,7 @@ class ThreatManager:
         relevant_holders = []
         for holder in list(self.holders.values()):
             # No reason to keep targets we cannot longer attack.
-            if not self.owner.can_attack_target(holder.unit):
+            if not self.can_attack_target(holder.unit):
                 self.current_holder = None if self.current_holder == holder else self.current_holder
                 self.holders.pop(holder.unit.guid)
             else:
@@ -150,7 +150,7 @@ class ThreatManager:
 
     # TODO Checking pet relation until friendliness can be evaluated properly.
     def can_attack_target(self, unit: UnitManager):
-        return unit.is_hostile_to(self.owner) and unit != self.owner.summoner
+        return unit.is_alive and unit.is_hostile_to(self.owner) and unit != self.owner.summoner
 
     # TODO Melee/outside of melee range reach
     def _is_exceeded_current_threat_melee_range(self, threat: float):


### PR DESCRIPTION
Closes #473 - Temporal enchants should now expire.
/ Fixes stats not properly updating upon enchants added/removed.
Closes #466 - update_known_world_objects() will now be called by each player on their own thread.
/ PlayerMgr - Avoid update ticks if online flag is off.
Closes #469 - Units should stop attacking and leave combat if ThreatManager is no longer able to resolve a target.
/ Fixes sql crash when taming a creature.