### PR TITLE
Fix pet detach.

### DIFF
--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -235,10 +235,13 @@ class GridManager:
         else:
             return res[0]
 
-    def get_surrounding_unit_spawns(self, world_object):
+    def get_surrounding_unit_spawns(self, world_object, brute_force=False):
         spawns = {}
         location = world_object.location
-        for cell in self.get_surrounding_cells_by_location(location.x, location.y, world_object.map_):
+        # Search either near cells or beyond given brute_force flag.
+        cells = self.get_surrounding_cells_by_location(location.x, location.y, world_object.map_) \
+            if not brute_force else set(self.cells.values())
+        for cell in cells:
             for spawn_id, spawn in list(cell.creatures_spawns.items()):
                 spawns[spawn_id] = spawn
         return spawns
@@ -292,8 +295,8 @@ class GridManager:
 
         return None
 
-    def get_surrounding_creature_spawn_by_spawn_id(self, world_object, spawn_id):
-        surrounding_units_spawns = self.get_surrounding_unit_spawns(world_object)
+    def get_surrounding_creature_spawn_by_spawn_id(self, world_object, spawn_id, brute_force=False):
+        surrounding_units_spawns = self.get_surrounding_unit_spawns(world_object, brute_force=brute_force)
         if spawn_id in surrounding_units_spawns:
             return surrounding_units_spawns[spawn_id]
         return None

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -391,9 +391,9 @@ class MapManager:
             world_object, include_players)
 
     @staticmethod
-    def get_surrounding_creature_spawn_by_spawn_id(world_object, spawn_id):
+    def get_surrounding_creature_spawn_by_spawn_id(world_object, spawn_id, brute_force=False):
         return MapManager.get_grid_manager_by_map_id(world_object.map_).get_surrounding_creature_spawn_by_spawn_id(
-            world_object, spawn_id=spawn_id)
+            world_object, spawn_id=spawn_id, brute_force=brute_force)
 
     @staticmethod
     def get_surrounding_units_by_location(vector, target_map, range_, include_players=False):

--- a/game/world/managers/objects/units/PetManager.py
+++ b/game/world/managers/objects/units/PetManager.py
@@ -330,11 +330,11 @@ class PetManager:
         movement_type = MovementTypes.IDLE
         # Check if this is a borrowed creature instance.
         if creature.spawn_id:
-            charmer_or_summoner = creature.get_charmer_or_summoner()
-            spawn = MapManager.get_surrounding_creature_spawn_by_spawn_id(charmer_or_summoner, creature.spawn_id)
+            # This creature might be too far from its spawn upon detach, brute force the search.
+            spawn = MapManager.get_surrounding_creature_spawn_by_spawn_id(creature, creature.spawn_id, True)
             if not spawn:
                 Logger.error(f'Unable to locate SpawnCreature with id {creature.spawn_id} upon pet detach.')
-            if not spawn.restore_creature_instance(creature):
+            elif not spawn.restore_creature_instance(creature):
                 Logger.error(f'Unable to locate un-borrow creature from spawn id {creature.spawn_id} upon pet detach.')
             movement_type = spawn.movement_type
 


### PR DESCRIPTION
- Upon pet detaching of a borrowed creature instance, brute force the spawn parent search across cells.