### PR TITLE
Dustwallow improvements

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -501,5 +501,102 @@ begin not atomic
 
         insert into applied_updates values ('210820221');
     end if;
+
+    -- 21/08/2022 2
+    if (select count(*) from applied_updates where id='210820222') = 0 then
+        -- DUSTWALLOW MARCH
+        
+        -- Spider trainer
+        INSERT INTO `spawns_creatures` VALUES (NULL, 4882, 0, 0, 0, 1, -3154.872, -2848.983, 34.454, 0.031, 300, 300, 0, 100, 0, 0, 0, 0, 0);
+
+        UPDATE `creature_template`
+        SET `name`="Om'kan", `display_id1`=1120
+        WHERE `entry`=4882;
+        
+        -- Turtle trainer
+        INSERT INTO `spawns_creatures` VALUES (NULL, 4881, 0, 0, 0, 1, -3147.965, -2841.329, 34.646, 4.779, 300, 300, 0, 100, 0, 0, 0, 0, 0);
+
+        -- Krak
+        UPDATE `creature_template`
+        SET `display_id1` =1120
+        WHERE `entry`=4883;
+
+        -- Ogg'mar
+        UPDATE `creature_template`
+        SET `display_id1` =1120
+        WHERE `entry`=4879;
+
+        -- Zulrg
+        UPDATE `creature_template`
+        SET `display_id1`=1120
+        WHERE `entry`=4884;
+
+        -- Draz'lib
+        UPDATE `creature_template`
+        SET `display_id1`=1120
+        WHERE `entry`=4501;
+
+        -- Overlord Mok
+        UPDATE `creature_template`
+        SET `display_id1`=3193
+        WHERE `entry`=4500;
+
+        -- Nazeer
+        UPDATE `creature_template`
+        SET `display_id1`=1139
+        WHERE `entry`=4791;
+
+        -- Firemane Lash tail
+        UPDATE `creature_template`
+        SET `display_id1`=143
+        WHERE `entry`=4331;
+
+        -- Firemane Scalebane
+        UPDATE `creature_template`
+        SET `display_id1`=143
+        WHERE `entry`=4328;
+
+        -- Firemane Flamecaller
+        UPDATE `creature_template`
+        SET `display_id1`=143
+        WHERE `entry`=4334;
+
+        -- Giant Darkfang Spider
+        UPDATE `creature_template`
+        SET `display_id1`=2546
+        WHERE `entry`=4415;
+
+        -- Mirefin Coastrunner
+        UPDATE `creature_template`
+        SET `display_id1`=478
+        WHERE `entry`=4362;
+
+        -- Mirefin Oracle
+        UPDATE `creature_template`
+        SET `display_id1`=478
+        WHERE `entry`=4363;
+
+        -- Mirefin warrior
+        UPDATE `creature_template`
+        SET `display_id1`=478
+        WHERE `entry`=4360;
+
+        -- Murdrock Turtoise
+        UPDATE `creature_template`
+        SET `display_id1`=2307
+        WHERE `entry`=4396;
+
+        -- Murdrock Spikeshell
+        UPDATE `creature_template`
+        SET `display_id1`=2308
+        WHERE `entry`=4397;
+
+        -- Acidic Swamp Ooze
+        UPDATE `creature_template`
+        SET `display_id1`=1145
+        WHERE `entry`=4393;
+
+        insert into applied_updates values ('210820222');
+    end if;
 end $
 delimiter ;


### PR DESCRIPTION
Dustwallow
========

Murlocs
-------
![mai2004-27](https://user-images.githubusercontent.com/72315006/185771268-4cb29cbe-51cf-4605-af20-3f9e22370a4d.jpg)

As we can see, there are all violets. Most of them already use the right display_id, we apply the same on others.

Horde Village
--------
![848](https://user-images.githubusercontent.com/72315006/185771282-e0c9ee6b-e209-44f3-bb82-2315b603168d.jpg)

We spawn 2 trainers and we change Ogre NPC display_id to the same trainers use. We also change Nazeer (orc) display_id with 1139 placeholder (like Gromgol).

Turtle
-----

Only one colors for 0.5.3, we use 2 differents scale (1 & 1.2) for 2 turtles types here.

Firemane
-----
![143](https://user-images.githubusercontent.com/72315006/185771310-90e270cd-a97a-4b88-b1d3-3c1e6fd41d5b.png)

There is no female models for those mobs, most of them already use correct display_id, we apply it on those whose miss it.


Misc
-----
Giant Darkfang spider miss his display_id, we choose same models as Darkfang spider, but with a bigger scale.
Acidic Swamp ooze miss his display_id, we use same as vanilla.