### PR TITLE
Implement area aura effects separately from aura handling / minor fixes

### DIFF
--- a/game/world/managers/objects/ai/CreatureAI.py
+++ b/game/world/managers/objects/ai/CreatureAI.py
@@ -316,10 +316,6 @@ class CreatureAI:
                     return SpellCheckCastResult.SPELL_FAILED_UNIT_NOT_BEHIND
                 return SpellCheckCastResult.SPELL_FAILED_UNIT_NOT_INFRONT
 
-            # If the spell requires the target having a specific power type.
-            if not casting_spell.is_area_of_effect_spell() and not casting_spell.is_target_power_type_valid():
-                return SpellCheckCastResult.SPELL_FAILED_UNKNOWN
-
             # No point in casting if target is immune.
             if target and target != self:
                 if not casting_spell.is_positive_spell() and casting_spell.is_target_immune_to_damage():

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -240,21 +240,22 @@ class CastingSpell:
     def has_spell_visual_pre_cast_kit(self):
         return self.spell_visual_entry and self.spell_visual_entry.PrecastKit > 0
 
-    def is_target_power_type_valid(self):
-        if not self.initial_target:
-            return False
-
+    def is_target_power_type_valid(self, target):
         if len(self._effects) == 0:
             return True
 
         for effect in self.get_effects():
-            if (effect.effect_type == SpellEffects.SPELL_EFFECT_POWER_BURN
-                    or effect.effect_type == SpellEffects.SPELL_EFFECT_POWER_DRAIN
-                    or effect.aura_type == AuraTypes.SPELL_AURA_PERIODIC_MANA_LEECH) \
-                    and effect.misc_value != self.initial_target.power_type:
+            if effect.effect_type not in \
+                    {SpellEffects.SPELL_EFFECT_POWER_BURN,
+                     SpellEffects.SPELL_EFFECT_POWER_DRAIN} and \
+                    effect.aura_type not in \
+                    {AuraTypes.SPELL_AURA_PERIODIC_MANA_LEECH,
+                     AuraTypes.SPELL_AURA_PERIODIC_MANA_FUNNEL}:
                 continue
-            return True
-        return False
+
+            if effect.misc_value != target.power_type:
+                return False
+        return True
 
     # TODO: Check 'IsImmuneToDamage' - VMaNGOS
     def is_target_immune_to_damage(self):

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -7,6 +7,7 @@ from database.dbc.DbcModels import Spell, SpellRange, SpellDuration, SpellCastTi
 from game.world.managers.abstractions.Vector import Vector
 from game.world.managers.maps.MapManager import MapManager
 from game.world.managers.objects.ObjectManager import ObjectManager
+from game.world.managers.objects.dynamic.DynamicObjectManager import DynamicObjectManager
 from game.world.managers.objects.item.ItemManager import ItemManager
 from game.world.managers.objects.item.Stats import SpellStat
 from game.world.managers.objects.spell import ExtendedSpellData
@@ -48,6 +49,8 @@ class CastingSpell:
 
     spell_attack_type: int
     used_ranged_attack_item: ItemManager  # Ammo or thrown.
+
+    dynamic_object: Optional[DynamicObjectManager]
 
     def __init__(self, spell, caster, initial_target, target_mask, source_item=None, triggered=False, creature_spell=None):
         self.spell_entry = spell

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -344,7 +344,7 @@ class EffectTargets:
             return units_in_range
 
         for unit in units:
-            if caster is unit or unit is charmer_or_summoner or unit is caster or unit is caster_pet or \
+            if caster is unit or unit is charmer_or_summoner or unit is caster_pet or \
                     not party_group.is_party_member(unit.guid) or \
                     caster.can_attack_target(unit):   # Dueling party members
                 continue

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -1093,6 +1093,12 @@ class SpellManager:
 
         # Effect-specific validation.
 
+        # Target power type check (mana drain etc.)
+        if casting_spell.initial_target_is_unit_or_player() and \
+                not casting_spell.is_target_power_type_valid(validation_target):
+            self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS)
+            return False
+
         # Enchanting checks.
         if casting_spell.is_enchantment_spell():
             # TODO: We don't have EquippedItemInventoryTypeMask, so we have no way to validate inventory slots.

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -727,6 +727,8 @@ class SpellManager:
     def handle_spell_effect_update(self, casting_spell, timestamp) -> bool:
         is_finished = True
         for effect in casting_spell.get_effects():
+            # TODO Do other, non-area spell effects depend on any logic here?
+
             # Refresh targets.
             casting_spell.resolve_target_info_for_effect(effect.effect_index)
 

--- a/game/world/managers/objects/spell/aura/AppliedAura.py
+++ b/game/world/managers/objects/spell/aura/AppliedAura.py
@@ -59,15 +59,13 @@ class AppliedAura:
         return self.spell_effect.is_past_next_period()
 
     def update(self, timestamp):
-        # Don't manage active effects' duration/ticks here; both are handled by the caster's SpellManager instead.
-        # See SpellManager::handle_spell_effect_update for more information.
-        is_active = self.source_spell.cast_state == SpellState.SPELL_STATE_ACTIVE
+        if self.spell_effect.area_aura_holder:
+            return  # Area auras are managed by AreaAuraHolder.
 
-        if self.has_duration() and not is_active:
+        if self.has_duration():
             self.spell_effect.update_effect_aura(timestamp)
 
         if self.is_periodic():
             AuraEffectHandler.handle_aura_effect_change(self, self.target)
 
