### PR TITLE
Tanaris improvements

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9867,7 +9867,7 @@ begin not atomic
     end if;
 
     -- 18/08/2022 1
-    if (select count(*) from applied_updates where id='200820221') = 0 then
+    if (select count(*) from applied_updates where id='180820221') = 0 then
         
         -- TANARIS
 
@@ -10003,7 +10003,7 @@ begin not atomic
         SET `display_id1`=91
         WHERE `entry`=4131;
         
-        insert into applied_updates values ('200820221');
+        insert into applied_updates values ('180820221');
     end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -10002,6 +10002,11 @@ begin not atomic
         UPDATE `creature_template`
         SET `display_id1`=91
         WHERE `entry`=4131;
+
+        -- Land Rager
+        UPDATE `creature_template`
+        SET `display_id1`=3235
+        WHERE `entry`=5465;
         
         insert into applied_updates values ('180820221');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9865,5 +9865,145 @@ begin not atomic
 
         insert into applied_updates values ('150820221');
     end if;
+
+    -- 18/08/2022 1
+    if (select count(*) from applied_updates where id='200820221') = 0 then
+        
+        -- TANARIS
+
+        -- Scorpid Hunter
+        UPDATE `creature_template`
+        SET `display_id1`=3247
+        WHERE `entry`=5422;
+
+        -- Scorpid Tail Lasher
+        UPDATE `creature_template`
+        SET `display_id1`=3247
+        WHERE `entry`=5423;
+
+        -- Scorpid Dunestalker
+        UPDATE `creature_template`
+        SET `display_id1`=2489
+        WHERE `entry`=5424;
+
+        -- Glasshide Basilisk
+        UPDATE `creature_template`
+        SET `display_id1`=2743
+        WHERE `entry`=5419;
+
+        -- Glasshide Gazer
+        UPDATE `creature_template`
+        SET `display_id1`=2743
+        WHERE `entry`=5420;
+
+        -- Glasshide Petrifier
+        UPDATE `creature_template`
+        SET `display_id1`=2744
+        WHERE `entry`=5421;
+
+        -- Hazzali Stinger
+        UPDATE `creature_template`
+        SET `display_id1`=92
+        WHERE `entry`=5450;
+
+        -- Hazzali Swarmer
+        UPDATE `creature_template`
+        SET `display_id1`=92
+        WHERE `entry`=5451;
+
+        -- Hazzali Wasp
+        UPDATE `creature_template`
+        SET `display_id1`=92
+        WHERE `entry`=5441;
+
+        -- Hazzali Worker
+        UPDATE `creature_template`
+        SET `display_id1`=157
+        WHERE `entry`=5452;
+
+        -- Hazzali Tunneler
+        UPDATE `creature_template`
+        SET `display_id1`=91
+        WHERE `entry`=5453;
+
+        -- Hazzali Sandreaver
+        UPDATE `creature_template`
+        SET `display_id1`=91
+        WHERE `entry`=5454;
+
+        -- Dunemaul Enforcer
+        UPDATE `creature_template`
+        SET `display_id1`=3193
+        WHERE `entry`=5472;
+
+        -- Dunemaul Warlock
+        UPDATE `creature_template`
+        SET `display_id1`=3191
+        WHERE `entry`=5475;
+
+        -- Dunemaul Brute
+        UPDATE `creature_template`
+        SET `display_id1`=3192
+        WHERE `entry`=5474;
+
+        -- Dunemaul Ogre mage
+        UPDATE `creature_template`
+        SET `display_id1`=3190
+        WHERE `entry`=5473;
+
+        -- Dunemaul Ogre 
+        UPDATE `creature_template`
+        SET `display_id1`=3189
+        WHERE `entry`=5471;
+
+        -- Fire roc
+        UPDATE `creature_template`
+        SET `display_id1`=3248
+        WHERE `entry`=5429;
+
+        -- Searing roc
+        UPDATE `creature_template`
+        SET `display_id1`=3248
+        WHERE `entry`=5430;
+
+        -- Dune Smasher
+        UPDATE `creature_template`
+        SET `display_id1`=3216
+        WHERE `entry`=5469;
+
+        -- Thistlerub RootShaper
+        UPDATE `creature_template`
+        SET `display_id1`=3385
+        WHERE `entry`=5485;
+
+        -- Sandfury Hideskinner
+        UPDATE `creature_template`
+        SET `display_id1`=1154, `display_id2`=0
+        WHERE `entry`=5645;
+
+        -- Sandfury Axe Thrower
+        UPDATE `creature_template`
+        SET `display_id1`=590, `display_id2`=0
+        WHERE `entry`=5646;
+
+        -- Sandfury Firecaller
+        UPDATE `creature_template`
+        SET `display_id1`=590, `display_id2`=0
+        WHERE `entry`=5647;
+
+        -- Surf glider
+        UPDATE `creature_template`
+        SET `display_id1`=2308
+        WHERE `entry`=5431;
+
+        -- THOUSAND NEEDLES
+
+        -- Silithid Invader
+        UPDATE `creature_template`
+        SET `display_id1`=91
+        WHERE `entry`=4131;
+        
+        insert into applied_updates values ('200820221');
+    end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -9931,6 +9931,61 @@ begin not atomic
         SET `display_id1`=91
         WHERE `entry`=5454;
 
