### PR TITLE
Stealth and others.

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -14435,6 +14435,13 @@ begin not atomic
 
         insert into applied_updates values ('281020222');
     end if;
-
+    
+    -- 03/11/2022 1
+    -- Fix QuickShot repeat delay to 60/70 secs.
+    if (select count(*) from applied_updates where id='031120221') = 0 then
+        UPDATE `creature_spells` SET `delayRepeatMin_1` = '60', `delayRepeatMax_1` = '70' WHERE (`entry` = '29510');
+        insert into applied_updates values ('281020222');
+    end if;
+        
 end $
 delimiter ;

--- a/game/world/WorldSessionStateHandler.py
+++ b/game/world/WorldSessionStateHandler.py
@@ -21,7 +21,7 @@ class WorldSessionStateHandler(object):
 
     @staticmethod
     def push_active_player_session(session):
-        lowercase_name = session.player_mgr.player.name.lower()
+        lowercase_name = session.player_mgr.get_name().lower()
 
         # This is filled upon player successful login (in-world).
         PLAYERS_BY_GUID[session.player_mgr.guid] = session.player_mgr
@@ -31,7 +31,7 @@ class WorldSessionStateHandler(object):
 
     @staticmethod
     def pop_active_player(player_mgr):
-        lowercase_name = player_mgr.player.name.lower()
+        lowercase_name = player_mgr.get_name().lower()
 
         # Flushed when player leaves the world.
         if lowercase_name in PLAYER_BY_NAME:
@@ -113,4 +113,4 @@ class WorldSessionStateHandler(object):
             player_mgr.pet_manager.save()
             player_mgr.quest_manager.save()
         except AttributeError as ae:
-            Logger.error(f'Error while saving {player_mgr.player.name} ({player_mgr.player.guid}) into db: {ae}.')
+            Logger.error(f'Error while saving {player_mgr.get_name()} ({player_mgr.player.guid}) into db: {ae}.')

--- a/game/world/managers/CommandManager.py
+++ b/game/world/managers/CommandManager.py
@@ -523,8 +523,7 @@ class CommandManager(object):
         result = ''
         if unit:
             flag_count = 0
-            name = unit.player.name if unit.get_type_id() == ObjectTypeIds.ID_PLAYER else unit.creature_template.name
-            result += f'Unit: {name}\n'
+            result += f'Unit: {unit.get_name()}\n'
             for flag in UnitFlags:
                 if unit.unit_flags & flag:
                     flag_count += 1
@@ -539,7 +538,7 @@ class CommandManager(object):
         creature = MapManager.get_surrounding_unit_by_guid(world_session.player_mgr,
                                                            world_session.player_mgr.current_selection)
         if creature:
-            return 0, f'[{creature.creature_template.name}]\n' \
+            return 0, f'[{creature.get_name()}]\n' \
                       f'Spawn ID: {creature.spawn_id}\n' \
                       f'Guid: {creature.get_low_guid()}\n' \
                       f'Entry: {creature.creature_template.entry}\n' \
@@ -558,7 +557,7 @@ class CommandManager(object):
         player_mgr = CommandManager._target_or_self(world_session, only_players=True)
 
         if player_mgr:
-            return 0, f'[{player_mgr.player.name}] - Guid: {player_mgr.get_low_guid()}\n' \
+            return 0, f'[{player_mgr.get_name()}] - Guid: {player_mgr.get_low_guid()}\n' \
                       f'Account ID: {player_mgr.session.account_mgr.account.id}\n' \
                       f'Account name: {player_mgr.session.account_mgr.account.name}'
         return -1, 'error retrieving player info.'
@@ -576,7 +575,7 @@ class CommandManager(object):
                 if distance <= max_distance:
                     found_count += 1
                     ChatManager.send_system_message(world_session,
-                                                    f'[{gobject.gobject_template.name}]\n'
+                                                    f'[{gobject.get_name()}]\n'
                                                     f'Spawn ID: {gobject.spawn_id}\n'
                                                     f'Guid: {gobject.get_low_guid()}\n'
                                                     f'Entry: {gobject.gobject_template.entry}\n'

--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -177,7 +177,7 @@ class GridManager:
     def send_surrounding(self, packet, world_object, include_self=True, exclude=None, use_ignore=False):
         if world_object.current_cell:
             for cell in self.get_surrounding_cells_by_object(world_object):
-                cell.send_all(packet, source=None if include_self else world_object, exclude=exclude, use_ignore=use_ignore)
+                cell.send_all(packet, world_object, include_source=include_self, exclude=exclude, use_ignore=use_ignore)
         # This player has no current cell, send the message directly.
         elif world_object.get_type_id() == ObjectTypeIds.ID_PLAYER and include_self:
             world_object.enqueue_packet(packet)

--- a/game/world/managers/objects/ObjectManager.py
+++ b/game/world/managers/objects/ObjectManager.py
@@ -151,6 +151,9 @@ class ObjectManager:
 
         return data
 
+    def get_name(self):
+        return ''
+
     def get_display_id(self):
         return self.current_display_id
 

--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -433,6 +433,10 @@ class GameObjectManager(ObjectManager):
         ]
 
     # override
+    def get_name(self):
+        return self.gobject_template.name
+
+    # override
     def get_type_mask(self):
         return super().get_type_mask() | ObjectTypeFlags.TYPE_GAMEOBJECT
 

--- a/game/world/managers/objects/gameobjects/managers/GooberManager.py
+++ b/game/world/managers/objects/gameobjects/managers/GooberManager.py
@@ -37,5 +37,5 @@ class GooberManager(object):
                 self.goober_object.destroy()
         else:
             entry = self.goober_object.entry
-            name = self.goober_object.gobject_template.name
+            name = self.goober_object.get_name()
             Logger.warning(f'Unimplemented gameobject use for type Goober entry {entry} name {name}')

--- a/game/world/managers/objects/gameobjects/managers/RitualManager.py
+++ b/game/world/managers/objects/gameobjects/managers/RitualManager.py
@@ -25,7 +25,7 @@ class RitualManager(object):
     def ritual_use(self, player_mgr):
         # Ritual should have a summoner.
         if not self.ritual_object.summoner:
-            Logger.warning(f'Player {player_mgr.player.name} tried to use Ritual with no summoner set.')
+            Logger.warning(f'Player {player_mgr.get_name()} tried to use Ritual with no summoner set.')
             player_mgr.spell_manager.send_cast_result(self.ritual_summon_spell_id,
                                                       SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS)
             return

--- a/game/world/managers/objects/item/ItemManager.py
+++ b/game/world/managers/objects/item/ItemManager.py
@@ -472,6 +472,10 @@ class ItemManager(ObjectManager):
             RealmDatabaseManager.character_inventory_update_item(self.item_instance)
 
     # override
+    def get_name(self):
+        return self.item_template.name
+
+    # override
     def get_type_mask(self):
         return super().get_type_mask() | ObjectTypeFlags.TYPE_ITEM
 

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -557,7 +557,7 @@ class SpellManager:
 
         # Send spell interrupted.
         if interrupted:
