### PR TITLE
Fixes

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -14377,5 +14377,12 @@ begin not atomic
 
         insert into applied_updates values ('201020221');
     end if;
+	
+    -- 23/10/2022 1
+    if (select count(*) from applied_updates where id='231020221') = 0 then
+        -- Fix Sirens Call cooldown.
+        UPDATE `creature_spells` SET `delayRepeatMin_1` = '120', `delayRepeatMax_1` = '180' WHERE (`entry` = '21800');
+        insert into applied_updates values ('231020221');
+    end if;	
 end $
 delimiter ;

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -310,6 +310,8 @@ class CastingSpell:
     # TODO: need more checks.
     #  Refer to 'IsPositiveEffect' in SpellEntry.cpp - VMaNGOS
     def is_positive_spell(self):
+        if not self.initial_target_is_unit_or_player():
+            return False
         return not self.spell_caster.can_attack_target(self.initial_target)
 
     def get_charm_effect(self) -> Optional[SpellEffect]:

--- a/game/world/managers/objects/spell/ExtendedSpellData.py
+++ b/game/world/managers/objects/spell/ExtendedSpellData.py
@@ -210,15 +210,17 @@ class ProfessionInfo:
 
 class UnitSpellsValidator:
     # TODO: For further investigation:
+    #  Spells that crashes the client upon cast.
+    #  All client crashes end up at ModelHasSequenceId/AnimHasSequenceId.
     #  https://github.com/The-Alpha-Project/alpha-core/issues/655
     #  https://github.com/The-Alpha-Project/alpha-core/issues/383
-    #  Spells that crashes the client upon cast.
     #  Might be that these spells were not used in alpha.
     #  e.g. Frost Breath, Glacial Roar, crashes both on Unit and Player. (Cast reaches server, crashes before reply)
     _INVALID_PRECAST_SPELLS_ = {
         3131,  # Frost Breath
         3129,  # Frost Breath
         3143,  # Glacial Roar
+        7395  # Deadmines Dynamite
     }
 
     @staticmethod

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -770,6 +770,12 @@ class SpellManager:
         # The client expects the source to only be set for unit casters.
         source_unit = self.caster.guid if self.caster.get_type_mask() & ObjectTypeFlags.TYPE_UNIT else 0
 
+        # Spell cast sent with CAST_FLAG_PROC to avoid client crashing, set back to CAST_FLAG_NONE here.
+        # This allows spells like 'Deadmines Dynamite' to actually show an explosion and trigger an animation on caster.
+        if not ExtendedSpellData.UnitSpellsValidator.spell_has_valid_cast(casting_spell) and \
+                self.caster.get_type_id() == ObjectTypeIds.ID_UNIT:
+            casting_spell.cast_flags = SpellCastFlags.CAST_FLAG_NONE
+
         data = [self.caster.guid, source_unit,
                 casting_spell.spell_entry.ID, casting_spell.cast_flags]
 

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -978,8 +978,7 @@ class SpellManager:
         # Required nearby spell focus GO.
         spell_focus_type = casting_spell.spell_entry.RequiresSpellFocus
         if spell_focus_type:
-            surrounding_gos = [go for go in
-                               MapManager.get_surrounding_gameobjects(self.caster).values()]
+            surrounding_gos = [go for go in MapManager.get_surrounding_gameobjects(self.caster).values()]
 
             # Check if any nearby GO is the required spell focus.
             if not any([go.gobject_template.type == GameObjectTypes.TYPE_SPELL_FOCUS and
@@ -1022,7 +1021,6 @@ class SpellManager:
                     self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_NOT_BEHIND)
                 else:
                     self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_UNIT_NOT_INFRONT)
-
                 return False
 
         # Range validations. Skip for fishing as generated targets will always be valid.

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -297,14 +297,17 @@ class AuraEffectHandler:
 
     @staticmethod
     def handle_mod_charm(aura, effect_target, remove):
+        # Player target.
+        # TODO: Implement behavior for charmed players.
+        if effect_target.get_type_id() == ObjectTypeIds.ID_PLAYER:
+            effect_target.set_charmed_by(aura.caster, remove=remove)
+            return
+
+        # Creature.
         if remove:
             aura.caster.pet_manager.detach_active_pet()
             return
-
-        if effect_target.get_type_id() == ObjectTypeIds.ID_UNIT:
-            aura.caster.pet_manager.add_pet_from_world(effect_target, aura.spell_id)
-        elif effect_target.get_type_id == ObjectTypeIds.ID_PLAYER:
-            pass  # TODO: Implement behavior for charmed players.
+        aura.caster.pet_manager.add_pet_from_world(effect_target, aura.spell_id)
 
     @staticmethod
     def handle_taunt(aura, effect_target, remove):

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -226,6 +226,9 @@ class UnitManager(ObjectManager):
 
     # override
     def can_attack_target(self, target):
+        if not target:
+            return False
+
         is_enemy = super().can_attack_target(target)
         if is_enemy:
             return True

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1424,12 +1424,16 @@ class PlayerManager(UnitManager):
 
         return True  # TODO Stunned check
 
-    def set_charmed_by(self, charmer, subtype=CustomCodes.CreatureSubtype.SUBTYPE_GENERIC, movement_type=None, remove=False):
+    def set_charmed_by(self, charmer, subtype=0, movement_type=None, remove=False):
         # Charmer must be set here not in parent.
         self.charmer = charmer if not remove else None
-        # Restore faction.
+
         if remove:
+            # Restore faction.
             self.set_player_variables()
+        else:
+            # Charmer faction.
+            self.faction = charmer.faction
         super().set_charmed_by(charmer, subtype=subtype, remove=remove)
 
     # override


### PR DESCRIPTION
- Fix Sirens Call creature spell cooldown.
- Creature spells, use spell template target mask and use Vector for initial target for terrain when needed.
- Charm vs player, set unit fields and faction even if we're missing behavior.
- Closes #697 .