### PR TITLE
Power type validation/mana leech/aura removal fixes

### DIFF
--- a/game/world/managers/CommandManager.py
+++ b/game/world/managers/CommandManager.py
@@ -302,7 +302,8 @@ class CommandManager(object):
     @staticmethod
     def _unlearn_spell(world_session, spell_id):
         if world_session.player_mgr.spell_manager.unlearn_spell(spell_id):
-            world_session.player_mgr.aura_manager.cancel_auras_by_spell_id(spell_id)
+            world_session.player_mgr.aura_manager.cancel_auras_by_spell_id(spell_id,
+                                                                           source_restriction=world_session.player_mgr)
             return 0, 'Spell unlearned.'
         return -1, 'you do not know this spell yet.'
 

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -253,7 +253,7 @@ class CastingSpell:
                      AuraTypes.SPELL_AURA_PERIODIC_MANA_FUNNEL}:
                 continue
 
-            if effect.misc_value != target.power_type:
+            if effect.misc_value != target.power_type or not target.get_max_power_value():
                 return False
         return True
 

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -549,8 +549,7 @@ class SpellManager:
             for miss_info in casting_spell.object_target_results.values():  # Get the last effect application results.
                 if not miss_info.target.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
                     continue
-                miss_info.target.aura_manager.cancel_auras_by_spell_id(
-                    casting_spell.spell_entry.ID)  # Cancel effects from this aura.
+                miss_info.target.aura_manager.remove_aura_from_spell(casting_spell)
 
         if casting_spell.is_channeled():
             self.handle_channel_end(casting_spell)

--- a/game/world/managers/objects/spell/aura/AreaAuraHolder.py
+++ b/game/world/managers/objects/spell/aura/AreaAuraHolder.py
@@ -34,12 +34,13 @@ class AreaAuraHolder:
         self.current_targets[target.guid] = (target, aura_index)
 
     def remove_target(self, target_guid):
-        target = self.current_targets.pop(target_guid, (None, -1))[0]
+        target, aura_index = self.current_targets.pop(target_guid, (None, -1))[0]
         if not target:
             return
 
-        # noinspection PyUnresolvedReferences
-        target.aura_manager.cancel_auras_by_spell_id(self.effect.casting_spell.spell_entry.ID)
+        aura = target.aura_manager.get_aura_by_index(aura_index)
+        if aura:
+            target.aura_manager.remove_aura(aura)
 
     def destroy(self):
         self.update_effect_on_targets(remove=True)

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -78,9 +78,7 @@ class AuraEffectHandler:
             return
         amount = aura.get_effect_points()
 
-        if effect_target.get_power_type_value(PowerTypes.TYPE_MANA) - amount < 0:
-            return
-
+        amount = min(amount, effect_target.get_power_type_value(PowerTypes.TYPE_MANA))
         effect_target.receive_power(-amount, PowerTypes.TYPE_MANA)
         aura.caster.receive_power(amount, PowerTypes.TYPE_MANA, source=effect_target)
 

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -343,10 +343,12 @@ class AuraManager:
         for aura in list(self.active_auras.values()):
             self.remove_aura(aura)
 
-    def cancel_auras_by_spell_id(self, spell_id):
+    def cancel_auras_by_spell_id(self, spell_id, source_restriction=None):
         auras = self.get_auras_by_spell_id(spell_id)
 
         for aura in auras:
+            if source_restriction and aura.caster is not source_restriction:
+                continue
             self.remove_aura(aura, canceled=True)
 
     def remove_aura_from_spell(self, casting_spell):

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -349,6 +349,14 @@ class AuraManager:
         for aura in auras:
             self.remove_aura(aura, canceled=True)
 
+    def remove_aura_from_spell(self, casting_spell):
+        effects = casting_spell.get_effects()
+        auras = []
+        for aura in list(self.active_auras.values()):
+            if aura.spell_effect in effects:
+                self.remove_aura(aura)
+        return auras
+
     def build_update(self):
         [self.write_aura_to_unit(aura, send_duration=False) for aura in list(self.active_auras.values())]
 

--- a/game/world/managers/objects/units/player/EnchantmentManager.py
+++ b/game/world/managers/objects/units/player/EnchantmentManager.py
@@ -124,7 +124,8 @@ class EnchantmentManager(object):
         for enchantment in EnchantmentManager.get_enchantments_by_type(item, enchantment_type):
             effect_spell_value = enchantment.get_enchantment_effect_spell_by_type(enchantment_type)
             if effect_spell_value and self.unit_mgr.aura_manager.has_aura_by_spell_id(effect_spell_value):
-                self.unit_mgr.aura_manager.cancel_auras_by_spell_id(effect_spell_value)
+                self.unit_mgr.aura_manager.cancel_auras_by_spell_id(effect_spell_value,
+                                                                    source_restriction=self.unit_mgr)
 
     def _handle_equip_buffs(self, item, remove=False):
         enchantment_type = ItemEnchantmentType.BUFF_EQUIPPED
@@ -134,7 +135,8 @@ class EnchantmentManager(object):
                 continue
 
             if remove:
-                self.unit_mgr.aura_manager.cancel_auras_by_spell_id(effect_spell_value)
+                self.unit_mgr.aura_manager.cancel_auras_by_spell_id(effect_spell_value,
+                                                                    source_restriction=self.unit_mgr)
                 enchantment.flush()
                 continue
 


### PR DESCRIPTION
* Fix power type check for creatures without a power (closes #737)
* Fix mana leech handler behavior when leech amount is greater than remaining mana
* Restrict aura removal calls' scope to avoid removing unrelated auras
    * Add source restriction when removing by spell ID where applicable
    * Remove auras by source spell when possible