### PR TITLE
West Plague Improvements

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -598,5 +598,82 @@ begin not atomic
 
         insert into applied_updates values ('210820222');
     end if;
+
+    -- 22/08/2022 3
+    if (select count(*) from applied_updates where id='220820223') = 0 then
+        -- WEST PLAGUE
+
+        -- Freezing Ghoul
+        UPDATE `creature_template`
+        SET `display_id1`=547
+        WHERE `entry`=1796;
+        
+        -- Skeletal Sorcerer
+        UPDATE `creature_template`
+        SET `display_id1`=200
+        WHERE `entry`=1784;
+        
+        -- High Priest Thel'danis
+        UPDATE `creature_template`
+        SET `display_id1`=2192
+        WHERE `entry`=1854;
+        
+        -- Skeletal Executionner
+        UPDATE `creature_template`
+        SET `display_id1`=200
+        WHERE `entry`=1787;
+        
+        -- Skeletal Acolyte
+        UPDATE `creature_template`
+        SET `display_id1`=200
+        WHERE `entry`=1789;
+        
+        -- Soulless Ghoul
+        UPDATE `creature_template`
+        SET `display_id1`=519
+        WHERE `entry`=1794;
+        
+        -- Putridus
+        UPDATE `creature_template`
+        SET `display_id1`=1693
+        WHERE `entry`=1850;
+        
+        -- Rotting Cadaver
+        UPDATE `creature_template`
+        SET `display_id1`=1197
+        WHERE `entry`=4474;
+        
+        -- Blighted Zombie
+        UPDATE `creature_template`
+        SET `display_id1`=1198, `display_id2`=0
+        WHERE `entry`=4475;
+        
+        -- Skeletal Terror
+        UPDATE `creature_template`
+        SET `display_id1`=200
+        WHERE `entry`=1785;
+        
+        -- Hungering Wraith
+        UPDATE `creature_template`
+        SET `display_id1`=146
+        WHERE `entry`=1802;
+        
+        -- Wailing Death
+        UPDATE `creature_template`
+        SET `display_id1`=915
+        WHERE `entry`=1804;
+        
+        -- Rotting Behemoth
+        UPDATE `creature_template`
+        SET `display_id1`=631
+        WHERE `entry`=1812;
+        
+        -- Devoring Hooze
+        UPDATE `creature_template`
+        SET `display_id1`=682
+        WHERE `entry`=1808;
+
+        insert into applied_updates values ('220820223');
+    end if;
 end $
 delimiter ;


### PR DESCRIPTION
West Plagueland
============

High Priest Thel'danis
----
![546](https://user-images.githubusercontent.com/72315006/185814462-cc2b4869-eed5-4d2f-80d2-32eaa3c6baec.jpg)

Skeletal
----

There is no "only bones" models, so we use Skeletal placeholder with 1.0 scale  for all of them whose missing display_id.

Ooze
----

Devoring ooze miss display_id

![Capture d’écran_2022-08-22_01-03-15](https://user-images.githubusercontent.com/72315006/185814540-8f16ab63-025d-43ff-8e10-ee45dac7242f.png)

Ooze next to Devoring Ooze use 681, so we use 682 (it's also same color as vanilla)

Putridus
----

There is only one color for 0.5.3, we use 1.2 scale
![1693](https://user-images.githubusercontent.com/72315006/185814570-1fd2f009-8a5a-406d-be75-e7cd10e96c4e.png)

Misc
-----

Since models are already presents in 0.5.3, we will use same models as vanilla for them

4474 Rotting Cadaver
4475 Blighted Zombie 
1802 Hungering Wraith
1804 Wailing Death (as we saw in Ashenvale, I choose Banshee, but it's also can be Ghost)
1912 Rotting Behemoth
1794 Soulless Ghoul