### PR TITLE
Feralas Improvements

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -239,5 +239,202 @@ begin not atomic
 
         insert into applied_updates values ('200820223');
     end if;
+    
+    -- 21/08/2022 1
+    if (select count(*) from applied_updates where id='210820221') = 0 then
+        -- FERALAS
+            
+        -- Gordunni Ogre Mage
+        UPDATE `creature_template`
+        SET `display_id1`=3190
+        WHERE `entry`=5237;
+
+        -- Gordunni Brute
+        UPDATE `creature_template`
+        SET `display_id1`=3192
+        WHERE `entry`=5232;
+
+        -- Gordunni Warlock
+        UPDATE `creature_template`
+        SET `display_id1`=3191
+        WHERE `entry`=5240;
+
+        -- Gordunni Mauler
+        UPDATE `creature_template`
+        SET `display_id1`=3192
+        WHERE `entry`=5234;
+
+        -- Gordunni Shaman
+        UPDATE `creature_template`
+        SET `display_id1`=3192
+        WHERE `entry`=5236;
+
+        -- Gordunni Battlemaster
+        UPDATE `creature_template`
+        SET `display_id1`=3193
+        WHERE `entry`=5238;
+
+        -- Gordunni Mage Lord
+        UPDATE `creature_template`
+        SET `display_id1`=3191
+        WHERE `entry`=5239;
+
+        -- Gordunni Warlord
+        UPDATE `creature_template`
+        SET `display_id1`=3192
+        WHERE `entry`=5241;
+
+        -- Woodpaw Trapper
+        UPDATE `creature_template`
+        SET `display_id1`=3197
+        WHERE `entry`=5251;
+
+        -- Woodpaw Mystic
+        UPDATE `creature_template`
+        SET `display_id1`=3198
+        WHERE `entry`=5254;
+
+        -- Woodpaw Alpha
+        UPDATE `creature_template`
+        SET `display_id1`=3199
+        WHERE `entry`=5258;
+
+        -- Woodpaw Reaver
+        UPDATE `creature_template`
+        SET `display_id1`=3196
+        WHERE `entry`=5255;
+
+        -- Woodpaw Mongrel
+        UPDATE `creature_template`
+        SET `display_id1`=3196
+        WHERE `entry`=5249;
+
+        -- Glizled Ironfur Bear
+        UPDATE `creature_template`
+        SET `display_id1`=3201
+        WHERE `entry`=5272;
+
+        -- Frayfeather Patriarch
+        UPDATE `creature_template`
+        SET `display_id1`=3212
+        WHERE `entry`=5306;
+
+        -- Frayfeather Stagwing
+        UPDATE `creature_template`
+        SET `display_id1`=3211
+        WHERE `entry`=5304;
+
+        -- Antilus (named frayfeather)
+        UPDATE `creature_template`
+        SET `display_id1`=3212
+        WHERE `entry`=5347;
+
+        -- Hulking Feral Scar
+        UPDATE `creature_template`
+        SET `display_id1`=3209
+        WHERE `entry`=5293;
+
+        -- Enraged Feral Scar
+        UPDATE `creature_template`
+        SET `display_id1`=3208
+        WHERE `entry`=5295;
+
+        -- See elemental
+        UPDATE `creature_template`
+        SET `display_id1`=110
+        WHERE `entry`=5461;
+
+        -- See spray
+        UPDATE `creature_template`
+        SET `display_id1`=110
+        WHERE `entry`=5462;
+
+        -- Deep strider
+        UPDATE `creature_template`
+        SET `display_id1`=3217
+        WHERE `entry`=5360;
+
+        -- Wave strider
+        UPDATE `creature_template`
+        SET `display_id1`=3219
+        WHERE `entry`=5361;
+
+        -- Jademir Broughguard
+        UPDATE `creature_template`
+        SET `display_id1`=624
+        WHERE `entry`=5320;
+
+        -- Jademir Oracle
+        UPDATE `creature_template`
+        SET `display_id1`=623
+        WHERE `entry`=5317;
+
+        -- Hatecrest Warrior
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=5331;
+
+        -- Hatecrest Screamer
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=5335;
+
+        -- Hatecrest Siren
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=5337;
+
+        -- Hatecrest Wave rider
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=5332;
+
+        -- Hatecrest Serpent Guard
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=5333;
+
+        -- Hatecrest Myrmidon
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=5334;
+
+        -- Hatecrest Sorceress
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=5336;
+
+        -- Sprite Dragon
+        UPDATE `creature_template`
+        SET `display_id1`=2158
+        WHERE `entry`=5276;
+
+        -- Land Walker
+        UPDATE `creature_template`
+        SET `display_id1`=3216
+        WHERE `entry`=5357;
+
+        -- Cliff Giant
+        UPDATE `creature_template`
+        SET `display_id1`=3216
+        WHERE `entry`=5358;
+
+        -- Northspring Roguefeather
+        UPDATE `creature_template`
+        SET `display_id1`=3218
+        WHERE `entry`=5363;
+
+        -- Northspring Harpy
+        UPDATE `creature_template`
+        SET `display_id1`=3218
+        WHERE `entry`=5362;
+
+        -- Northspring Slayer
+        UPDATE `creature_template`
+        SET `display_id1`=3218
+        WHERE `entry`=5364;
+
+        insert into applied_updates values ('210820221');
+    end if;
 end $
 delimiter ;


