### PR TITLE
Burning blade mobs fix & Desolace fix

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -214,8 +214,8 @@ begin not atomic
         SET `display_id1`=1139, `display_id2`=0, `display_id3`=0, `display_id4`=0
         WHERE `name` LIKE "burning blade%" AND `name` NOT LIKE "burning blade nightmare" AND `entry` < 5764 AND `display_id1` > 4165;
 
-        insert into applied_updates values ('200820223');
-
+        -- DESOLACE
+        
         -- Magram Marauder
         UPDATE `creature_template`
         SET `display_id1`=1349
@@ -225,6 +225,18 @@ begin not atomic
         UPDATE `creature_template`
         SET `display_id1`=1348
         WHERE `entry`=4639;
+
+        -- Rabid Bonepaw
+        UPDATE `creature_template`
+        SET `display_id1`=2714
+        WHERE `entry`=4690;
+
+        -- Piter Verance
+        UPDATE `creature_template`
+        SET `display_id1`=4833
+        WHERE `entry`=4890;
+
+        insert into applied_updates values ('200820223');
     end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -210,12 +210,21 @@ begin not atomic
     -- 20/08/2022 3
     if (select count(*) from applied_updates where id='200820223') = 0 then
         -- BURNING BLADE MOBS (orc)
-
         UPDATE `creature_template`
         SET `display_id1`=1139, `display_id2`=0, `display_id3`=0, `display_id4`=0
         WHERE `name` LIKE "burning blade%" AND `name` NOT LIKE "burning blade nightmare" AND `entry` < 5764 AND `display_id1` > 4165;
 
         insert into applied_updates values ('200820223');
+
+        -- Magram Marauder
+        UPDATE `creature_template`
+        SET `display_id1`=1349
+        WHERE `entry`=4644;
+
+        -- Magram Outruner
+        UPDATE `creature_template`
+        SET `display_id1`=1348
+        WHERE `entry`=4639;
     end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -206,5 +206,16 @@ begin not atomic
 
         insert into applied_updates values ('200820222');
     end if;
+
+    -- 20/08/2022 3
+    if (select count(*) from applied_updates where id='200820223') = 0 then
+        -- BURNING BLADE MOBS (orc)
+
+        UPDATE `creature_template`
+        SET `display_id1`=1139, `display_id2`=0, `display_id3`=0, `display_id4`=0
+        WHERE `name` LIKE "burning blade%" AND `name` NOT LIKE "burning blade nightmare" AND `entry` < 5764 AND `display_id1` > 4165;
+
+        insert into applied_updates values ('200820223');
+    end if;
 end $
 delimiter ;


### PR DESCRIPTION
Burning Blade
=======
![Capture d’écran_2022-08-20_17-09-47](https://user-images.githubusercontent.com/72315006/185760325-04298d2b-1b6e-41ed-a4ea-1d96ed6eaf46.png)

We change all display_id of Burning Blade orc with 1139 placeholder. We exclude Burning blade Nightmare (horse), and high entries whose are not part of 0.5.3.

Here's evidences
![Capture d’écran_2022-08-20_03-02-23](https://user-images.githubusercontent.com/72315006/185760364-9368df9e-c89f-41ff-b8e3-1c824caddfae.png)

Desolace
======

Centaurs
-----
We fix forgotten Magram Marauder and Magram Outrunner in Desolace

Rabid Bonepaw
----

By mistake, I applied display_id on 4890 (Piter Verence)  instead of 4690 (Rabid). So we revert Piter display_id and apply it on rabid