+        -- Centipaar Stinger
+        UPDATE `creature_template`
+        SET `display_id1`=92
+        WHERE `entry`=5456;
+
+        -- Centipaar Swarmer
+        UPDATE `creature_template`
+        SET `display_id1`=92
+        WHERE `entry`=5457;
+
+        -- Centipaar Wasp
+        UPDATE `creature_template`
+        SET `display_id1`=92
+        WHERE `entry`=5455;
+
+        -- Centipaar Worker
+        UPDATE `creature_template`
+        SET `display_id1`=157
+        WHERE `entry`=5458;
+
+        -- Centipaar Tunneler
+        UPDATE `creature_template`
+        SET `display_id1`=91
+        WHERE `entry`=5459;
+
+        -- Centipaar Sandreaver
+        UPDATE `creature_template`
+        SET `display_id1`=91
+        WHERE `entry`=5460;
+
+        -- Wasterwander Shadow mage
+        UPDATE `creature_template`
+        SET `display_id1`=263, `display_id2`=278
+        WHERE `entry`=5617;
+
+        -- Wasterwander bandit
+        UPDATE `creature_template`
+        SET `display_id1`=208, `display_id2`=0
+        WHERE `entry`=5618;
+
+        -- Wasterwander thief
+        UPDATE `creature_template`
+        SET `display_id1`=208, `display_id2`=0
+        WHERE `entry`=5616;
+
+        -- Wasterwander assasin
+        UPDATE `creature_template`
+        SET `display_id1`=210, `display_id2`=0
+        WHERE `entry`=5623;
+
+        -- Wasterwander rogue
+        UPDATE `creature_template`
+        SET `display_id1`=210, `display_id2`=0
+        WHERE `entry`=5615;
+
         -- Dunemaul Enforcer
         UPDATE `creature_template`
         SET `display_id1`=3193
@@ -9996,17 +10051,17 @@ begin not atomic
         SET `display_id1`=2308
         WHERE `entry`=5431;
 
+        -- Land Rager
+        UPDATE `creature_template`
+        SET `display_id1`=3235
+        WHERE `entry`=5465;
+
         -- THOUSAND NEEDLES
 
         -- Silithid Invader
         UPDATE `creature_template`
         SET `display_id1`=91
         WHERE `entry`=4131;
-
-        -- Land Rager
-        UPDATE `creature_template`
-        SET `display_id1`=3235
-        WHERE `entry`=5465;
         
         insert into applied_updates values ('180820221');
     end if;


### PR DESCRIPTION
Tanaris
======

