### PR TITLE
General database improvements #638 #639 #642

### DIFF
--- a/database/world/WorldModels.py
+++ b/database/world/WorldModels.py
@@ -435,7 +435,7 @@ class AppliedItemUpdates(Base):
 
 
 class AreatriggerInvolvedrelation(Base):
-    __tablename__ = 'areatrigger_involvedrelation'
+    __tablename__ = 'areatrigger_quest_relation'
     __table_args__ = {'comment': 'Trigger System'}
 
     id = Column(MEDIUMINT(8), primary_key=True, server_default=text("0"), comment='Identifier')
@@ -818,14 +818,14 @@ t_creature_quest_finisher = Table(
 
 
 t_gameobject_quest_starter = Table(
-    'gameobject_questrelation', metadata,
+    'gameobject_quest_starter', metadata,
     Column('entry', ForeignKey('gameobject_template.entry', ondelete='CASCADE', onupdate='CASCADE'), primary_key=True, nullable=False, server_default=text("'0'"), comment='Identifier'),
     Column('quest', ForeignKey('quest_template.entry', ondelete='CASCADE', onupdate='CASCADE'), primary_key=True, nullable=False, index=True, server_default=text("'0'"), comment='Quest Identifier')
 )
 
 
 t_gameobject_quest_finisher = Table(
-    'gameobject_involvedrelation', metadata,
+    'gameobject_quest_finisher', metadata,
     Column('entry', ForeignKey('creature_template.entry', ondelete='CASCADE', onupdate='CASCADE'), primary_key=True, nullable=False, server_default=text("'0'"), comment='Identifier'),
     Column('quest', ForeignKey('quest_template.entry', ondelete='CASCADE', onupdate='CASCADE'), primary_key=True, nullable=False, index=True, server_default=text("'0'"), comment='Quest Identifier')
 )

--- a/etc/databases/dbc/updates/updates.sql
+++ b/etc/databases/dbc/updates/updates.sql
@@ -857,6 +857,7 @@ begin not atomic
 
     -- 21/08/2022 1
     if (select count(*) from applied_updates where id='210820221') = 0 then
+        DROP TABLE IF EXISTS `SpellIcon`;
         CREATE TABLE `SpellIcon` ( `ID` INT NOT NULL DEFAULT '0', `TextureFilename` TEXT NULL, PRIMARY KEY (`ID`)) ENGINE=MyISAM DEFAULT CHARSET=utf8;
         INSERT INTO `SpellIcon` VALUES (1,"Interface\\Icons\\Temp");
         INSERT INTO `SpellIcon` VALUES (9,"Interface\\Icons\\Spell_Shadow_BlackPlague");

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -12562,5 +12562,15 @@ begin not atomic
 
         insert into applied_updates values ('150920221');
     end if;
+
+    -- 17/09/2022 1
+    if (select count(*) from applied_updates where id='170920221') = 0 then
+        -- #642
+        RENAME TABLE `gameobject_involvedrelation` TO `gameobject_quest_finisher`;
+        RENAME TABLE `gameobject_questrelation` TO `gameobject_quest_starter`;
+        RENAME TABLE `areatrigger_involvedrelation` TO `areatrigger_quest_relation`;
+       
+        insert into applied_updates values ('170920221');
+    end if;
 end $
 delimiter ;


### PR DESCRIPTION
- Drop the `applied_updates` table when creating a new DBC database.
- Fix to allow recreation of DBC database without first dropping it.

- Rename `gameobject_involvedrelation` to `gameobject_quest_finisher`
- Rename `gameobject_questrelation` to `gameobject_quest_starter`
- Rename `areatrigger_involvedrelation` to `areatrigger_quest_relation`
- Updated python models to reflect database changes