### PR DESCRIPTION
Feralas
======

About
-------

Bad news is that we don't have any screenshot from 0.5.3, good news is we have a very clear range for this location
![range](https://user-images.githubusercontent.com/72315006/185770384-8495076c-00f8-4f82-92ca-8269d36668e0.png)

We can see almost all mobs of this area.

Frayfeather
-----
![Capture d’écran_2022-08-21_02-28-47](https://user-images.githubusercontent.com/72315006/185770416-68de9b9f-c968-47ff-8aa3-9251d14b16eb.png)

We use appropriate scale for each lvl range

Hulking
------
![Capture d’écran_2022-08-21_02-29-39](https://user-images.githubusercontent.com/72315006/185770436-8ef57a5f-50ea-46c2-b2e6-e0951c53a35f.png)

2 mobs miss display_id, others here already use brown models, so we put silver for those. We use appropriate scale for each lvl range

Gordunni 
-----
![Capture d’écran_2022-08-21_02-31-01](https://user-images.githubusercontent.com/72315006/185770494-06750d50-7e01-49b4-9fff-ddd8161a1d16.png)
We use appropriate scale for each lvl range

Woodpaw
-----
![Capture d’écran_2022-08-21_02-33-16](https://user-images.githubusercontent.com/72315006/185770550-e54e0c30-d43d-467d-8409-4d54b484d007.png)
We use appropriate scale for each lvl range

Jademir
-----
![Capture d’écran_2022-08-21_02-33-59](https://user-images.githubusercontent.com/72315006/185770569-cf6feafd-bbd9-42ff-81a8-cda3248aa965.png)
We use appropriate scale for each lvl range

Northspring
----
![Capture d’écran_2022-08-21_02-36-14](https://user-images.githubusercontent.com/72315006/185770609-2f5e12da-61a1-4eca-93df-f599d4be27f6.png)

2 mobs miss display_id, we can see only one model in range, it's unsure but we apply it on Roguefeather/Harpy for now.

Giants
----
Only one colors in 0.5.3
![Capture d’écran_2022-08-21_02-46-09](https://user-images.githubusercontent.com/72315006/185770794-ec9eb6cb-9efe-4fb1-87ab-9dd452b3e64d.png)



Elementals
----
We put placeholder display_id 110 for water elementals

Naga
----
Only one display_id for 0.5.3, we apply on all nagas.

Strider
-----

![Capture d’écran_2022-08-21_02-39-45](https://user-images.githubusercontent.com/72315006/185770675-72522346-ae52-43a2-8065-91282ea8a97e.png)

Bear
----
![Capture d’écran_2022-08-21_02-42-47](https://user-images.githubusercontent.com/72315006/185770737-75806173-c52d-40c6-82be-40f0ed470c81.png)











