### PR TITLE
Some fixes/tweaks.

### DIFF
--- a/game/world/managers/objects/spell/ExtendedSpellData.py
+++ b/game/world/managers/objects/spell/ExtendedSpellData.py
@@ -212,17 +212,18 @@ class UnitSpellsValidator:
     # TODO: For further investigation:
     #  https://github.com/The-Alpha-Project/alpha-core/issues/655
     #  https://github.com/The-Alpha-Project/alpha-core/issues/383
-    #  Spells pre cast kits that cause the client to crash.
+    #  Spells that crashes the client upon cast.
     #  Might be that these spells were not used in alpha.
-    #  e.g. Frost Breath, Glacial Roar, crashes both on Unit and Player cast. (Player cast does not even reach server).
-    _INVALID_PRECAST_KITS_ = {
-        703
+    #  e.g. Frost Breath, Glacial Roar, crashes both on Unit and Player. (Cast reaches server, crashes before reply)
+    _INVALID_PRECAST_SPELLS_ = {
+        3131,  # Frost Breath
+        3129,  # Frost Breath
+        3143,  # Glacial Roar
     }
 
     @staticmethod
-    def spell_has_invalid_precast_kit(casting_spell):
-        return casting_spell.spell_visual_entry and casting_spell.spell_visual_entry.PrecastKit not in \
-               UnitSpellsValidator._INVALID_PRECAST_KITS_
+    def spell_has_valid_cast(casting_spell):
+        return casting_spell.spell_entry.ID not in UnitSpellsValidator._INVALID_PRECAST_SPELLS_
 
 
 class SpellEffectMechanics:

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -659,11 +659,11 @@ class SpellManager:
         if not self.caster.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
             return  # Non-unit casters should not broadcast their casts.
 
+        is_player = self.caster.get_type_id() == ObjectTypeIds.ID_PLAYER
         # Validate if this spell crashes the client.
         # Force SpellCastFlags.CAST_FLAG_PROC, which hides the start cast.
-        if self.caster.get_type_id() == ObjectTypeIds.ID_UNIT and \
-                not ExtendedSpellData.UnitSpellsValidator.spell_has_invalid_precast_kit(casting_spell):
-            Logger.warning(f'Hiding spell {casting_spell.spell_entry.Name_enUS} start cast due invalid pre cast kit.')
+        if not is_player and not ExtendedSpellData.UnitSpellsValidator.spell_has_valid_cast(casting_spell):
+            Logger.warning(f'Hiding spell {casting_spell.spell_entry.Name_enUS} start cast due invalid cast.')
             casting_spell.cast_flags = SpellCastFlags.CAST_FLAG_PROC
 
         source_guid = casting_spell.initial_target.guid if casting_spell.initial_target_is_item() else self.caster.guid
@@ -685,7 +685,6 @@ class SpellManager:
             data.append(casting_spell.used_ranged_attack_item.item_template.inventory_type)
 
         # Spell start.
-        is_player = self.caster.get_type_id() == ObjectTypeIds.ID_PLAYER
         data = pack(signature, *data)
         packet = PacketWriter.get_packet(OpCode.SMSG_SPELL_START, data)
         MapManager.send_surrounding(packet, self.caster, include_self=is_player)

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -327,6 +327,8 @@ class CreatureManager(UnitManager):
         self.location = self.spawn_position.copy()
         # Restore original spawn face position.
         self.movement_manager.send_face_target(self)
+        # Scan surrounding for enemies.
+        self._on_relocation()
 
     def can_swim(self):
         return (self.static_flags & CreatureStaticFlags.AMPHIBIOUS) or (self.static_flags & CreatureStaticFlags.AQUATIC)
@@ -351,6 +353,10 @@ class CreatureManager(UnitManager):
     # override
     def leave_combat(self):
         super().leave_combat()
+
+        # Stop casts.
+        self.spell_manager.remove_casts()
+
         if not self.is_player_controlled_pet():
             self.evade()
 


### PR DESCRIPTION
- Closes #430
- Fixes non wandering mobs not scanning surroundings when reaching spawn position after evade.
- Minor tweaks to ThreatManager.
- Skip spell cast start by spell ID and not by pre cast kit, this was preventing other spells like Throw, which does not crash the client.
- Creatures will now stop casting upon leaving combat, this fixes lingering spell casting sound after a player died.