-            data = pack('<QI', self.caster.guid, casting_spell.spell_entry.ID)
+            data = pack('<QIB', self.caster.guid, casting_spell.spell_entry.ID, cast_result)
             packet = PacketWriter.get_packet(OpCode.SMSG_SPELL_FAILURE, data)
             MapManager.send_surrounding(packet, self.caster, include_self=True)
 

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -218,7 +218,7 @@ class SpellManager:
             spell = DbcDatabaseManager.SpellHolder.spell_get_by_id(spell_info.spell_id)
             if not spell:
                 Logger.warning(f'Spell {spell_info.spell_id} tied to item {item.item_template.entry} '
-                               f'({item.item_template.name}) could not be found in the spell database.')
+                               f'({item.get_name()}) could not be found in the spell database.')
                 continue
 
             casting_spell = self.try_initialize_spell(spell, spell_target, target_mask, item)

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -1156,9 +1156,14 @@ class SpellManager:
                 return False
 
         # Duel target check.
-        if casting_spell.is_duel_spell() and validation_target.duel_manager:
-            self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_TARGET_DUELING)
-            return False
+        if casting_spell.is_duel_spell():
+            if validation_target.duel_manager:
+                self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_TARGET_DUELING)
+                return False
+            if casting_spell.spell_caster.unit_flags & UnitFlags.UNIT_FLAG_SNEAK:
+                # There is no 'SPELL_FAILED_CANT_DUEL_WHILE_STEALTHED' in alpha, but this needs to be handled.
+                self.send_cast_result(casting_spell.spell_entry.ID, SpellCheckCastResult.SPELL_FAILED_ERROR)
+                return False
 
         # Lock/chest checks.
         if casting_spell.is_unlocking_spell():

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -112,10 +112,10 @@ class AuraManager:
         return True
 
     def check_aura_interrupts(self, moved=False, turned=False, changed_stand_state=False, negative_aura_applied=False,
-                              received_damage=False, cast_spell: Optional[CastingSpell] = None):
+                              received_damage=False, enter_combat=False, cast_spell: Optional[CastingSpell] = None):
         # Add once movement information is passed to update.
         flag_cases = {
-            SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_ENTER_COMBAT: self.unit_mgr.in_combat,
+            SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_ENTER_COMBAT: enter_combat,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NOT_MOUNTED: self.unit_mgr.unit_flags & UnitFlags.UNIT_MASK_MOUNTED,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_MOVE: moved,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_TURNING: turned,

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -271,9 +271,6 @@ class UnitManager(ObjectManager):
         if self.has_offhand_weapon():
             self.set_attack_timer(AttackTypes.OFFHAND_ATTACK, self.offhand_attack_time)
 
-        # Handle enter combat interrupts.
-        self.aura_manager.check_aura_interrupts(enter_combat=True)
-
         self.send_attack_start(self.combat_target.guid)
 
         return True
@@ -878,6 +875,8 @@ class UnitManager(ObjectManager):
         self.in_combat = True
         self.unit_flags |= UnitFlags.UNIT_FLAG_IN_COMBAT
         self.set_uint32(UnitFields.UNIT_FIELD_FLAGS, self.unit_flags)
+        # Handle enter combat interrupts.
+        self.aura_manager.check_aura_interrupts(enter_combat=True)
 
     def leave_combat(self):
         if not self.in_combat:

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -961,7 +961,6 @@ class UnitManager(ObjectManager):
         return super().change_speed(speed)
 
     # override
-    # TODO: Always detect party members, other cases?
     def can_detect_target(self, target, distance=0):
         if not target.unit_flags & UnitFlags.UNIT_FLAG_SNEAK:
             return True, False

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -958,9 +958,13 @@ class UnitManager(ObjectManager):
         return super().change_speed(speed)
 
     # override
-    def can_detect_target(self, target, distance):
+    def can_detect_target(self, target, distance=0):
         if not target.unit_flags & UnitFlags.UNIT_FLAG_SNEAK:
             return True, False
+
+        # No distance provided, calculate here.
+        if not distance:
+            distance = self.location.distance(target.location)
 
         # Collision.
         if distance < 1.5:

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -958,6 +958,7 @@ class UnitManager(ObjectManager):
         return super().change_speed(speed)
 
     # override
+    # TODO: Always detect party members, other cases?
     def can_detect_target(self, target, distance=0):
         if not target.unit_flags & UnitFlags.UNIT_FLAG_SNEAK:
             return True, False

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -271,6 +271,9 @@ class UnitManager(ObjectManager):
         if self.has_offhand_weapon():
             self.set_attack_timer(AttackTypes.OFFHAND_ATTACK, self.offhand_attack_time)
 
+        # Handle enter combat interrupts.
+        self.aura_manager.check_aura_interrupts(enter_combat=True)
+
         self.send_attack_start(self.combat_target.guid)
 
         return True
@@ -961,6 +964,10 @@ class UnitManager(ObjectManager):
     # TODO: Always detect party members, other cases?
     def can_detect_target(self, target, distance=0):
         if not target.unit_flags & UnitFlags.UNIT_FLAG_SNEAK:
+            return True, False
+
+        # Attacked by sneaking unit.
+        if self.threat_manager.has_aggro_from(target):
             return True, False
 
         # No distance provided, calculate here.

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -965,7 +965,7 @@ class UnitManager(ObjectManager):
         if not target.unit_flags & UnitFlags.UNIT_FLAG_SNEAK:
             return True, False
 
-        # Attacked by sneaking unit.
+        # Already attacked by the target.
         if self.threat_manager.has_aggro_from(target):
             return True, False
 

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -604,8 +604,6 @@ class CreatureManager(UnitManager):
         if not self.combat_target:
             self.object_ai.attack_start(victim)
         super().attack(victim)
-        # Handle enter combat interrupts.
-        self.aura_manager.check_aura_interrupts()
 
     # override
     def attack_update(self, elapsed):

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -712,6 +712,10 @@ class CreatureManager(UnitManager):
         self.set_uint32(UnitFields.UNIT_DYNAMIC_FLAGS, self.dynamic_flags)
 
     # override
+    def get_name(self):
+        return self.creature_template.name
+
+    # override
     def get_bytes_0(self):
         return ByteUtils.bytes_to_int(
             self.power_type,  # power type

--- a/game/world/managers/objects/units/player/ChannelManager.py
+++ b/game/world/managers/objects/units/player/ChannelManager.py
@@ -148,7 +148,7 @@ class ChannelManager(object):
     def get_owner(channel, sender):
         if channel in ChannelManager.CHANNELS[sender.team]:
             packet = ChannelManager.build_notify_packet(channel, ChannelNotifications.CHANNEL_OWNER,
-                                                        player_name=sender.player.name)
+                                                        player_name=sender.get_name())
             ChannelManager.send_to_player(sender, packet)
         else:
             packet = ChannelManager.build_notify_packet(channel, ChannelNotifications.NOT_MEMBER)
@@ -202,7 +202,7 @@ class ChannelManager(object):
         if ChannelManager.default_checks(channel, sender, check_owner=True, check_moderator=True):
             if not ChannelManager._is_banned(channel, target_player):
                 packet = ChannelManager.build_notify_packet(channel, ChannelNotifications.PLAYER_NOT_FOUND,
-                                                            player_name=target_player.player.name)
+                                                            player_name=target_player.get_name())
                 ChannelManager.send_to_player(sender, packet)
             else:
                 packet = ChannelManager.build_notify_packet(channel, ChannelNotifications.UNBANNED, target_player,
@@ -297,7 +297,7 @@ class ChannelManager(object):
             return False
         elif target_player and not ChannelManager._in_channel(channel, target_player):
             packet = ChannelManager.build_notify_packet(channel, ChannelNotifications.PLAYER_NOT_FOUND,
-                                                        player_name=target_player.player.name)
+                                                        player_name=target_player.get_name())
             ChannelManager.send_to_player(sender, packet)
         elif target_player and target_player == sender:  # Avoid self ban / kick
             return False