Scorpid
--------
![septembre2004-26](https://user-images.githubusercontent.com/72315006/185286124-d9fbe453-f7eb-4f01-8a8a-658535f4a1e8.jpg)

![WoWScrnShot_062904_054505](https://user-images.githubusercontent.com/72315006/185258191-c4e6bb7b-fbde-415f-8dfd-784c92aeb739.jpg)
![scor](https://user-images.githubusercontent.com/72315006/185258607-ef7835e4-37cc-4c65-82bd-399850364fe6.png)

Probably, 3 scorpids type here should use pink model. We use appropriate scale for each level range.

Basilisk
--------
See background, it's probably Gasshide Basilisk
![7m_horde_push3_mount_WoWScrnShot_070504_022658](https://user-images.githubusercontent.com/72315006/185259771-33344f02-4448-4117-9ca5-1ebf33979870.jpg)
![WoWScrnShot_062904_054213](https://user-images.githubusercontent.com/72315006/185286327-5cd1bc53-0f13-48df-8762-b61f50f24bbe.jpg)

See background, it's probably Gasshide Gazer
![WoWScrnShot_062904_054308](https://user-images.githubusercontent.com/72315006/185258314-fdd52c14-7734-4951-88b8-b05cd7bc7995.jpg)

Such as scorpids, 3 basilisks type should use same color.
![Capture d’écran_2022-08-17_23-19-06](https://user-images.githubusercontent.com/72315006/185258367-704063c3-2424-47ef-a62a-f921363ed276.png)
![basi](https://user-images.githubusercontent.com/72315006/185258375-c19b88a8-242e-49e5-8232-d828b1b13c8a.png)

Hazzali (silitidh)
-------
![WoWScrnShot_062904_053920](https://user-images.githubusercontent.com/72315006/185258677-8d92a738-46ab-4a08-9aca-080bcc0cb6b5.jpg)
![WoWScrnShot_062904_054712](https://user-images.githubusercontent.com/72315006/185258700-14c9faeb-a34a-44fb-950b-25fcbe7a01fc.jpg)
![WoWScrnShot_062904_054308](https://user-images.githubusercontent.com/72315006/185258706-a7cfdb44-254a-4715-9b1d-8f111b4f59cb.jpg)

![scorpion](https://user-images.githubusercontent.com/72315006/185258894-4090e607-707e-4634-af6d-bb4c4f8913d8.png)

We will use those 3 models

Ogre
------
Probably tanaris ogre push
![Capture d’écran_2022-08-17_22-35-19](https://user-images.githubusercontent.com/72315006/185258958-b40eb925-b6fd-46c4-93ad-32d7f049d687.png)
![ogre](https://user-images.githubusercontent.com/72315006/185258967-1e3266f4-ce49-4b73-bc3a-2b07fe26e61b.png)

There are 5 models for 5 mobs type (2casters, 3melee), we use appopriate scale for each level.

Buzzard
--------

There are not a lot red buzzard model (probably 2 with one with a tiny scale).
There is 3 types of buzzards here. We use same model for all. 
Buzzard Roc here already use this display_id.

Dune Smasher
----------
![WoWScrnShot_061704_082049](https://user-images.githubusercontent.com/72315006/185259213-9e5c6fc2-d98c-40d5-9b37-b15759a58db5.jpg)

Only one color for giant in 0.5.3, we use default one

Thistlerub Rootshaper
-------
![Capture d’écran_2022-08-18_01-11-25](https://user-images.githubusercontent.com/72315006/185259353-16404678-3ac6-4ac9-b69e-481916efc270.png)

3386 is used by mob next to him, so we use 3385.


Sandfury
------

In vanilla, there are kind of red.
![6411](https://user-images.githubusercontent.com/72315006/185259434-cd14a2b5-0629-44cc-afe5-adb20d0c01b0.gif)

Since we have only 3 colors : red, blue, white, we will use red models.

Hideskinner
![1154](https://user-images.githubusercontent.com/72315006/185259528-1184161b-335f-4c13-ae0b-1da0512cbc23.png)

Firecaller, Axe thrower (we have evidence show Ace thrower troll with this display_id in STV)
![590](https://user-images.githubusercontent.com/72315006/185259578-9be6238d-bcef-4edb-a601-3e1c1cb1cfaa.png)


Turtle
-----

There is only one color, we choose a model with 1.2 scale.

Wastewander
------

Should we use old defias models on those ?

Centipaar (silithid)
-----

We can see a green push here (seems to fit Tanaris range)
![Capture d’écran_2022-08-17_22-35-38](https://user-images.githubusercontent.com/72315006/185260194-f136d412-6050-4970-b270-a570366c083a.png)

In vanilla, Hazzali are green and Centipaar are pink. 

There are 2 choices : 
-  All bugs are pink and blizzard will update Centipaar mobs color later
-  Hazzali are pink, Centipaar are green and blizzard will swap color later.

The first seems more logical, but it's not explain why we retrieve 2 green silithids models in tanaris range

Should we use green models or pink models for those bugs ?

Thousand Needle
======

Silithid
------

Change Invader display_id with the good one (mistake on another PR)
