### PR TITLE
Use existing can_attack logic in ThreatManager, correct pet unit flags

### DIFF
--- a/game/world/managers/objects/ObjectManager.py
+++ b/game/world/managers/objects/ObjectManager.py
@@ -373,7 +373,7 @@ class ObjectManager:
 
         # Checks for both players and creatures (all units).
         if target.object_type_mask & ObjectTypeFlags.TYPE_UNIT:
-            if not target.is_alive:
+            if not target.is_alive or not target.is_spawned:
                 return False
 
         return self._allegiance_status_checker(target) < UnitReaction.UNIT_REACTION_AMIABLE

--- a/game/world/managers/objects/units/PetManager.py
+++ b/game/world/managers/objects/units/PetManager.py
@@ -17,7 +17,7 @@ from utils.constants import CustomCodes
 from utils.constants.OpCodes import OpCode
 from utils.constants.PetCodes import PetActionBarIndex, PetCommandState, PetTameResult, PetReactState
 from utils.constants.SpellCodes import SpellTargetMask, SpellCheckCastResult
-from utils.constants.UnitCodes import MovementTypes
+from utils.constants.UnitCodes import MovementTypes, UnitFlags
 from utils.constants.UpdateFields import UnitFields
 
 
@@ -328,7 +328,11 @@ class PetManager:
 
         creature.set_summoned_by(None)
         creature.set_uint64(UnitFields.UNIT_FIELD_CREATEDBY, 0)
+
+        creature.unit_flags &= ~UnitFlags.UNIT_FLAG_PLAYER_CONTROLLED
         creature.faction = creature.creature_template.faction
+
+        creature.set_uint32(UnitFields.UNIT_FIELD_FLAGS, creature.unit_flags)
         creature.set_uint32(UnitFields.UNIT_FIELD_FACTIONTEMPLATE, creature.faction)
         creature.set_uint32(UnitFields.UNIT_FIELD_PET_NAME_TIMESTAMP, 0)
         creature.set_uint32(UnitFields.UNIT_FIELD_PETNUMBER, 0)
@@ -456,10 +460,13 @@ class PetManager:
 
     def _tame_creature(self, creature: CreatureManager, summon_spell_id: int):
         creature.set_summoned_by(self.owner)
-        creature.set_uint64(UnitFields.UNIT_FIELD_CREATEDBY, self.owner.guid)
         creature.faction = self.owner.faction
+        creature.unit_flags |= UnitFlags.UNIT_FLAG_PLAYER_CONTROLLED
+
+        creature.set_uint32(UnitFields.UNIT_FIELD_FLAGS, creature.unit_flags)
         creature.set_uint32(UnitFields.UNIT_FIELD_FACTIONTEMPLATE, creature.faction)
         creature.set_uint32(UnitFields.UNIT_CREATED_BY_SPELL, summon_spell_id)
+        creature.set_uint64(UnitFields.UNIT_FIELD_CREATEDBY, self.owner.guid)
 
         # TODO pet naming/pet number?
         creature.set_uint32(UnitFields.UNIT_FIELD_PET_NAME_TIMESTAMP, int(time.time()))

--- a/game/world/managers/objects/units/creature/ThreatManager.py
+++ b/game/world/managers/objects/units/creature/ThreatManager.py
@@ -53,7 +53,7 @@ class ThreatManager:
 
         # Threat target switching.
         if max_threat_holder != self.current_holder:
-            if not self.current_holder or self.can_attack_target(self.current_holder.unit) or \
+            if not self.current_holder or self.owner.can_attack_target(self.current_holder.unit) or \
                     self._is_exceeded_current_threat_melee_range(max_threat_holder.total_threat):
                 self.current_holder = max_threat_holder
 
@@ -119,7 +119,7 @@ class ThreatManager:
             return False
         elif not unit.threat_manager:  # TODO: Might be better to just prevent threat manager to be None at any point.
             return False
-        elif not unit.threat_manager.can_attack_target(source):
+        elif not unit.can_attack_target(source):
             return False
         elif unit.in_combat:
             return False
@@ -138,7 +138,7 @@ class ThreatManager:
         relevant_holders = []
         for holder in list(self.holders.values()):
             # No reason to keep targets we cannot longer attack.
-            if not self.can_attack_target(holder.unit):
+            if not self.owner.can_attack_target(holder.unit):
                 self.current_holder = None if self.current_holder == holder else self.current_holder
                 self.holders.pop(holder.unit.guid)
             else:
@@ -147,18 +147,6 @@ class ThreatManager:
         # Sort by threat.
         relevant_holders.sort(key=lambda h: h.total_threat)
         return relevant_holders
-
-    # TODO Checking pet relation until friendliness can be evaluated properly.
-    def can_attack_target(self, unit: UnitManager):
-        if not unit:
-            return False
-            
-        # Creature only checks.
-        if unit.get_type_id() == ObjectTypeIds.ID_UNIT:
-            if not unit.is_spawned:
-                return False
-
-        return unit.is_alive and unit.is_hostile_to(self.owner) and unit != self.owner.summoner
 
     # TODO Melee/outside of melee range reach
     def _is_exceeded_current_threat_melee_range(self, threat: float):


### PR DESCRIPTION
* Remove `can_attack_target` from ThreatManager and use existing UnitManager method instead
    * Fixes issue with pets not being able to attack neutral enemies
* Add player-controlled flag to pets
    * Fixes issue with pets not being targetable with some helpful spells