### PR TITLE
/ Fixes

### DIFF
--- a/game/world/managers/objects/gameobjects/RitualManager.py
+++ b/game/world/managers/objects/gameobjects/RitualManager.py
@@ -52,6 +52,7 @@ class RitualManager(object):
         player_mgr.spell_manager.remove_colliding_casts(spell)
         player_mgr.spell_manager.casting_spells.append(spell)
         player_mgr.spell_manager.handle_channel_start(spell)
+        player_mgr.set_channel_object(self.ritual_object.guid)
         self.ritual_participants.append(player_mgr)
 
         # Check if the ritual can be completed with the current participants.
@@ -76,6 +77,7 @@ class RitualManager(object):
         # If a participant interrupts their channeling, remove from participants and interrupt summoning if necessary.
         elif caster in self.ritual_participants:
             self.ritual_participants.remove(caster)
+            caster.flush_channel_fields()
             if not self.meets_participants():
                 self.ritual_object.summoner.spell_manager.remove_cast_by_id(self.ritual_summon_spell_id)
 

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -1245,6 +1245,10 @@ class UnitManager(ObjectManager):
         self.set_uint32(UnitFields.UNIT_FIELD_DISPLAYID, self.current_display_id)
         return True
 
+    def flush_channel_fields(self):
+        self.set_channel_object(0)
+        self.set_channel_spell(0)
+
     def set_channel_object(self, guid):
         self.channel_object = guid
         self.set_uint64(UnitFields.UNIT_FIELD_CHANNEL_OBJECT, guid)


### PR DESCRIPTION
/ Fix spell animations (Shadow bolt, mining, ritual of summoning, etc.)
/ Fix spell interrupt missing packet. (This also halts spell animations for surrounding observers)
/ Fix players not being able to use ritual of summoning again after interrupting their channeling.
/ Does not solve #610, that probably requires DynamicObject implementation.