-        if not is_active:
-            self.spell_effect.remove_old_periodic_effect_ticks()
+        self.spell_effect.remove_old_periodic_effect_ticks()

--- a/game/world/managers/objects/spell/aura/AreaAuraHolder.py
+++ b/game/world/managers/objects/spell/aura/AreaAuraHolder.py
@@ -1,0 +1,44 @@
+from game.world.managers.objects.spell.aura.AppliedAura import AppliedAura
+from game.world.managers.objects.spell.aura.AuraEffectHandler import AuraEffectHandler
+
+
+class AreaAuraHolder:
+
+    def __init__(self, effect):
+        self.spell_id = effect.casting_spell.spell_entry.ID
+        self.effect = effect
+        self.current_targets = dict()
+
+    def update(self, now):
+        if self.effect.applied_aura_duration != -1:
+            self.effect.update_effect_aura(now)
+
+        self.update_effect_on_targets()
+        self.effect.remove_old_periodic_effect_ticks()
+
+    def update_effect_on_targets(self, remove=False):
+        if not self.effect.is_periodic():
+            return
+
+        # Effect updates can cause a change in current targets on death - copy values for iteration.
+        for target, aura_index in list(self.current_targets.values()):
+            aura = target.aura_manager.get_aura_by_index(aura_index)
+            if not aura:
+                continue
+            AuraEffectHandler.handle_aura_effect_change(aura, target, remove=remove)
+
+    def add_target(self, target):
+        new_aura = AppliedAura(self.effect.casting_spell.spell_caster, self.effect.casting_spell, self.effect, target)
+        aura_index = target.aura_manager.add_aura(new_aura)
+        self.current_targets[target.guid] = (target, aura_index)
+
+    def remove_target(self, target):
+        target.aura_manager.cancel_auras_by_spell_id(self.effect.casting_spell.spell_entry.ID)
+        self.current_targets.pop(target.guid, None)
+
+    def destroy(self):
+        self.update_effect_on_targets(remove=True)
+        for target, aura_index in self.current_targets.values():
+            aura = target.aura_manager.get_aura_by_index(aura_index)
+            target.aura_manager.remove_aura(aura)
+

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -33,7 +33,7 @@ class AuraManager:
     def add_aura(self, aura):
         can_apply = self.can_apply_aura(aura) and self.remove_colliding_effects(aura)
         if not can_apply:
-            return
+            return -1
 
         # Application threat and negative aura application interrupts.
         if aura.harmful:
@@ -68,9 +68,13 @@ class AuraManager:
         AuraEffectHandler.handle_aura_effect_change(aura, aura.target)
 
         self.write_aura_to_unit(aura, is_refresh=is_refresh)
+        return aura.index
 
     def update(self, timestamp):
         for aura in list(self.active_auras.values()):
+            if aura.spell_effect.area_aura_holder:
+                continue  # Area auras are updated by AreaAuraHolder.
+
             aura.update(timestamp)  # Update duration and handle periodic effects.
             if aura.has_duration() and aura.get_duration() <= 0:
                 self.remove_aura(aura)

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -824,7 +824,7 @@ class UnitManager(ObjectManager):
     def send_spell_cast_debug_info(self, damage_info, casting_spell):
         is_player = self.get_type_id() == ObjectTypeIds.ID_PLAYER
         spell_debug_packet = damage_info.get_attacker_state_update_spell_info_packet()
-        target_is_player = damage_info.target.get_type_id()
+        target_is_player = damage_info.target.get_type_id() == ObjectTypeIds.ID_PLAYER
         if not damage_info.hit_info & SpellHitFlags.HEALED:
             MapManager.send_surrounding(spell_debug_packet, self, include_self=is_player)
             damage_done_packet = damage_info.get_damage_done_packet()

--- a/game/world/managers/objects/units/player/DuelManager.py
+++ b/game/world/managers/objects/units/player/DuelManager.py
@@ -114,8 +114,10 @@ class DuelManager(object):
             if entry.player.combo_target:
                 entry.player.remove_combo_points()
             entry.player.enqueue_packet(packet)
-            # TODO If this is reached out of combat (only spellcasts, forfeit etc.),
-            #  threat between the players is never cleared.
+
+            # Make sure to clear threat in case players finish out of combat.
+            #  TODO This should be handled elsewhere.
+            entry.player.threat_manager.remove_unit_threat(entry.target)
             entry.player.leave_combat()
             self.build_update(entry.player)
 

--- a/game/world/managers/objects/units/player/DuelManager.py
+++ b/game/world/managers/objects/units/player/DuelManager.py
@@ -114,6 +114,8 @@ class DuelManager(object):
             if entry.player.combo_target:
                 entry.player.remove_combo_points()
             entry.player.enqueue_packet(packet)
+            # TODO If this is reached out of combat (only spellcasts, forfeit etc.),
+            #  threat between the players is never cleared.
             entry.player.leave_combat()
             self.build_update(entry.player)
 


### PR DESCRIPTION
* Add `AreaAuraHolder` for updating area auras.
    * Separate other channeled spells' handling from area auras (handled by target's AuraManager now).
    * Area aura effects now work solely off the caster's SpellManager update. This should fix inconsistencies caused by race conditions with channeled periodic effects (closes #736, #696 probably related).
* Minor changes to dynamic object handling
* Move spell target power type to `validate_cast` from AI cast checks (closes #737)
* Add quick fix for threat not clearing after duels