--- a/game/world/managers/objects/units/player/DuelManager.py
+++ b/game/world/managers/objects/units/player/DuelManager.py
@@ -111,6 +111,8 @@ class DuelManager(object):
 
         packet = PacketWriter.get_packet(OpCode.SMSG_CANCEL_COMBAT)
         for entry in self.players.values():
+            if entry.player.combo_target:
+                entry.player.remove_combo_points()
             entry.player.enqueue_packet(packet)
             entry.player.leave_combat()
             self.build_update(entry.player)

--- a/game/world/managers/objects/units/player/DuelManager.py
+++ b/game/world/managers/objects/units/player/DuelManager.py
@@ -102,8 +102,8 @@ class DuelManager(object):
 
         # Was not interrupted, broadcast duel result.
         if duel_complete_flag == DuelComplete.DUEL_FINISHED:
-            winner_name_bytes = PacketWriter.string_to_bytes(winner.player.name)
-            loser_name_bytes = PacketWriter.string_to_bytes(self.players[winner.guid].target.player.name)
+            winner_name_bytes = PacketWriter.string_to_bytes(winner.get_name())
+            loser_name_bytes = PacketWriter.string_to_bytes(self.players[winner.guid].target.get_name())
             data = pack(f'<B{len(winner_name_bytes)}s{len(loser_name_bytes)}s', duel_winner_flag, winner_name_bytes,
                         loser_name_bytes)
             packet = PacketWriter.get_packet(OpCode.SMSG_DUEL_WINNER, data)

--- a/game/world/managers/objects/units/player/GroupManager.py
+++ b/game/world/managers/objects/units/player/GroupManager.py
@@ -209,7 +209,7 @@ class GroupManager(object):
                         disband_packet = PacketWriter.get_packet(OpCode.SMSG_GROUP_DESTROYED)
                         member_player.enqueue_packet(disband_packet)
                     elif was_formed and member_player and not is_kicked:
-                        GroupManager.send_group_operation_result(member_player, PartyOperations.PARTY_OP_LEAVE, member_player.player.name,
+                        GroupManager.send_group_operation_result(member_player, PartyOperations.PARTY_OP_LEAVE, member_player.get_name(),
                                                                  PartyResults.ERR_PARTY_RESULT_OK)
 
                     if member_player and is_kicked and member.guid == player_guid:  # 'You have been removed from the group.' message
@@ -447,24 +447,24 @@ class GroupManager(object):
     @staticmethod
     def invite_player(player_mgr, target_player_mgr):
         if player_mgr.is_hostile_to(target_player_mgr):
-            GroupManager.send_group_operation_result(player_mgr, PartyOperations.PARTY_OP_INVITE, target_player_mgr.player.name, PartyResults.ERR_PLAYER_WRONG_FACTION)
+            GroupManager.send_group_operation_result(player_mgr, PartyOperations.PARTY_OP_INVITE, target_player_mgr.get_name(), PartyResults.ERR_PLAYER_WRONG_FACTION)
             return
 
         if target_player_mgr.friends_manager.has_ignore(player_mgr.guid):
-            GroupManager.send_group_operation_result(player_mgr, PartyOperations.PARTY_OP_INVITE, target_player_mgr.player.name, PartyResults.ERR_IGNORING_YOU_S)
+            GroupManager.send_group_operation_result(player_mgr, PartyOperations.PARTY_OP_INVITE, target_player_mgr.get_name(), PartyResults.ERR_IGNORING_YOU_S)
             return
 
         if target_player_mgr.group_manager and target_player_mgr.group_manager.is_party_formed():
-            GroupManager.send_group_operation_result(player_mgr, PartyOperations.PARTY_OP_INVITE, target_player_mgr.player.name, PartyResults.ERR_ALREADY_IN_GROUP_S)
+            GroupManager.send_group_operation_result(player_mgr, PartyOperations.PARTY_OP_INVITE, target_player_mgr.get_name(), PartyResults.ERR_ALREADY_IN_GROUP_S)
             return
 
         if player_mgr.group_manager:
             if player_mgr.group_manager.group.leader_guid != player_mgr.guid:
-                GroupManager.send_group_operation_result(player_mgr, PartyOperations.PARTY_OP_INVITE, target_player_mgr.player.name, PartyResults.ERR_NOT_LEADER)
+                GroupManager.send_group_operation_result(player_mgr, PartyOperations.PARTY_OP_INVITE, target_player_mgr.get_name(), PartyResults.ERR_NOT_LEADER)
                 return
 
             if player_mgr.group_manager.is_full():
-                GroupManager.send_group_operation_result(player_mgr, PartyOperations.PARTY_OP_INVITE, target_player_mgr.player.name, PartyResults.ERR_GROUP_FULL)
+                GroupManager.send_group_operation_result(player_mgr, PartyOperations.PARTY_OP_INVITE, target_player_mgr.get_name(), PartyResults.ERR_GROUP_FULL)
                 return
 
             if not player_mgr.group_manager.try_add_member(target_player_mgr, True):
@@ -476,7 +476,7 @@ class GroupManager(object):
                 return
 
         target_player_mgr.has_pending_group_invite = True
-        name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
+        name_bytes = PacketWriter.string_to_bytes(player_mgr.get_name())
         data = pack(
             f'<{len(name_bytes)}s',
             name_bytes
@@ -485,7 +485,7 @@ class GroupManager(object):
         packet = PacketWriter.get_packet(OpCode.SMSG_GROUP_INVITE, data)
         target_player_mgr.enqueue_packet(packet)
 
-        GroupManager.send_group_operation_result(player_mgr, PartyOperations.PARTY_OP_INVITE, target_player_mgr.player.name, PartyResults.ERR_PARTY_RESULT_OK)
+        GroupManager.send_group_operation_result(player_mgr, PartyOperations.PARTY_OP_INVITE, target_player_mgr.get_name(), PartyResults.ERR_PARTY_RESULT_OK)
 
     @staticmethod
     def send_group_operation_result(player, group_operation, name, result):

--- a/game/world/managers/objects/units/player/InventoryManager.py
+++ b/game/world/managers/objects/units/player/InventoryManager.py
@@ -54,7 +54,7 @@ class InventoryManager(object):
             if item_template:
                 if item_template.display_id > MAX_3368_ITEM_DISPLAY_ID and \
                         self.is_equipment_pos(item_instance.bag, item_instance.slot):
-                    Logger.error(f'Character {self.owner.player.name} has an equipped item ({item_template.entry} - {item_template.name}) '
+                    Logger.error(f'Character {self.owner.get_name()} has an equipped item ({item_template.entry} - {item_template.name}) '
                                  f'with out of bounds display_id ({item_template.display_id}), '
                                  f'deleting in order to prevent crashes.')
                     RealmDatabaseManager.character_inventory_delete(item_instance)

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1,5 +1,4 @@
 import math
-from threading import RLock
 from dataclasses import dataclass
 
 from bitarray import bitarray
@@ -1685,6 +1684,10 @@ class PlayerManager(UnitManager):
         else:
             deathbind_map, deathbind_location = self.get_deathbind_coordinates()
             self.teleport(deathbind_map, deathbind_location, recovery=1, is_instant=False)
+
+    # override
+    def get_name(self):
+        return self.player.name
 
     def get_player_bytes(self):
         return ByteUtils.bytes_to_int(

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -383,10 +383,12 @@ class PlayerManager(UnitManager):
                 self.enqueue_packet(self.generate_partial_packet(requester=self))
         # Stealth detection.
         else:
+            # Unit is now visible.
             if world_object.guid not in self.known_objects and can_detect:
                 if world_object.guid in self.known_stealth_units:
                     del self.known_stealth_units[world_object.guid]
                 self.update_known_objects_on_tick = True  # Create this object for self on tick.
+            # Unit went stealth.
             elif world_object.guid in self.known_objects and not can_detect:
                 self.known_stealth_units[world_object.guid] = world_object
                 self.update_known_objects_on_tick = True  # Destroy this object for self on tick.

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1763,6 +1763,7 @@ class PlayerManager(UnitManager):
                 # Unit is stealth but remains visible to us, should destroy.
                 elif is_stealth and not can_detect and guid in self.known_objects:
                     self.update_known_objects_on_tick = True
+                # Unit is no longer stealth, can detect and we don't know this unit, should create.
                 elif not is_stealth and can_detect and guid not in self.known_objects:
                     # Unit is no longer stealth, pop.
                     if not unit.unit_flags & UnitFlags.UNIT_FLAG_SNEAK:

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -77,7 +77,6 @@ class PlayerManager(UnitManager):
                  **kwargs):
         super().__init__(**kwargs)
 
-        self.player_lock = RLock()
         self.session = session
         self.pending_teleport_recovery_percentage = -1
         self.pending_teleport_destination = None
@@ -85,6 +84,7 @@ class PlayerManager(UnitManager):
         self.update_lock = False
         self.known_objects = dict()
         self.known_items = dict()
+        self.known_stealth_units = dict()
 
         self.player = player
         self.online = online
@@ -108,7 +108,8 @@ class PlayerManager(UnitManager):
         self.resurrect_data = None
         self.team = Teams.TEAM_NONE  # Set at set_player_variables().
         self.trade_data = None
-        self.last_swimming_check = 0
+        self.last_swimming_check_timer = 0
+        self.stealth_detect_timer = 0
         self.spirit_release_timer = 0
         self.logout_timer = -1
         self.pending_taxi_destination = None
@@ -147,6 +148,7 @@ class PlayerManager(UnitManager):
             self.coinage = self.player.money
             self.regen_flags = RegenStatsFlags.REGEN_FLAG_HEALTH | RegenStatsFlags.REGEN_FLAG_POWER
             self.online = self.player.online
+            self.update_known_objects_on_tick = False
 
             # GM checks
             self.is_god = False
@@ -359,7 +361,11 @@ class PlayerManager(UnitManager):
     # Retrieve update packets from world objects, this is called only if object has pending changes.
     # (update_mask bits set).
     def update_world_object_on_me(self, world_object, has_changes=False, has_inventory_changes=False):
-        if world_object.guid in self.known_objects:
+        can_detect = self.can_detect_target(world_object)[0]
+        is_self = world_object.guid == self.guid
+
+        # We know the unit and can detect.
+        if world_object.guid in self.known_objects and can_detect:
             is_player = world_object.get_type_id() == ObjectTypeIds.ID_PLAYER
             # Check for inventory updates.
             if is_player and has_inventory_changes:
@@ -368,116 +374,131 @@ class PlayerManager(UnitManager):
             # Update self with known world object partial update packet.
             if has_changes:
                 self.enqueue_packet(world_object.generate_partial_packet(requester=self))
-        elif world_object.guid == self.guid:  # Self (Player)
+        elif is_self:  # Self (Player)
             # Update self inventory if needed.
             if has_inventory_changes:
                 self.enqueue_packets(self.inventory.get_inventory_update_packets(self))
             # Send self a partial update if needed.
             if has_changes:
                 self.enqueue_packet(self.generate_partial_packet(requester=self))
+        # Stealth detection.
+        else:
+            if world_object.guid not in self.known_objects and can_detect:
+                if world_object.guid in self.known_stealth_units:
+                    del self.known_stealth_units[world_object.guid]
+                self.update_known_objects_on_tick = True  # Create this object for self on tick.
+            elif world_object.guid in self.known_objects and not can_detect:
+                self.known_stealth_units[world_object.guid] = world_object
+                self.update_known_objects_on_tick = True  # Destroy this object for self on tick.
 
     # Notify self with create / destroy / partial movement packets of world objects in range.
     # Range = This player current active cell plus its adjacent cells.
     def update_known_world_objects(self, flush=False):
-        with self.player_lock:
-            players, creatures, game_objects, corpses, dynamic_objects = \
-                MapManager.get_surrounding_objects(self,
-                                                   [ObjectTypeIds.ID_PLAYER, ObjectTypeIds.ID_UNIT,
-                                                    ObjectTypeIds.ID_GAMEOBJECT, ObjectTypeIds.ID_CORPSE,
-                                                    ObjectTypeIds.ID_DYNAMICOBJECT])
+        players, creatures, game_objects, corpses, dynamic_objects = \
+            MapManager.get_surrounding_objects(self,
+                                               [ObjectTypeIds.ID_PLAYER, ObjectTypeIds.ID_UNIT,
+                                                ObjectTypeIds.ID_GAMEOBJECT, ObjectTypeIds.ID_CORPSE,
+                                                ObjectTypeIds.ID_DYNAMICOBJECT])
 
-            # Destroy all known objects.
-            if flush:
-                for guid, known_object in list(self.known_objects.items()):
-                    self.destroy_near_object(guid)
-                return
-
-            # Which objects were found in self surroundings.
-            active_objects = dict()
-
-            # Surrounding players.
-            for guid, player in players.items():
-                if self.guid != guid:
-                    active_objects[guid] = player
-                    if guid not in self.known_objects or not self.known_objects[guid]:
-                        # We don't know this player, notify self with its update packet.
-                        self.enqueue_packet(NameQueryHandler.get_query_details(player.player))
-                        # Retrieve their inventory updates.
-                        self.enqueue_packets(player.inventory.get_inventory_update_packets(self))
-                        # Create packet.
-                        self.enqueue_packet(player.generate_create_packet(requester=self))
-                        # Get partial movement packet if any.
-                        if player.movement_manager.unit_is_moving():
-                            packet = player.movement_manager.try_build_movement_packet(is_initial=False)
-                            if packet:
-                                self.enqueue_packet(packet)
-                    self.known_objects[guid] = player
-
-            # Surrounding corpses.
-            for guid, corpse in corpses.items():
-                if self.guid != guid:
-                    active_objects[guid] = corpse
-                    if guid not in self.known_objects or not self.known_objects[guid]:
-                        # Create packet.
-                        self.enqueue_packet(corpse.generate_create_packet(requester=self))
-                    self.known_objects[guid] = corpse
-
-            # Surrounding creatures.
-            for guid, creature in creatures.items():
-                active_objects[guid] = creature
-                if guid not in self.known_objects or not self.known_objects[guid]:
-                    # We don't know this creature, notify self with its update packet.
-                    self.enqueue_packet(UnitQueryUtils.query_details(creature_mgr=creature))
-                    if creature.is_spawned:
-                        self.enqueue_packet(creature.generate_create_packet(requester=self))
-                        # Get partial movement packet if any.
-                        if creature.movement_manager.unit_is_moving():
-                            packet = creature.movement_manager.try_build_movement_packet(is_initial=False)
-                            if packet:
-                                self.enqueue_packet(packet)
-                        # We only consider 'known' if its spawned, the details query is still sent.
-                        self.known_objects[guid] = creature
-                        # Add ourselves to creature known players.
-                        creature.known_players[self.guid] = self
-                # Player knows the creature but is not spawned anymore, destroy it for self.
-                elif guid in self.known_objects and not creature.is_spawned:
-                    active_objects.pop(guid)
-
-            # Surrounding game objects.
-            for guid, gobject in game_objects.items():
-                active_objects[guid] = gobject
-                if guid not in self.known_objects or not self.known_objects[guid]:
-                    # We don't know this game object, notify self with its update packet.
-                    self.enqueue_packet(GoQueryUtils.query_details(gameobject_mgr=gobject))
-                    if gobject.is_spawned:
-                        self.enqueue_packet(gobject.generate_create_packet(requester=self))
-                        # We only consider 'known' if its spawned, the details query is still sent.
-                        self.known_objects[guid] = gobject
-                        # Add ourselves to gameobject known players.
-                        gobject.known_players[self.guid] = self
-                # Player knows the game object but is not spawned anymore, destroy it for self.
-                elif guid in self.known_objects and not gobject.is_spawned:
-                    active_objects.pop(guid)
-
-            # Surrounding dynamic objects.
-            for guid, dynamic_objects in dynamic_objects.items():
-                active_objects[guid] = dynamic_objects
-                if guid not in self.known_objects or not self.known_objects[guid]:
-                    if dynamic_objects.is_spawned:
-                        self.enqueue_packet(dynamic_objects.generate_create_packet(requester=self))
-                        # We only consider 'known' if its spawned, the details query is still sent.
-                        self.known_objects[guid] = dynamic_objects
-                # Player knows the dynamic object but is not spawned anymore, destroy it for self.
-                elif guid in self.known_objects and not dynamic_objects.is_spawned:
-                    active_objects.pop(guid)
-
-            # World objects which are known but no longer active to self should be destroyed.
+        # Destroy all known objects.
+        if flush:
             for guid, known_object in list(self.known_objects.items()):
-                if guid not in active_objects:
-                    self.destroy_near_object(guid)
+                self.destroy_near_object(guid)
+            return
 
-            # Cleanup.
-            active_objects.clear()
+        # Which objects were found in self surroundings.
+        active_objects = dict()
+
+        # Surrounding players.
+        for guid, player in players.items():
+            if self.guid == guid:
+                continue
+            if not self.can_detect_target(player)[0]:
+                self.known_stealth_units[guid] = player
+                continue
+            active_objects[guid] = player
+            if guid not in self.known_objects or not self.known_objects[guid]:
+                # We don't know this player, notify self with its update packet.
+                self.enqueue_packet(NameQueryHandler.get_query_details(player.player))
+                # Retrieve their inventory updates.
+                self.enqueue_packets(player.inventory.get_inventory_update_packets(self))
+                # Create packet.
+                self.enqueue_packet(player.generate_create_packet(requester=self))
+                # Get partial movement packet if any.
+                if player.movement_manager.unit_is_moving():
+                    packet = player.movement_manager.try_build_movement_packet(is_initial=False)
+                    if packet:
+                        self.enqueue_packet(packet)
+            self.known_objects[guid] = player
+
+        # Surrounding corpses.
+        for guid, corpse in corpses.items():
+            if self.guid != guid:
+                active_objects[guid] = corpse
+                if guid not in self.known_objects or not self.known_objects[guid]:
+                    # Create packet.
+                    self.enqueue_packet(corpse.generate_create_packet(requester=self))
+                self.known_objects[guid] = corpse
+
+        # Surrounding creatures.
+        for guid, creature in creatures.items():
+            if not self.can_detect_target(creature):
+                self.known_stealth_units[guid] = creature
+                continue
+            active_objects[guid] = creature
+            if guid not in self.known_objects or not self.known_objects[guid]:
+                # We don't know this creature, notify self with its update packet.
+                self.enqueue_packet(UnitQueryUtils.query_details(creature_mgr=creature))
+                if creature.is_spawned:
+                    self.enqueue_packet(creature.generate_create_packet(requester=self))
+                    # Get partial movement packet if any.
+                    if creature.movement_manager.unit_is_moving():
+                        packet = creature.movement_manager.try_build_movement_packet(is_initial=False)
+                        if packet:
+                            self.enqueue_packet(packet)
+                    # We only consider 'known' if its spawned, the details query is still sent.
+                    self.known_objects[guid] = creature
+                    # Add ourselves to creature known players.
+                    creature.known_players[self.guid] = self
+            # Player knows the creature but is not spawned anymore, destroy it for self.
+            elif guid in self.known_objects and not creature.is_spawned:
+                active_objects.pop(guid)
+
+        # Surrounding game objects.
+        for guid, gobject in game_objects.items():
+            active_objects[guid] = gobject
+            if guid not in self.known_objects or not self.known_objects[guid]:
+                # We don't know this game object, notify self with its update packet.
+                self.enqueue_packet(GoQueryUtils.query_details(gameobject_mgr=gobject))
+                if gobject.is_spawned:
+                    self.enqueue_packet(gobject.generate_create_packet(requester=self))
+                    # We only consider 'known' if its spawned, the details query is still sent.
+                    self.known_objects[guid] = gobject
+                    # Add ourselves to gameobject known players.
+                    gobject.known_players[self.guid] = self
+            # Player knows the game object but is not spawned anymore, destroy it for self.
+            elif guid in self.known_objects and not gobject.is_spawned:
+                active_objects.pop(guid)
+
+        # Surrounding dynamic objects.
+        for guid, dynamic_objects in dynamic_objects.items():
+            active_objects[guid] = dynamic_objects
+            if guid not in self.known_objects or not self.known_objects[guid]:
+                if dynamic_objects.is_spawned:
+                    self.enqueue_packet(dynamic_objects.generate_create_packet(requester=self))
+                    # We only consider 'known' if its spawned, the details query is still sent.
+                    self.known_objects[guid] = dynamic_objects
+            # Player knows the dynamic object but is not spawned anymore, destroy it for self.
+            elif guid in self.known_objects and not dynamic_objects.is_spawned:
+                active_objects.pop(guid)
+
+        # World objects which are known but no longer active to self should be destroyed.
+        for guid, known_object in list(self.known_objects.items()):
+            if guid not in active_objects:
+                self.destroy_near_object(guid)
+
+        # Cleanup.
+        active_objects.clear()
 
     def destroy_near_object(self, guid):
         implements_known_players = [ObjectTypeIds.ID_UNIT, ObjectTypeIds.ID_GAMEOBJECT]
@@ -1475,9 +1496,9 @@ class PlayerManager(UnitManager):
         if not self.is_alive:
             return
 
-        self.last_swimming_check += elapsed
-        if self.last_swimming_check >= 1:
-            self.last_swimming_check = 0
+        self.last_swimming_check_timer += elapsed
+        if self.last_swimming_check_timer >= 1:
+            self.last_swimming_check_timer = 0
             if self.is_swimming() and not self.liquid_information:
                 self.update_swimming_state(True)
             elif not self.is_swimming() and self.liquid_information:
@@ -1492,6 +1513,13 @@ class PlayerManager(UnitManager):
             self.player.totaltime += elapsed
             self.player.leveltime += elapsed
 
+            # Update known objects if needed.
+            if self.update_known_objects_on_tick:
+                self.update_known_objects_on_tick = False
+                self.update_known_world_objects()
+
+            # Stealth detect.
+            self.stealth_detect_units(elapsed)
             # Regeneration.
             self.regenerate(elapsed)
             # Attack update.
@@ -1690,6 +1718,16 @@ class PlayerManager(UnitManager):
     # override
     def get_damages(self):
         return self.damage
+
+    def stealth_detect_units(self, elapsed):
+        if len(self.known_stealth_units) == 0:
+            return
+        self.stealth_detect_timer += elapsed
+        if self.stealth_detect_timer >= 2:  # Secs.
+            for guid, unit in list(self.known_stealth_units.items()):
+                print(f'Checking {unit.player.name}')
+                self.update_world_object_on_me(unit)
+            self.stealth_detect_timer = 0
 
     def _on_relocation(self):
         for guid, unit in MapManager.get_surrounding_units(self).items():

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1755,7 +1755,7 @@ class PlayerManager(UnitManager):
                 unit = stealth_status[0]
                 can_detect = self.can_detect_target(unit)[0]
                 # Can detect and we had the object invisible.
-                if stealth_status[1] and can_detect and guid in self.known_objects:
+                if is_stealth and can_detect and guid in self.known_objects:
                     # Unit is no longer stealth, pop.
                     if not unit.unit_flags & UnitFlags.UNIT_FLAG_SNEAK:
                         del self.known_stealth_units[guid]

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1763,7 +1763,7 @@ class PlayerManager(UnitManager):
                 # Unit is stealth but remains visible to us, should destroy.
                 elif is_stealth and not can_detect and guid in self.known_objects:
                     self.update_known_objects_on_tick = True
-                # Unit is no longer stealth, can detect and we don't know this unit, should create.
+                # Unit is no longer stealth, can detect, and we don't know this unit, should create.
                 elif not is_stealth and can_detect and guid not in self.known_objects:
                     # Unit is no longer stealth, pop.
                     if not unit.unit_flags & UnitFlags.UNIT_FLAG_SNEAK:

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -303,7 +303,7 @@ class SkillManager(object):
 
     def add_skill(self, skill_id):
         if self.has_reached_skills_limit():
-            Logger.warning(f'Player {self.player_mgr.player.name} with guid {self.player_mgr.guid} reached max skills.')
+            Logger.warning(f'Player {self.player_mgr.get_name()} with guid {self.player_mgr.guid} reached max skills.')
             return False
 
         # Skill already learned.

--- a/game/world/managers/objects/units/player/guild/GuildManager.py
+++ b/game/world/managers/objects/units/player/guild/GuildManager.py
@@ -113,7 +113,7 @@ class GuildManager(object):
         self.members[player_mgr.guid] = guild_member
 
         data = pack('<2B', GuildEvents.GUILD_EVENT_JOINED, 1)
-        name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
+        name_bytes = PacketWriter.string_to_bytes(player_mgr.get_name())
         data += pack(f'<{len(name_bytes)}s', name_bytes)
 
         self.build_update(player_mgr)

--- a/game/world/managers/objects/units/player/quest/QuestManager.py
+++ b/game/world/managers/objects/units/player/quest/QuestManager.py
@@ -259,7 +259,7 @@ class QuestManager(object):
             self.send_quest_giver_quest_list(text, 0, quest_giver_guid, quest_menu.items)
         elif quest_giver.get_type_id() == ObjectTypeIds.ID_GAMEOBJECT:
             # TODO: e.g. Stone of Remembrance - Needs broadcast_text table.
-            Logger.warning(f'Missing handling for quest giver {quest_giver.gobject_template.name}, '
+            Logger.warning(f'Missing handling for quest giver {quest_giver.get_name()}, '
                            f'Entry: {quest_giver.entry}.')
 
     def get_quest_state(self, quest_entry):

--- a/game/world/opcode_handling/handlers/group/GroupInviteDeclineHandler.py
+++ b/game/world/opcode_handling/handlers/group/GroupInviteDeclineHandler.py
@@ -7,7 +7,7 @@ class GroupInviteDeclineHandler(object):
             return 0
 
         if player.guid != player.group_manager.group.leader_guid:
-            player.group_manager.send_invite_decline(player.player.name)
+            player.group_manager.send_invite_decline(player.get_name())
 
         player.group_manager.remove_invitation(player.guid)
 

--- a/game/world/opcode_handling/handlers/group/GroupInviteHandler.py
+++ b/game/world/opcode_handling/handlers/group/GroupInviteHandler.py
@@ -26,10 +26,10 @@ class GroupInviteHandler(object):
                                                          target_name, PartyResults.ERR_IGNORING_YOU_S)
             elif target_player_mgr and (target_player_mgr.has_pending_group_invite or target_player_mgr.group_manager):
                 GroupManager.send_group_operation_result(world_session.player_mgr, PartyOperations.PARTY_OP_INVITE,
-                                                         target_player_mgr.player.name, PartyResults.ERR_ALREADY_IN_GROUP_S)
+                                                         target_player_mgr.get_name(), PartyResults.ERR_ALREADY_IN_GROUP_S)
             elif target_player_mgr and target_player_mgr.guid == world_session.player_mgr.guid:
                 GroupManager.send_group_operation_result(world_session.player_mgr, PartyOperations.PARTY_OP_INVITE,
-                                                         target_player_mgr.player.name, PartyResults.ERR_INVITE_RESTRICTED)
+                                                         target_player_mgr.get_name(), PartyResults.ERR_INVITE_RESTRICTED)
             else:
                 GroupManager.invite_player(world_session.player_mgr, target_player_mgr)
 

--- a/game/world/opcode_handling/handlers/guild/GuildInviteDeclineHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildInviteDeclineHandler.py
@@ -12,7 +12,7 @@ class GuildInviteDeclineHandler(object):
             inviter = GuildManager.PENDING_INVITES[player_mgr.guid].inviter
             GuildManager.PENDING_INVITES.pop(player_mgr.guid)
 
-            inviter_name_bytes = PacketWriter.string_to_bytes(inviter.player.name)
+            inviter_name_bytes = PacketWriter.string_to_bytes(inviter.get_name())
             data = pack(
                 f'<{len(inviter_name_bytes)}s',
                 inviter_name_bytes

--- a/game/world/opcode_handling/handlers/guild/GuildInviteHandler.py
+++ b/game/world/opcode_handling/handlers/guild/GuildInviteHandler.py
@@ -34,7 +34,7 @@ class GuildInviteHandler(object):
                     GuildManager.send_guild_command_result(player_mgr, GuildTypeCommand.GUILD_INVITE_S, target_name,
                                                            GuildCommandResults.GUILD_U_HAVE_INVITED)
 
-                    name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
+                    name_bytes = PacketWriter.string_to_bytes(player_mgr.get_name())
                     data = pack(
                         f'<{len(name_bytes)}s',
                         name_bytes

--- a/game/world/opcode_handling/handlers/npc/PetitionOfferHandler.py
+++ b/game/world/opcode_handling/handlers/npc/PetitionOfferHandler.py
@@ -32,7 +32,7 @@ class PetitionOfferHandler(object):
                 # If target is already in a guild.
                 if target_player_mgr.guild_manager:
                     GuildManager.send_guild_command_result(world_session.player_mgr, GuildTypeCommand.GUILD_INVITE_S,
-                                                           target_player_mgr.player.name,
+                                                           target_player_mgr.get_name(),
                                                            GuildCommandResults.GUILD_ALREADY_IN_GUILD)
                     return 0
 

--- a/game/world/opcode_handling/handlers/player/MovementHandler.py
+++ b/game/world/opcode_handling/handlers/player/MovementHandler.py
@@ -29,7 +29,7 @@ class MovementHandler:
                 # Hacky way to prevent random teleports when colliding with elevators
                 # Also acts as a rudimentary teleport cheat detection
                 if not player_mgr.pending_taxi_destination and player_mgr.location.distance(x=x, y=y, z=z) > 64:
-                    Logger.anticheat(f'Preventing desync from player {player_mgr.player.name} ({player_mgr.guid}).')
+                    Logger.anticheat(f'Preventing desync from player {player_mgr.get_name()} ({player_mgr.guid}).')
                     player_mgr.teleport(player_mgr.map_, player_mgr.location, is_instant=True)
                     return 0
 

--- a/game/world/opcode_handling/handlers/player/cheats/BeastMasterHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/BeastMasterHandler.py
@@ -16,7 +16,7 @@ class CheatBeastMasterHandler(object):
             return res
 
         if not player_mgr.is_gm:
-            Logger.anticheat(f'Player {player_mgr.player.name} ({player_mgr.guid}) tried to give himself Beastmaster.')
+            Logger.anticheat(f'Player {player_mgr.get_name()} ({player_mgr.guid}) tried to give himself Beastmaster.')
             return 0
 
         if len(reader.data) >= 1:  # Avoid handling empty beast master packet.

--- a/game/world/opcode_handling/handlers/player/cheats/CheatSetMoneyHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/CheatSetMoneyHandler.py
@@ -14,7 +14,7 @@ class CheatSetMoneyHandler(object):
             return res
 
         if not player_mgr.is_gm:
-            Logger.anticheat(f'Player {player_mgr.player.name} ({player_mgr.guid}) tried to give himself money.')
+            Logger.anticheat(f'Player {player_mgr.get_name()} ({player_mgr.guid}) tried to give himself money.')
             return 0
 
         if len(reader.data) >= 4:  # Avoid handling empty cheat set money packet.

--- a/game/world/opcode_handling/handlers/player/cheats/CooldownCheatHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/CooldownCheatHandler.py
@@ -15,7 +15,7 @@ class CooldownCheatHandler(object):
             return res
 
         if not player_mgr.is_gm:
-            Logger.anticheat(f'Player {player_mgr.player.name} ({player_mgr.guid}) tried to remove his cooldowns.')
+            Logger.anticheat(f'Player {player_mgr.get_name()} ({player_mgr.guid}) tried to remove his cooldowns.')
             return 0
 
         # Clear server-side cooldowns.

--- a/game/world/opcode_handling/handlers/player/cheats/CreateItemHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/CreateItemHandler.py
@@ -15,7 +15,7 @@ class CreateItemHandler(object):
             return res
 
         if not player_mgr.is_gm:
-            Logger.anticheat(f'Player {player_mgr.player.name} ({player_mgr.guid}) tried create item.')
+            Logger.anticheat(f'Player {player_mgr.get_name()} ({player_mgr.guid}) tried create item.')
             return 0
 
         if len(reader.data) >= 4:  # Avoid handling empty create item packet.

--- a/game/world/opcode_handling/handlers/player/cheats/GodModeHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/GodModeHandler.py
@@ -15,7 +15,7 @@ class GodModeHandler(object):
             return res
 
         if not player_mgr.is_gm:
-            Logger.anticheat(f'Player {player_mgr.player.name} ({player_mgr.guid}) tried to set god mode.')
+            Logger.anticheat(f'Player {player_mgr.get_name()} ({player_mgr.guid}) tried to set god mode.')
             return 0
 
         if len(reader.data) >= 1:  # Avoid handling empty god mode packet.

--- a/game/world/opcode_handling/handlers/player/cheats/LearnSpellCheatHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/LearnSpellCheatHandler.py
@@ -13,7 +13,7 @@ class LearnSpellCheatHandler(object):
             return res
 
         if not player_mgr.is_gm:
-            Logger.anticheat(f'Player {player_mgr.player.name} ({player_mgr.guid}) tried to learn spell.')
+            Logger.anticheat(f'Player {player_mgr.get_name()} ({player_mgr.guid}) tried to learn spell.')
             return 0
 
         if len(reader.data) >= 4:  # Avoid handling empty learn spell cheat packet.

--- a/game/world/opcode_handling/handlers/player/cheats/LevelCheatHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/LevelCheatHandler.py
@@ -14,7 +14,7 @@ class LevelCheatHandler(object):
             return res
 
         if not player_mgr.is_gm:
-            Logger.anticheat(f'Player {player_mgr.player.name} ({player_mgr.guid}) tried to modify level.')
+            Logger.anticheat(f'Player {player_mgr.get_name()} ({player_mgr.guid}) tried to modify level.')
             return 0
 
         if len(reader.data) >= 4:  # Avoid empty packet level cheat packet.

--- a/game/world/opcode_handling/handlers/player/cheats/LevelUpCheatHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/LevelUpCheatHandler.py
@@ -13,7 +13,7 @@ class LevelUpCheatHandler(object):
             return res
 
         if not player_mgr.is_gm:
-            Logger.anticheat(f'Player {player_mgr.player.name} ({player_mgr.guid}) tried to modify level.')
+            Logger.anticheat(f'Player {player_mgr.get_name()} ({player_mgr.guid}) tried to modify level.')
             return 0
 
         player_mgr.mod_level(player_mgr.level + 1)

--- a/game/world/opcode_handling/handlers/player/cheats/RechargeHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/RechargeHandler.py
@@ -13,7 +13,7 @@ class RechargeHandler(object):
             return res
 
         if not player_mgr.is_gm:
-            Logger.anticheat(f'Player {player_mgr.player.name} ({player_mgr.guid}) tried to recharge powers.')
+            Logger.anticheat(f'Player {player_mgr.get_name()} ({player_mgr.guid}) tried to recharge powers.')
             return 0
 
         player_mgr.recharge_power()

--- a/game/world/opcode_handling/handlers/player/cheats/SpeedCheatHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/SpeedCheatHandler.py
@@ -14,7 +14,7 @@ class SpeedCheatHandler(object):
             return res
 
         if not player_mgr.is_gm:
-            Logger.anticheat(f'Player {player_mgr.player.name} ({player_mgr.guid}) tried to modify speed.')
+            Logger.anticheat(f'Player {player_mgr.get_name()} ({player_mgr.guid}) tried to modify speed.')
             return 0
 
         if len(reader.data) >= 52:  # Avoid handling empty speed cheat packet.

--- a/game/world/opcode_handling/handlers/player/cheats/TaxiClearAllNodesHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/TaxiClearAllNodesHandler.py
@@ -13,7 +13,7 @@ class TaxiClearAllNodesHandler(object):
             return res
 
         if not player_mgr.is_gm:
-            Logger.anticheat(f'Player {player_mgr.player.name} ({player_mgr.guid}) tried to clear all taxi nodes.')
+            Logger.anticheat(f'Player {player_mgr.get_name()} ({player_mgr.guid}) tried to clear all taxi nodes.')
             return 0
 
         player_mgr.taxi_manager.disable_all_taxi_nodes()

--- a/game/world/opcode_handling/handlers/player/cheats/TaxiEnableAllNodesHandlers.py
+++ b/game/world/opcode_handling/handlers/player/cheats/TaxiEnableAllNodesHandlers.py
@@ -13,7 +13,7 @@ class TaxiEnableAllNodesHandler(object):
             return res
 
         if not player_mgr.is_gm:
-            Logger.anticheat(f'Player {player_mgr.player.name} ({player_mgr.guid}) tried to enable all taxi nodes.')
+            Logger.anticheat(f'Player {player_mgr.get_name()} ({player_mgr.guid}) tried to enable all taxi nodes.')
             return 0
 
         player_mgr.taxi_manager.enable_all_taxi_nodes()

--- a/game/world/opcode_handling/handlers/player/cheats/TriggerCinematicCheatHandler.py
+++ b/game/world/opcode_handling/handlers/player/cheats/TriggerCinematicCheatHandler.py
@@ -17,7 +17,7 @@ class TriggerCinematicCheatHandler(object):
             return res
 
         if not player_mgr.is_gm:
-            Logger.anticheat(f'Player {player_mgr.player.name} ({player_mgr.guid}) tried to force trigger a cinematic.')
+            Logger.anticheat(f'Player {player_mgr.get_name()} ({player_mgr.guid}) tried to force trigger a cinematic.')
             return 0
 
         if len(reader.data) >= 4:  # Avoid handling empty trigger cinematic cheat packet.

--- a/game/world/opcode_handling/handlers/social/BugHandler.py
+++ b/game/world/opcode_handling/handlers/social/BugHandler.py
@@ -19,7 +19,7 @@ class BugHandler(object):
                 is_bug=is_bug,
                 account_name=world_session.account_mgr.account.name,
                 account_id=world_session.account_mgr.account.id,
-                character_name=world_session.player_mgr.player.name,
+                character_name=world_session.player_mgr.get_name(),
                 text_body=body
             ))
 

--- a/game/world/opcode_handling/handlers/social/TextEmoteHandler.py
+++ b/game/world/opcode_handling/handlers/social/TextEmoteHandler.py
@@ -22,11 +22,11 @@ class TextEmoteHandler(object):
                 if not target:
                     data += pack('<B', 0)
                 elif target.get_type_id() == ObjectTypeIds.ID_PLAYER:
-                    player_name_bytes = PacketWriter.string_to_bytes(target.player.name)
+                    player_name_bytes = PacketWriter.string_to_bytes(target.get_name())
                     data += pack(f'<{len(player_name_bytes)}s',
                                  player_name_bytes)
                 elif target.get_type_id() == ObjectTypeIds.ID_UNIT and target.creature_template:
-                    unit_name_bytes = PacketWriter.string_to_bytes(target.creature_template.name)
+                    unit_name_bytes = PacketWriter.string_to_bytes(target.get_name())
                     data += pack(f'<{len(unit_name_bytes)}s',
                                  unit_name_bytes)
                 else:

--- a/game/world/opcode_handling/handlers/social/WhoHandler.py
+++ b/game/world/opcode_handling/handlers/social/WhoHandler.py
@@ -56,7 +56,7 @@ class WhoHandler(object):
 
                     if player_mgr.level < level_min or player_mgr.level > level_max:
                         continue
-                    if player_name and not player_name.lower() in player_mgr.player.name.lower:
+                    if player_name and not player_name.lower() in player_mgr.get_name().lower:
                         continue
                     if player_mgr.guild_manager and guild_name and guild_name.lower() not in player_mgr.guild_manager.guild.name.lower():
                         continue
@@ -84,13 +84,13 @@ class WhoHandler(object):
                     if user_strings_count > 0:
                         skip = True
                         for string in user_strings:
-                            if string.lower() in player_mgr.player.name.lower():
+                            if string.lower() in player_mgr.get_name().lower():
                                 skip = False
                                 break
                         if skip:
                             continue
 
-                    player_name_bytes = PacketWriter.string_to_bytes(player_mgr.player.name)
+                    player_name_bytes = PacketWriter.string_to_bytes(player_mgr.get_name())
 
                     player_guild_name = player_mgr.guild_manager.guild.name if player_mgr.guild_manager else ''
                     guild_name_bytes = PacketWriter.string_to_bytes(player_guild_name)

--- a/game/world/opcode_handling/handlers/world/WorldTeleportHandler.py
+++ b/game/world/opcode_handling/handlers/world/WorldTeleportHandler.py
@@ -18,7 +18,7 @@ class WorldTeleportHandler(object):
                 pack_guid, map_, x, y, z, o = unpack('<IB4f', reader.data[:21])
                 world_session.player_mgr.teleport(map_, Vector(x, y, z, o))
         else:
-            Logger.anticheat(f'Player {world_session.player_mgr.player.name} ({world_session.player_mgr.guid}) tried to teleport himself.')
+            Logger.anticheat(f'Player {world_session.player_mgr.get_name()} ({world_session.player_mgr.guid}) tried to teleport himself.')
 
         return 0
 

--- a/network/packet/update/UpdatePacketFactory.py
+++ b/network/packet/update/UpdatePacketFactory.py
@@ -100,7 +100,7 @@ class UpdatePacketFactory(object):
     def _debug_field_acquisition(self, requester, index, was_protected):
         update_field_info = ENCAPSULATION_INFORMATION[self.fields_type][index]
         result = {'[PROTECTED]' if was_protected else '[ACCESSED]'}
-        Logger.debug(f"{requester.player.name} - [{update_field_info}] - {result}, Value [{self.update_values[index]}]")
+        Logger.debug(f"{requester.get_name()} - [{update_field_info}] - {result}, Value [{self.update_values[index]}]")
 
     def reset(self):
         self.update_mask.clear()

--- a/utils/TextUtils.py
+++ b/utils/TextUtils.py
@@ -51,8 +51,8 @@ class GameTextFormatter:
         return text \
             .replace('$B', '\n') \
             .replace('$b', '\n') \
-            .replace('$N', player_mgr.player.name) \
-            .replace('$n', player_mgr.player.name) \
+            .replace('$N', player_mgr.get_name()) \
+            .replace('$n', player_mgr.get_name()) \
             .replace('$R', GameTextFormatter.race_to_text(player_mgr.player.race)) \
             .replace('$r', GameTextFormatter.race_to_text(player_mgr.player.race).lower()) \
             .replace('$C', GameTextFormatter.class_to_text(player_mgr.player.class_)) \


### PR DESCRIPTION
- Stealth now works alongside the update system. (Destroying or creating world objects based on detection)
- AuraInterrupt for entering combat should only trigger upon entering combat.
- Can't request duel while stealth.
- Reset combo points after duel end.
- Players, update_known_world_objects() no longer needs a thread lock and will be called on tick.
- Cell, send_surrounding() will now always skip recipients which don't know the source (world object) of the message.
- Party members should always detect stealth, unless dueling.
- Changes to detection system, 'unit gain stealth' should now appear on near players logs.
- We no longer destroy the player immediately upon stealth, this gives a brief period of time for the near players to see the 'vanishing' animation. We have the same popping issue than with teleport or using chairs so this can't be smoothed.
- Add missing field to SMSG_SPELL_FAILURE packet. (Was not able to reproduce lingering spell casting sound but might be related #715)
- Closes #716