### PR TITLE
Trainers & Others.

### DIFF
--- a/database/dbc/DbcDatabaseManager.py
+++ b/database/dbc/DbcDatabaseManager.py
@@ -242,10 +242,19 @@ class DbcDatabaseManager:
 
     class SkillLineAbilityHolder:
         SKILL_LINE_ABILITIES = defaultdict(list)
+        SKILL_LINE_PRECEDED = dict()
 
         @staticmethod
         def load_skill_line_ability(skill_line_ability):
             DbcDatabaseManager.SkillLineAbilityHolder.SKILL_LINE_ABILITIES[skill_line_ability.Spell].append(skill_line_ability)
+            if skill_line_ability.SupercededBySpell:
+                DbcDatabaseManager.SkillLineAbilityHolder.SKILL_LINE_PRECEDED[skill_line_ability.SupercededBySpell] = skill_line_ability
+
+        @staticmethod
+        def skill_line_abilities_get_preceded_by_spell(spell_id) -> Optional[SkillLineAbility]:
+            if spell_id in DbcDatabaseManager.SkillLineAbilityHolder.SKILL_LINE_PRECEDED:
+                return DbcDatabaseManager.SkillLineAbilityHolder.SKILL_LINE_PRECEDED[spell_id]
+            return None
 
         @staticmethod
         def skill_line_abilities_get_by_spell(spell_id) -> list:

--- a/database/dbc/DbcModels.py
+++ b/database/dbc/DbcModels.py
@@ -704,7 +704,6 @@ class SkillLineAbility(Base):
     TrivialSkillLineRankHigh = Column(INTEGER(11), nullable=False, server_default=text("'0'"))
     TrivialSkillLineRankLow = Column(INTEGER(11), nullable=False, server_default=text("'0'"))
     Abandonable = Column(INTEGER(11), nullable=False, server_default=text("'0'"))
-    custom_PrecededBySpell = Column(INTEGER(11), nullable=False, server_default=text("'0'"))
 
 
 class SoundEntry(Base):

--- a/etc/databases/dbc/updates/updates.sql
+++ b/etc/databases/dbc/updates/updates.sql
@@ -2,17 +2,7 @@ CREATE TABLE IF NOT EXISTS `applied_updates` (`id` varchar(9) NOT NULL DEFAULT '
 
 delimiter $
 begin not atomic
-    -- 09/02/2021 1
-    if (select count(*) from applied_updates where id='090220211') = 0 then
-        alter table SkillLineAbility add column custom_PrecededBySpell int(11) not null default 0;
-        
-        UPDATE SkillLineAbility t1
-        INNER JOIN SkillLineAbility t2 ON t2.SupercededBySpell = t1.Spell
-        SET t1.custom_PrecededBySpell = t2.Spell;
 
-        insert into applied_updates values ('090220211');
-    end if;
-	
 	-- 04/07/2021 1
 	if (select count(*) from applied_updates where id='040720211') = 0 then
         ALTER TABLE `TaxiNodes`

--- a/game/world/managers/objects/gameobjects/GameObjectBuilder.py
+++ b/game/world/managers/objects/gameobjects/GameObjectBuilder.py
@@ -1,7 +1,6 @@
 from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.managers.objects.gameobjects.GameObjectManager import GameObjectManager
 from game.world.managers.objects.guids.GuidManager import GuidManager
-from utils.constants.MiscCodes import GameObjectStates
 from utils.constants.MiscFlags import GameObjectFlags
 
 

--- a/game/world/managers/objects/locks/LockManager.py
+++ b/game/world/managers/objects/locks/LockManager.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 
 from database.dbc.DbcDatabaseManager import DbcDatabaseManager
-from game.world.managers.objects.ObjectManager import ObjectManager
 from game.world.managers.objects.units.player.SkillManager import SkillTypes
 from utils.constants.MiscCodes import LockKeyTypes, LockType, ObjectTypeIds
 from utils.constants.SpellCodes import SpellCheckCastResult

--- a/game/world/managers/objects/spell/CooldownEntry.py
+++ b/game/world/managers/objects/spell/CooldownEntry.py
@@ -7,11 +7,16 @@ class CooldownEntry:
     cooldown_length: int
     end_timestamp: int
     locked: bool
+    cooldown_penalty: int
 
-    def __init__(self, spell_entry, timestamp, locked=False):
+    def __init__(self, spell_entry, timestamp, locked=False, cooldown_penalty=0):
         self.spell_id = spell_entry.ID
-        self.cooldown_category = spell_entry.Category if spell_entry.CategoryRecoveryTime > 0 else -1  # If category cd isn't provided, set to invalid category
+        self.cooldown_penalty = cooldown_penalty
+        # If category cd isn't provided, set to invalid category.
+        self.cooldown_category = spell_entry.Category if spell_entry.CategoryRecoveryTime > 0 else -1
         self.cooldown_length = spell_entry.CategoryRecoveryTime if self.cooldown_category != -1 else spell_entry.RecoveryTime
+        # Either use normal recovery time or provided penalty.
+        self.cooldown_length = cooldown_penalty if cooldown_penalty else self.cooldown_length
         self.end_timestamp = timestamp + self.cooldown_length / 1000
         self.locked = locked
 

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -12,7 +12,6 @@ from game.world.managers.objects.spell.SpellEffectHandler import SpellEffectHand
 from utils.Logger import Logger
 from utils.constants.MiscCodes import ObjectTypeFlags, ObjectTypeIds
 from utils.constants.SpellCodes import SpellImplicitTargets, SpellMissReason, SpellEffects
-from utils.constants.UpdateFields import UnitFields
 
 
 @dataclass

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -584,11 +584,7 @@ class SpellEffectHandler:
         if not target.is_alive:
             return
 
-        target_spell = target.spell_manager.get_casting_spell()
-        if not target_spell:
-            return
-
-        target.spell_manager.interrupt_cast(target_spell, cooldown_penalty=casting_spell.get_duration())
+        target.spell_manager.interrupt_casting_spell(cooldown_penalty=casting_spell.get_duration())
 
     @staticmethod
     def handle_stuck(casting_spell, effect, caster, target):

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -8,7 +8,6 @@ from game.world.managers.maps.MapManager import MapManager
 from game.world.managers.objects.ObjectManager import ObjectManager
 from game.world.managers.objects.dynamic.DynamicObjectManager import DynamicObjectManager
 from game.world.managers.objects.gameobjects.GameObjectBuilder import GameObjectBuilder
-from game.world.managers.objects.gameobjects.GameObjectManager import GameObjectManager
 from game.world.managers.objects.locks.LockManager import LockManager
 from game.world.managers.objects.spell import SpellEffectDummyHandler
 from game.world.managers.objects.spell.aura.AuraManager import AppliedAura
@@ -20,7 +19,7 @@ from utils.Formulas import UnitFormulas
 from utils.Logger import Logger
 from utils.constants import CustomCodes
 from utils.constants.ItemCodes import EnchantmentSlots, InventoryError, ItemClasses
-from utils.constants.MiscCodes import ObjectTypeFlags, HighGuid, ObjectTypeIds, AttackTypes, DynamicObjectTypes, \
+from utils.constants.MiscCodes import ObjectTypeFlags, HighGuid, ObjectTypeIds, AttackTypes, \
     GameObjectStates
 from utils.constants.SpellCodes import AuraTypes, SpellEffects, SpellState, SpellTargetMask, \
     SpellImmunity

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -18,7 +18,6 @@ from game.world.managers.objects.spell.CooldownEntry import CooldownEntry
 from game.world.managers.objects.spell.SpellEffectHandler import SpellEffectHandler
 from game.world.managers.objects.units.DamageInfoHolder import DamageInfoHolder
 from game.world.managers.objects.units.player.EnchantmentManager import EnchantmentManager
-from game.world.managers.objects.units.player.SkillManager import SkillTypes
 from network.packet.PacketWriter import PacketWriter, OpCode
 from utils.Logger import Logger
 from utils.constants.ItemCodes import InventoryError, ItemSubClasses, ItemClasses, ItemDynFlags

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -117,7 +117,7 @@ class SpellManager:
         for spell_id in self.spells.keys():
             # Skip inactive spells.
             if not self.spells[spell_id].active:
-                return
+                continue
             spell_template = DbcDatabaseManager.SpellHolder.spell_get_by_id(spell_id)
 
             # Shapeshift passives are only applied on shapeshift change.
@@ -132,7 +132,7 @@ class SpellManager:
         for spell_id in self.spells.keys():
             # Skip inactive spells.
             if not self.spells[spell_id].active:
-                return
+                continue
             spell_template = DbcDatabaseManager.SpellHolder.spell_get_by_id(spell_id)
             if spell_template and spell_template.AttributesEx & SpellAttributesEx.SPELL_ATTR_EX_CAST_WHEN_LEARNED:
                 self.start_spell_cast(spell_template, self.caster, SpellTargetMask.SELF)
@@ -150,7 +150,7 @@ class SpellManager:
         for spell_id in self.spells.keys():
             # Skip inactive spells.
             if not self.spells[spell_id].active:
-                return
+                continue
             spell_template = DbcDatabaseManager.SpellHolder.spell_get_by_id(spell_id)
             req_form = spell_template.ShapeshiftMask
             if not req_form or not spell_template.Attributes & SpellAttributes.SPELL_ATTR_PASSIVE:

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -475,7 +475,11 @@ class SpellManager:
 
     # TODO: called by SPELL_EFFECT_INTERRUPT_CAST.
     #  The given spell should be set on a cooldown equal to cooldown_penalty value.
-    def interrupt_cast_by_casting_spell(self, casting_spell, cooldown_penalty=0):
+    def interrupt_casting_spell(self, cooldown_penalty=0):
+        casting_spell = self.get_casting_spell()
+        if not casting_spell:
+            return
+
         self.remove_cast(casting_spell, cast_result=SpellCheckCastResult.SPELL_FAILED_INTERRUPTED, interrupted=True)
 
     def remove_cast(self, casting_spell, cast_result=SpellCheckCastResult.SPELL_NO_ERROR, interrupted=False) -> bool:

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -305,7 +305,8 @@ class AuraManager:
         AuraEffectHandler.handle_aura_effect_change(aura, aura.target, remove=True)
         if not self.active_auras.pop(aura.index, None):
             return
-        # Some area effect auras (paladin auras, tranq etc.) are tied to spell effects. Cancel cast on aura cancel, canceling the auras as well.
+        # Some area effect auras (paladin auras, tranq etc.) are tied to spell effects.
+        # Cancel cast on aura cancel, canceling the auras as well.
         self.unit_mgr.spell_manager.remove_cast(aura.source_spell, interrupted=canceled)
 
         # Some spells start cooldown on aura remove, handle that case here.

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -11,7 +11,6 @@ from game.world.managers.maps.MapManager import MapManager
 from game.world.managers.objects.ObjectManager import ObjectManager
 from game.world.managers.objects.item.ItemManager import ItemManager
 from game.world.managers.objects.spell.aura.AuraManager import AuraManager
-from game.world.managers.objects.spell.SpellManager import SpellManager
 from game.world.managers.objects.units.DamageInfoHolder import DamageInfoHolder
 from game.world.managers.objects.units.MovementManager import MovementManager
 from game.world.managers.objects.units.player.StatManager import StatManager, UnitStats

--- a/game/world/managers/objects/units/creature/utils/TrainerUtils.py
+++ b/game/world/managers/objects/units/creature/utils/TrainerUtils.py
@@ -59,7 +59,7 @@ class TrainerUtils:
             if player_spell_id in player_mgr.spell_manager.spells:
                 status = TrainerServices.TRAINER_SERVICE_USED
             else:
-                if preceded_spell and preceded_spell not in player_mgr.spell_manager.spells and player_mgr.level >= spell.BaseLevel:
+                if preceded_spell and preceded_spell not in player_mgr.spell_manager.spells:
                     status = TrainerServices.TRAINER_SERVICE_UNAVAILABLE
                 elif not fulfill_skill_reqs:
                     status = TrainerServices.TRAINER_SERVICE_UNAVAILABLE

--- a/game/world/managers/objects/units/player/DuelManager.py
+++ b/game/world/managers/objects/units/player/DuelManager.py
@@ -4,8 +4,7 @@ from game.world.managers.maps.MapManager import MapManager
 from network.packet.PacketWriter import PacketWriter, OpCode
 from utils.constants.DuelCodes import *
 from utils.constants.MiscCodes import ObjectTypeIds
-from utils.constants.UnitCodes import UnitFlags
-from utils.constants.UpdateFields import PlayerFields, UnitFields
+from utils.constants.UpdateFields import PlayerFields
 
 
 class PlayerDuelInformation(object):

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -37,7 +37,7 @@ from utils.constants.ItemCodes import InventoryTypes
 from utils.constants.MiscCodes import ChatFlags, LootTypes, LiquidTypes, MountResults, DismountResults
 from utils.constants.MiscCodes import ObjectTypeFlags, ObjectTypeIds, PlayerFlags, WhoPartyStatus, HighGuid, \
     AttackTypes, MoveFlags
-from utils.constants.SpellCodes import SpellSchools, SpellTargetMask
+from utils.constants.SpellCodes import SpellTargetMask
 from utils.constants.UnitCodes import Classes, PowerTypes, Races, Genders, UnitFlags, Teams, SplineFlags, \
     RegenStatsFlags
 from utils.constants.UpdateFields import *

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -166,6 +166,13 @@ class SkillTypes(IntEnum):
     FISHING = 0x164
 
 
+class SkillLineType(IntEnum):
+    Primary = 0,
+    Racial = 2,
+    Talents = 3,
+    Secondary = 4
+
+
 class LanguageDesc(NamedTuple):
     lang_id: int
     spell_id: int

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -5,7 +5,7 @@ from struct import pack, unpack
 
 from database.world.WorldDatabaseManager import WorldDatabaseManager, config
 from game.world.managers.objects.units.player.EnchantmentManager import EnchantmentManager
-from game.world.managers.objects.units.player.SkillManager import SkillTypes, SkillManager
+from game.world.managers.objects.units.player.SkillManager import SkillTypes
 from utils.Formulas import UnitFormulas
 from utils.Logger import Logger
 from utils.constants.ItemCodes import InventorySlots, InventoryStats, ItemSubClasses, ItemEnchantmentType

--- a/game/world/managers/objects/units/player/TalentManager.py
+++ b/game/world/managers/objects/units/player/TalentManager.py
@@ -8,10 +8,6 @@ from network.packet.PacketWriter import PacketWriter, OpCode
 from utils.constants.MiscCodes import TrainerServices, TrainerTypes
 from utils.constants.SpellCodes import SpellEffects
 
-TALENT_SKILL_ID = 3
-# Weapon, Attribute, Slayer, Magic, Defensive
-SKILL_LINE_TALENT_IDS: list[int] = [222, 230, 231, 233, 234]
-
 
 class TalentManager(object):
     def __init__(self, player_mgr):

--- a/game/world/managers/objects/units/player/TalentManager.py
+++ b/game/world/managers/objects/units/player/TalentManager.py
@@ -6,7 +6,7 @@ from database.dbc.DbcDatabaseManager import DbcDatabaseManager
 from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.managers.objects.units.creature.utils.TrainerUtils import TrainerUtils
 from network.packet.PacketWriter import PacketWriter, OpCode
-from utils.constants.MiscCodes import TrainerServices, TrainerTypes
+from utils.constants.MiscCodes import TrainerTypes
 from utils.constants.SpellCodes import SpellEffects
 
 

--- a/game/world/managers/objects/units/player/TalentManager.py
+++ b/game/world/managers/objects/units/player/TalentManager.py
@@ -33,7 +33,6 @@ class TalentManager(object):
             if not spell:
                 continue
 
-            spell_rank: int = DbcDatabaseManager.SpellHolder.spell_get_rank_by_spell(spell)
             skill_line_ability = DbcDatabaseManager.SkillLineAbilityHolder.skill_line_ability_get_by_spell_for_player(
                 spell.ID, self.player_mgr)
 
@@ -61,9 +60,9 @@ class TalentManager(object):
             if spell.ID in self.player_mgr.spell_manager.spells:
                 status = TrainerServices.TRAINER_SERVICE_USED
             else:
-                if preceded_spell in self.player_mgr.spell_manager.spells and spell_rank > 1:
-                    status = TrainerServices.TRAINER_SERVICE_AVAILABLE
-                elif spell_rank == 1:
+                if preceded_spell and preceded_spell not in self.player_mgr.spell_manager.spells:
+                    status = TrainerServices.TRAINER_SERVICE_UNAVAILABLE
+                elif self.player_mgr.level >= spell.BaseLevel:
                     status = TrainerServices.TRAINER_SERVICE_AVAILABLE
                 else:
                     status = TrainerServices.TRAINER_SERVICE_UNAVAILABLE

--- a/game/world/managers/objects/units/player/guild/PetitionManager.py
+++ b/game/world/managers/objects/units/player/guild/PetitionManager.py
@@ -2,7 +2,6 @@ from struct import pack
 
 from database.realm.RealmDatabaseManager import RealmDatabaseManager
 from database.realm.RealmModels import Petition
-from game.world.managers.objects.units.player.EnchantmentManager import EnchantmentManager
 from game.world.managers.objects.units.player.guild.GuildManager import GuildManager
 from network.packet.PacketWriter import PacketWriter, OpCode
 from utils.constants.ItemCodes import PetitionError

--- a/game/world/opcode_handling/handlers/friends/FriendAddHandler.py
+++ b/game/world/opcode_handling/handlers/friends/FriendAddHandler.py
@@ -1,10 +1,4 @@
-from database.realm.RealmDatabaseManager import RealmDatabaseManager
-from game.world.WorldSessionStateHandler import WorldSessionStateHandler
-from game.world.managers.objects.units.player.FriendsManager import FriendsManager
-from game.world.managers.objects.units.player.PlayerManager import PlayerManager
 from network.packet.PacketReader import *
-from network.packet.PacketWriter import *
-from utils.constants.MiscCodes import FriendResults
 
 
 class FriendAddHandler(object):

--- a/game/world/opcode_handling/handlers/friends/FriendDeleteHandler.py
+++ b/game/world/opcode_handling/handlers/friends/FriendDeleteHandler.py
@@ -1,6 +1,4 @@
 from network.packet.PacketReader import *
-from network.packet.PacketWriter import *
-from utils.constants.MiscCodes import FriendResults
 
 
 class FriendDeleteHandler(object):

--- a/game/world/opcode_handling/handlers/friends/FriendDeleteIgnoreHandler.py
+++ b/game/world/opcode_handling/handlers/friends/FriendDeleteIgnoreHandler.py
@@ -1,6 +1,4 @@
 from network.packet.PacketReader import *
-from network.packet.PacketWriter import *
-from utils.constants.MiscCodes import FriendResults
 
 
 class FriendDeleteIgnoreHandler(object):

--- a/game/world/opcode_handling/handlers/friends/FriendIgnoreHandler.py
+++ b/game/world/opcode_handling/handlers/friends/FriendIgnoreHandler.py
@@ -1,8 +1,4 @@
-from database.realm.RealmDatabaseManager import RealmDatabaseManager
-from game.world.WorldSessionStateHandler import WorldSessionStateHandler
 from network.packet.PacketReader import *
-from network.packet.PacketWriter import *
-from utils.constants.MiscCodes import FriendResults
 
 
 class FriendIgnoreHandler(object):

--- a/game/world/opcode_handling/handlers/gameobject/GameObjectQueryHandler.py
+++ b/game/world/opcode_handling/handlers/gameobject/GameObjectQueryHandler.py
@@ -2,7 +2,6 @@ from struct import unpack
 
 from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.managers.maps.MapManager import MapManager
-from game.world.managers.objects.gameobjects.GameObjectManager import GameObjectManager
 from game.world.managers.objects.gameobjects.utils.GoQueryUtils import GoQueryUtils
 
 

--- a/game/world/opcode_handling/handlers/interface/CharCreateHandler.py
+++ b/game/world/opcode_handling/handlers/interface/CharCreateHandler.py
@@ -3,7 +3,7 @@ from database.realm.RealmDatabaseManager import *
 from database.world.WorldDatabaseManager import *
 from game.world.managers.objects.item.ItemManager import ItemManager
 from game.world.managers.objects.units.player.ReputationManager import ReputationManager
-from game.world.managers.objects.units.player.SkillManager import SkillManager
+from game.world.managers.objects.units.player.SkillManager import SkillManager, SkillLineType
 from network.packet.PacketReader import *
 from network.packet.PacketWriter import *
 from utils import TextUtils
@@ -79,6 +79,7 @@ class CharCreateHandler(object):
             CharCreateHandler.generate_starting_reputations(character.guid)
             CharCreateHandler.generate_starting_spells(character.guid, race, class_, character.level)
             CharCreateHandler.generate_starting_spells_skills(character.guid, race, class_, character.level)
+            CharCreateHandler.generate_starting_talents_skills(character.guid)
             CharCreateHandler.generate_starting_items(character.guid, race, class_, gender)
             CharCreateHandler.generate_starting_buttons(character.guid, race, class_)
             CharCreateHandler.generate_starting_taxi_nodes(character, race)
@@ -169,6 +170,20 @@ class CharCreateHandler(object):
 
                 insert_skill(lang_desc.skill_id, override_rank_value=1, override_max_rank_value=1)
         """
+
+    @staticmethod
+    def generate_starting_talents_skills(guid):
+        # Weapon Talents, Attribute Enhancements, Slayer Talents, Magic Talents, Defensive Talents.
+        # TODO: Need further research, maybe each type of class started with access to specific talents.
+        #  Doesn't make sense to have Magic Talents available to melee classes etc.
+        for skill_id, skill in DbcDatabaseManager.SkillHolder.SKILLS.items():
+            if skill.SkillType == SkillLineType.Talents:
+                skill_to_set = CharacterSkill()
+                skill_to_set.guid = guid
+                skill_to_set.skill = skill_id
+                skill_to_set.value = skill.MaxRank
+                skill_to_set.max = skill.MaxRank
+                RealmDatabaseManager.character_add_skill(skill_to_set)
 
     @staticmethod
     def generate_starting_spells_skills(guid, race, class_, level):

--- a/game/world/opcode_handling/handlers/inventory/ItemQueryMultipleHandler.py
+++ b/game/world/opcode_handling/handlers/inventory/ItemQueryMultipleHandler.py
@@ -1,7 +1,6 @@
-from struct import unpack, pack
+from struct import unpack
 from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.managers.objects.item.ItemManager import ItemManager
-from network.packet.PacketWriter import PacketWriter, OpCode
 
 
 class ItemQueryMultipleHandler(object):

--- a/game/world/opcode_handling/handlers/inventory/OpenItemHandler.py
+++ b/game/world/opcode_handling/handlers/inventory/OpenItemHandler.py
@@ -2,10 +2,8 @@ from struct import unpack
 
 from database.dbc.DbcDatabaseManager import DbcDatabaseManager
 from database.realm.RealmDatabaseManager import RealmDatabaseManager
-from game.world.managers.objects.locks.LockManager import LockManager
 from utils.constants.ItemCodes import InventoryError, InventorySlots, ItemDynFlags
-from utils.constants.MiscCodes import LockType, HighGuid
-from utils.constants.SpellCodes import SpellCheckCastResult
+from utils.constants.MiscCodes import HighGuid
 from utils.constants.UnitCodes import UnitFlags
 
 

--- a/game/world/opcode_handling/handlers/npc/CreatureQueryHandler.py
+++ b/game/world/opcode_handling/handlers/npc/CreatureQueryHandler.py
@@ -2,7 +2,6 @@ from struct import unpack
 
 from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.managers.maps.MapManager import MapManager
-from game.world.managers.objects.units.creature.CreatureManager import CreatureManager
 from game.world.managers.objects.units.creature.utils.UnitQueryUtils import UnitQueryUtils
 
 

--- a/game/world/opcode_handling/handlers/npc/TrainerBuySpellHandler.py
+++ b/game/world/opcode_handling/handlers/npc/TrainerBuySpellHandler.py
@@ -1,3 +1,4 @@
+from database.dbc.DbcDatabaseManager import DbcDatabaseManager
 from game.world.managers.objects.units.creature.utils.TrainerUtils import TrainerUtils
 from game.world.opcode_handling.HandlerValidator import HandlerValidator
 from utils.constants.SpellCodes import SpellTargetMask
@@ -69,6 +70,12 @@ class TrainerBuySpellHandler(object):
                 break
 
         if not trainer_spell:
+            fail_reason = TrainingFailReasons.TRAIN_FAIL_UNAVAILABLE
+            TrainerBuySpellHandler.send_trainer_buy_fail(player_mgr, trainer_guid, training_spell_id, fail_reason)
+            return
+
+        player_spell = DbcDatabaseManager.SpellHolder.spell_get_by_id(trainer_spell.playerspell)
+        if not player_spell:
             fail_reason = TrainingFailReasons.TRAIN_FAIL_UNAVAILABLE
             TrainerBuySpellHandler.send_trainer_buy_fail(player_mgr, trainer_guid, training_spell_id, fail_reason)
             return

--- a/game/world/opcode_handling/handlers/player/PlayerLoginHandler.py
+++ b/game/world/opcode_handling/handlers/player/PlayerLoginHandler.py
@@ -1,5 +1,4 @@
 from game.world.managers.objects.units.player.guild.GuildManager import GuildManager
-from game.world.managers.objects.units.player.guild.PetitionManager import PetitionManager
 from network.packet.PacketReader import PacketReader
 import time
 from struct import unpack

--- a/game/world/opcode_handling/handlers/player/cheats/CooldownCheatHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/CooldownCheatHandler.py
@@ -19,8 +19,7 @@ class CooldownCheatHandler(object):
             return 0
 
         # Clear server-side cooldowns.
-        for cooldown_entry in list(player_mgr.spell_manager.cooldowns):
-            player_mgr.spell_manager.cooldowns.remove(cooldown_entry)
+        player_mgr.spell_manager.flush_cooldowns()
 
         # Clear client-side cooldowns.
         data = pack('<Q', player_mgr.guid)


### PR DESCRIPTION
- Deprecate custom_PrecededBySpell column.
- Deprecated use of spell_chain.
- Honor client dbc data when filling training lists packets.
- Send and validate required skill, min rank and step.
- Initialize talent related skills on all characters upon creation.
- Trainers code decoupling.
- Spells that are preceded by another spell will now trigger SMSG_SUPERCEDED_SPELL. (Some spells allow for holding multiple ranks, others do not and must be removed upon learning a new rank)
- Counterspell now properly works. (On players)
- Fixes crash with SPELL_EFFECT_INTERRUPT_CAST.