### PR TITLE
Fixes and major refactor for power regeneration, other stat fixes/balancing

### DIFF
--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -1304,7 +1304,7 @@ class SpellManager:
         has_health_cost = casting_spell.spell_entry.PowerType == PowerTypes.TYPE_HEALTH
         power_cost = casting_spell.get_resource_cost()
         has_correct_power = self.caster.power_type == casting_spell.spell_entry.PowerType or has_health_cost
-        current_power = self.caster.health if has_health_cost else self.caster.get_power_type_value()
+        current_power = self.caster.health if has_health_cost else self.caster.get_power_value()
         is_player = self.caster.get_type_id() == ObjectTypeIds.ID_PLAYER
         # Items like scrolls or creatures need to be able to cast spells even if they lack the required power type.
         ignore_wrong_power = not is_player or casting_spell.source_item or casting_spell.triggered
@@ -1431,20 +1431,15 @@ class SpellManager:
         else:
             cost = casting_spell.get_resource_cost()
             # Note: resources are consumed after the cast, which means that the caster's power type can change.
-            # Pass the required power to get_power_type_value.
-            current_power = self.caster.health if power_type == PowerTypes.TYPE_HEALTH else self.caster.get_power_type_value(power_type)
+            # Pass the required power to get_power_value.
+            current_power = self.caster.health if power_type == PowerTypes.TYPE_HEALTH \
+                else self.caster.get_power_value(power_type)
             new_power = current_power - cost
 
-        if power_type == PowerTypes.TYPE_MANA:
-            self.caster.set_mana(new_power)
-        elif power_type == PowerTypes.TYPE_RAGE:
-            self.caster.set_rage(new_power)
-        elif power_type == PowerTypes.TYPE_FOCUS:
-            self.caster.set_focus(new_power)
-        elif power_type == PowerTypes.TYPE_ENERGY:
-            self.caster.set_energy(new_power)
-        elif power_type == PowerTypes.TYPE_HEALTH:
+        if power_type == PowerTypes.TYPE_HEALTH:
             self.caster.set_health(new_power)
+        else:
+            self.caster.set_power_value(new_power, power_type)
 
         if is_player and casting_spell.requires_combo_points():
             self.caster.remove_combo_points()

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -78,7 +78,7 @@ class AuraEffectHandler:
             return
         amount = aura.get_effect_points()
 
-        amount = min(amount, effect_target.get_power_type_value(PowerTypes.TYPE_MANA))
+        amount = min(amount, effect_target.get_power_value(PowerTypes.TYPE_MANA))
         effect_target.receive_power(-amount, PowerTypes.TYPE_MANA)
         aura.caster.receive_power(amount, PowerTypes.TYPE_MANA, source=effect_target)
 
@@ -546,7 +546,11 @@ class AuraEffectHandler:
             effect_target.stat_manager.remove_aura_stat_bonus(aura.index)
             return
         amount = aura.get_effect_points()
-        effect_target.stat_manager.apply_aura_stat_bonus(aura.index, UnitStats.POWER_REGENERATION_PER_5, amount)
+
+        # This effect is only used for mana regen by deprecated food rejuvenation spells.
+        # Check provided power type regardless for consistency.
+        power_type = aura.spell_effect.misc_value
+        effect_target.stat_manager.apply_aura_stat_bonus(aura.index, UnitStats.POWER_REGEN_START << power_type, amount)
 
     @staticmethod
     def handle_mod_skill(aura, effect_target, remove):

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -1128,7 +1128,7 @@ class UnitManager(ObjectManager):
             return self.power_4
         return 0
 
-    def set_power_value(self, value, power_type=-1):
+    def set_power_value(self, value: int, power_type=-1):
         if power_type == -1:
             power_type = self.power_type
 

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -543,89 +543,77 @@ class UnitManager(ObjectManager):
 
         # The check to set Focus to 0 on movement needs to be outside of the 2 seconds timer to avoid being able to move
         # without losing Focus on that 2 seconds window.
-        if self.power_type == PowerTypes.TYPE_FOCUS:
+        if self.power_type == PowerTypes.TYPE_FOCUS and self.has_moved and self.get_power_value():
             # https://web.archive.org/web/20040420191923/http://www.worldofwar.net/articles/gencon2003_2.php
             # While a Hunter is standing still, Focus gradually increases. The moment a Hunter moves,
             # Focus drops to zero to prevent kiting. (Blizzard seems to be very anti-kiting;
             # several other features to minimize kiting are in place as well.)
-            if self.has_moved:
-                if self.power_3 > 0:
-                    self.set_focus(0)
+            self.set_power_value(0)
 
         self.last_regen += elapsed
         # Every 2 seconds.
-        if self.last_regen >= 2:
-            self.last_regen = 0
+        if self.last_regen < 2:
+            return
 
-            # Healing aura increases regeneration "by 2 every second", and base points equal to 10.
-            # Calculate 2/5 of hp5/mp5.
-            health_regen = self.stat_manager.get_total_stat(UnitStats.HEALTH_REGENERATION_PER_5) * 0.4
-            mana_regen = self.stat_manager.get_total_stat(UnitStats.POWER_REGENERATION_PER_5) * 0.4
+        self.last_regen = 0
+        self._power_regen_tick(PowerTypes.TYPE_HEALTH)
+        self._power_regen_tick(self.power_type)
 
-            # Health
-            if self.regen_flags & RegenStatsFlags.REGEN_FLAG_HEALTH:
-                if self.health < self.max_health and not self.in_combat:
-                    if health_regen < 1:
-                        health_regen = 1
+    def _power_regen_tick(self, power_type):
+        # Compare regen flags to power type.
+        regen_type_flag = RegenStatsFlags.REGEN_FLAG_HEALTH if power_type == PowerTypes.TYPE_HEALTH \
+            else RegenStatsFlags.REGEN_FLAG_POWER
 
-                    # Apply bonus if sitting.
-                    if self.is_sitting():
-                        health_regen += health_regen * 0.33
+        if not self.regen_flags & regen_type_flag:
+            return
 
-                    if self.health + health_regen >= self.max_health:
-                        self.set_health(self.max_health)
-                    elif self.health < self.max_health:
-                        self.set_health(self.health + int(health_regen))
+        if power_type == PowerTypes.TYPE_FOCUS and self.has_moved:
+            return  # Focus only generates when not moving.
 
-            # Powers
-            # Check if this unit should regenerate its powers.
-            if self.regen_flags & RegenStatsFlags.REGEN_FLAG_POWER:
-                # Mana
-                if self.power_type == PowerTypes.TYPE_MANA:
-                    if self.power_1 < self.max_power_1:
-                        if self.in_combat:
-                            # 1% per second (5% per 5 seconds)
-                            mana_regen = self.base_mana * 0.02
+        current_power = self.get_power_value(power_type)
+        if power_type == PowerTypes.TYPE_RAGE:
+            if current_power <= 0:
+                return  # Rage only decays.
+        elif current_power >= self.get_max_power_value(power_type):
+            return  # Other powers only generate.
 
-                        if mana_regen < 1:
-                            mana_regen = 1
+        regen_stat = UnitStats.POWER_REGEN_START << power_type if \
+            power_type != PowerTypes.TYPE_HEALTH else UnitStats.HEALTH_REGENERATION_PER_5
 
-                        if self.power_1 + mana_regen >= self.max_power_1:
-                            self.set_mana(self.max_power_1)
-                        elif self.power_1 < self.max_power_1:
-                            self.set_mana(self.power_1 + int(mana_regen))
-                # Focus
-                elif self.power_type == PowerTypes.TYPE_FOCUS:
-                    # Don't do anything if the unit is moving.
-                    if self.movement_flags & MoveFlags.MOVEFLAG_MOTION_MASK:
-                        return
+        # TODO It's unclear how mana regeneration should behave and how it should be affected by casting.
+        #  We are currently missing any logic related to casting and mana regen.
+        # 0.12: Life Tap no longer interrupts mana regeneration.
+        # 1.4.0:
+        #  Mana regeneration is now disrupted when a spell has completed casting rather than at the start of casting.
+        #  It will resume normally five seconds after the last spell cast.
+        #  This change increases the total time spent regenerating mana and
+        #  therefore increases the total contribution from Spirit for mana-based classes.
 
-                    if self.power_3 < self.max_power_3:
-                        # 1 Focus per second (2 every 2 seconds) is a guessed value based on the cost of spells.
-                        if self.power_3 + 2 >= self.max_power_3:
-                            self.set_focus(self.max_power_3)
-                        elif self.power_3 < self.max_power_3:
-                            self.set_focus(self.power_3 + 2)
-                # Energy
-                elif self.power_type == PowerTypes.TYPE_ENERGY:
-                    if self.power_4 < self.max_power_4:
-                        # Regenerating 5 Energy every 2 seconds instead of 20. This is a guess based on the cost of
-                        # Sinister Strike in both 1.12 (45 Energy) and 0.5.3 (10 Energy). ((10 * 20) / 45 = 4.44)
-                        if self.power_4 + 5 >= self.max_power_4:
-                            self.set_energy(self.max_power_4)
-                        elif self.power_4 < self.max_power_4:
-                            self.set_energy(self.power_4 + 5)
+        # Always regen 1% base mana per second.
+        regen_per_5 = self.base_mana * 0.05 if power_type == PowerTypes.TYPE_MANA else 0
 
-            # Rage decay
-            if self.power_type == PowerTypes.TYPE_RAGE:
-                if self.power_2 > 0:
-                    if not self.in_combat:
-                        # Defensive Stance (71) description says:
-                        #     "A defensive stance that reduces rage decay when out of combat. [...]."
-                        # We assume the rage decay value is reduced by 50% when on Defensive Stance. We don't really
-                        # know how much it should be reduced, but 50% seemed reasonable (1 point instead of 2).
-                        rage_decay_value = 10 if self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_DEFENSIVESTANCE) else 20
-                        self.set_rage(self.power_2 - rage_decay_value)
+        # Apply regen bonuses from stats, but only out of combat for health and mana.
+        # Note that spells affecting mana regen are not affected by this restriction (only mp5 from spirit),
+        # as they're implemented as periodic energize effects instead.
+        if power_type not in {PowerTypes.TYPE_HEALTH, PowerTypes.TYPE_MANA} or not self.in_combat:
+            regen_per_5 += self.stat_manager.get_total_stat(regen_stat)
+
+        # Health regen from sitting.
+        if power_type == PowerTypes.TYPE_HEALTH and not self.in_combat and self.is_sitting():
+            regen_per_5 *= 4/3
+
+        if power_type == PowerTypes.TYPE_RAGE and not self.in_combat:
+            regen_per_5 = -20  # Hardcode rage decay since there's no stat modifier for it.
+            if self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_DEFENSIVESTANCE):
+                # Defensive Stance (71) description says:
+                #     "A defensive stance that reduces rage decay when out of combat. [...]."
+                # We assume the rage decay value is reduced by 50% when on Defensive Stance. We don't really
+                # know how much it should be reduced, but 50% seemed reasonable (1 point instead of 2).
+                regen_per_5 *= 0.5
+
+        regen_per_tick = regen_per_5 * 0.4  # Regen per 5 -> regen per 2 (per tick).
+        if 0 < regen_per_tick < 1:
+            regen_per_tick = 1  # Round up to 1, but account for negative/zero regen.
 
     # Warrior Stances and Bear Form.
     # Defensive Stance (71): "A defensive stance that reduces rage decay when out of combat.
@@ -634,15 +622,15 @@ class UnitManager(ObjectManager):
     # Berserker Stance (2458): "An aggressive stance. Generate rage when you strike an opponent."
     def generate_rage(self, damage_info, is_attacking=True):
         # Avoid regen if unit has no rage power type.
-        if self.get_type_id() == ObjectTypeIds.ID_UNIT:
-            if self.power_type != PowerTypes.TYPE_RAGE:
-                return
+        if self.power_type != PowerTypes.TYPE_RAGE:
+            return
 
         if not is_attacking and self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_DEFENSIVESTANCE) \
                 or is_attacking and self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BERSERKERSTANCE) \
                 or self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BATTLESTANCE) \
                 or self.has_form(ShapeshiftForms.SHAPESHIFT_FORM_BEAR):
-            self.set_rage(self.power_2 + UnitFormulas.calculate_rage_regen(damage_info, is_attacking=is_attacking))
+            self.receive_power(UnitFormulas.calculate_rage_regen(damage_info, is_attacking=is_attacking),
+                               PowerTypes.TYPE_RAGE)
 
     # Implemented by PlayerManager
     def handle_combat_skill_gain(self, damage_info):
@@ -734,10 +722,8 @@ class UnitManager(ObjectManager):
             return False
 
         new_health = self.health + amount
-        if new_health > self.max_health:
-            self.set_health(self.max_health)
-        else:
-            self.set_health(new_health)
+        # Clamp to 0 - max health.
+        self.set_health(max(0, min(new_health, self.max_health)))
         return True
 
     def receive_power(self, amount, power_type, source=None):
@@ -747,15 +733,7 @@ class UnitManager(ObjectManager):
         if self.power_type != power_type:
             return False
 
-        new_power = self.get_power_type_value() + amount
-        if power_type == PowerTypes.TYPE_MANA:
-            self.set_mana(new_power)
-        elif power_type == PowerTypes.TYPE_RAGE:
-            self.set_rage(new_power)
-        elif power_type == PowerTypes.TYPE_FOCUS:
-            self.set_focus(new_power)
-        elif power_type == PowerTypes.TYPE_ENERGY:
-            self.set_energy(new_power)
+        self.set_power_value(self.get_power_value() + amount)
         return True
 
     def apply_spell_damage(self, target, damage, casting_spell, is_periodic=False):
@@ -1121,7 +1099,7 @@ class UnitManager(ObjectManager):
             self.unit_flags &= ~UnitFlags.UNIT_FLAG_PLAYER_CONTROLLED
         self.set_uint32(UnitFields.UNIT_FIELD_FLAGS, self.unit_flags)
 
-    def get_power_type_value(self, power_type=-1):
+    def get_power_value(self, power_type=-1):
         if power_type == -1:
             power_type = self.power_type
 
@@ -1135,27 +1113,53 @@ class UnitManager(ObjectManager):
             return self.power_4
         return 0
 
-    def get_max_power_value(self):
-        if self.power_type == PowerTypes.TYPE_MANA:
+    def set_power_value(self, value, power_type=-1):
+        if power_type == -1:
+            power_type = self.power_type
+
+        value = max(0, min(value, self.get_max_power_value(power_type)))  # Clamp to 0 - max power.
+
+        if power_type == PowerTypes.TYPE_MANA:
+            self.power_1 = value
+        elif power_type == PowerTypes.TYPE_RAGE:
+            self.power_2 = value
+        elif power_type == PowerTypes.TYPE_FOCUS:
+            self.power_3 = value
+        elif power_type == PowerTypes.TYPE_ENERGY:
+            self.power_4 = value
+
+        self.set_uint32(UnitFields.UNIT_FIELD_POWER1 + power_type, value)
+
+    def get_max_power_value(self, power_type=-1):
+        if power_type == -1:
+            power_type = self.power_type
+
+        if power_type == PowerTypes.TYPE_MANA:
             return self.max_power_1
-        elif self.power_type == PowerTypes.TYPE_RAGE:
+        elif power_type == PowerTypes.TYPE_RAGE:
             return self.max_power_2
-        elif self.power_type == PowerTypes.TYPE_FOCUS:
+        elif power_type == PowerTypes.TYPE_FOCUS:
             return self.max_power_3
-        elif self.power_type == PowerTypes.TYPE_ENERGY:
+        elif power_type == PowerTypes.TYPE_ENERGY:
             return self.max_power_4
         return 0
 
+    def set_max_power_value(self, value, power_type=-1):
+        if power_type == -1:
+            power_type = self.power_type
+
+        if power_type == PowerTypes.TYPE_MANA:
+            self.max_power_1 = value
+        elif power_type == PowerTypes.TYPE_RAGE:
+            self.max_power_2 = value
+        elif power_type == PowerTypes.TYPE_FOCUS:
+            self.max_power_3 = value
+        elif power_type == PowerTypes.TYPE_ENERGY:
+            self.max_power_4 = value
+
     def recharge_power(self):
         max_power = self.get_max_power_value()
-        if self.power_type == PowerTypes.TYPE_MANA:
-            self.set_mana(max_power)
-        elif self.power_type == PowerTypes.TYPE_RAGE:
-            self.set_rage(max_power)
-        elif self.power_type == PowerTypes.TYPE_FOCUS:
-            self.set_focus(max_power)
-        elif self.power_type == PowerTypes.TYPE_ENERGY:
-            self.set_energy(max_power)
+        self.set_power_value(max_power)
 
     def set_school_absorb(self, school_mask, aura_index, value, absorb=True):
         # Initialize if needed.
@@ -1255,30 +1259,6 @@ class UnitManager(ObjectManager):
     def set_max_health(self, health):
         self.max_health = health
         self.set_uint32(UnitFields.UNIT_FIELD_MAXHEALTH, health)
-
-    def set_mana(self, mana):
-        if mana < 0:
-            mana = 0
-        self.power_1 = min(mana, self.max_power_1)
-        self.set_uint32(UnitFields.UNIT_FIELD_POWER1, self.power_1)
-
-    def set_rage(self, rage):
-        if rage < 0:
-            rage = 0
-        self.power_2 = min(rage, self.max_power_2)
-        self.set_uint32(UnitFields.UNIT_FIELD_POWER2, self.power_2)
-
-    def set_focus(self, focus):
-        if focus < 0:
-            focus = 0
-        self.power_3 = min(focus, self.max_power_3)
-        self.set_uint32(UnitFields.UNIT_FIELD_POWER3, self.power_3)
-
-    def set_energy(self, energy):
-        if energy < 0:
-            energy = 0
-        self.power_4 = min(energy, self.max_power_4)
-        self.set_uint32(UnitFields.UNIT_FIELD_POWER4, self.power_4)
 
     def set_max_mana(self, mana):
         self.max_power_1 = mana

--- a/game/world/managers/objects/units/player/GroupManager.py
+++ b/game/world/managers/objects/units/player/GroupManager.py
@@ -547,7 +547,7 @@ class GroupManager(object):
             player_mgr.health if player_mgr else 0,
             player_mgr.max_health if player_mgr else 0,
             player_mgr.power_type if player_mgr else 0,
-            player_mgr.get_power_type_value() if player_mgr else 0,
+            player_mgr.get_power_value() if player_mgr else 0,
             player_mgr.get_max_power_value() if player_mgr else 0,
             player_mgr.level if player_mgr else character.level,
             player_mgr.map_ if player_mgr else character.map,

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1046,7 +1046,7 @@ class PlayerManager(UnitManager):
                 self.stat_manager.init_stats()
                 hp_diff, mana_diff = self.stat_manager.apply_bonuses()
                 self.set_health(self.max_health)
-                self.set_mana(self.max_power_1)
+                self.recharge_power()
 
                 if is_leveling_up:
                     data = pack(
@@ -1674,13 +1674,11 @@ class PlayerManager(UnitManager):
         # the % that players had in 0.5.3, so 100% is assumed.
         self.set_health(math.ceil(self.max_health * recovery_percentage))
         if self.power_type == PowerTypes.TYPE_MANA:
-            self.set_mana(math.ceil(self.max_power_1 * recovery_percentage))
-        if self.power_type == PowerTypes.TYPE_RAGE:
-            self.set_rage(0)
-        if self.power_type == PowerTypes.TYPE_FOCUS:
-            self.set_focus(0)
-        if self.power_type == PowerTypes.TYPE_ENERGY:
-            self.set_energy(self.max_power_4)
+            self.set_power_value(math.ceil(self.get_max_power_value() * recovery_percentage))
+        elif self.power_type == PowerTypes.TYPE_ENERGY:
+            self.recharge_power()
+        else:  # Rage or focus.
+            self.set_power_value(0)
 
         super().respawn()
 

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -168,7 +168,8 @@ class StatManager(object):
             self.unit_mgr.base_hp = base_stats.basehp
             self.unit_mgr.base_mana = base_stats.basemana
 
-            self.base_stats[UnitStats.FOCUS_REGENERATION_PER_5] = 2
+            # Focus/energy values
+            self.base_stats[UnitStats.FOCUS_REGENERATION_PER_5] = 5
             self.base_stats[UnitStats.ENERGY_REGENERATION_PER_5] = 20
             self.base_stats[UnitStats.RAGE_REGENERATION_PER_5] = -50  # Rage decay out of combat.
         # Creatures.

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -512,8 +512,8 @@ class StatManager(object):
         unit_class = self.unit_mgr.class_
         spirit = self.get_total_stat(UnitStats.SPIRIT)
         spirit_regen = int(CLASS_BASE_REGEN_HEALTH[unit_class] + spirit * CLASS_SPIRIT_SCALING_HP5[unit_class])
-        # Values for spirit regen scaling are per second.
-        self.base_stats[UnitStats.HEALTH_REGENERATION_PER_5] = max(0, spirit_regen) * 5
+        # Values for spirit regen scaling are per tick.
+        self.base_stats[UnitStats.HEALTH_REGENERATION_PER_5] = max(0, spirit_regen) * 2.5
 
     def update_base_mana_regen(self):
         unit_class = self.unit_mgr.class_
@@ -523,7 +523,7 @@ class StatManager(object):
         spirit = self.get_total_stat(UnitStats.SPIRIT)
         regen = CLASS_BASE_REGEN_MANA[unit_class] + spirit * CLASS_SPIRIT_SCALING_MANA[unit_class]
         # Values for mana regen scaling are per second.
-        self.base_stats[UnitStats.MANA_REGENERATION_PER_5] = regen * 5
+        self.base_stats[UnitStats.MANA_REGENERATION_PER_5] = regen * 2.5  # Values are per tick (* 5/2).
 
     def update_base_melee_critical_chance(self):
         if self.unit_mgr.get_type_id() != ObjectTypeIds.ID_PLAYER:

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -391,8 +391,9 @@ class StatManager(object):
                 # Use weapon damage values for paw damage instead.
                 # VMaNGOS values.
 
-                # Base attack delay for the two forms.
-                attack_delay = 1000 if self.unit_mgr.has_form(ShapeshiftForms.SHAPESHIFT_FORM_CAT) else 2500
+                # Base attack delay for both forms.
+                # Cat form provides a haste bonus in alpha - using the same attack delay for both.
+                attack_delay = 2500
 
                 self.item_stats[UnitStats.MAIN_HAND_DAMAGE_MIN] = self.unit_mgr.level * 0.85 * (attack_delay / 1000)
                 self.item_stats[UnitStats.MAIN_HAND_DAMAGE_MAX] = self.unit_mgr.level * 1.25 * (attack_delay / 1000)

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -170,7 +170,7 @@ class StatManager(object):
 
             self.base_stats[UnitStats.FOCUS_REGENERATION_PER_5] = 2
             self.base_stats[UnitStats.ENERGY_REGENERATION_PER_5] = 20
-            self.base_stats[UnitStats.RAGE_REGENERATION_PER_5] = -20  # Rage decay.
+            self.base_stats[UnitStats.RAGE_REGENERATION_PER_5] = -50  # Rage decay out of combat.
         # Creatures.
         else:
             self.base_stats[UnitStats.HEALTH] = self.unit_mgr.max_health

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -521,7 +521,7 @@ class StatManager(object):
 
         spirit = self.get_total_stat(UnitStats.SPIRIT)
         regen = CLASS_BASE_REGEN_MANA[unit_class] + spirit * CLASS_SPIRIT_SCALING_MANA[unit_class]
-        # Values for spirit regen scaling are per second.
+        # Values for mana regen scaling are per second.
         self.base_stats[UnitStats.MANA_REGENERATION_PER_5] = regen * 5
 
     def update_base_melee_critical_chance(self):

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -170,6 +170,7 @@ class StatManager(object):
 
             self.base_stats[UnitStats.FOCUS_REGENERATION_PER_5] = 2
             self.base_stats[UnitStats.ENERGY_REGENERATION_PER_5] = 20
+            self.base_stats[UnitStats.RAGE_REGENERATION_PER_5] = -20  # Rage decay.
         # Creatures.
         else:
             self.base_stats[UnitStats.HEALTH] = self.unit_mgr.max_health

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -168,8 +168,10 @@ class StatManager(object):
             self.unit_mgr.base_hp = base_stats.basehp
             self.unit_mgr.base_mana = base_stats.basemana
 
-            # Focus/energy values
-            self.base_stats[UnitStats.FOCUS_REGENERATION_PER_5] = 5
+            # Focus/energy values are guessed.
+            self.base_stats[UnitStats.FOCUS_REGENERATION_PER_5] = 5  # 1 focus/sec
+            # Regenerating 4 Energy every 2 seconds instead of 20. This is a guess based on the cost of
+            # Sinister Strike in both 1.12 (45 Energy) and 0.5.3 (10 Energy). ((10 * 20) / 45 = 4.44)
             self.base_stats[UnitStats.ENERGY_REGENERATION_PER_5] = 20
             self.base_stats[UnitStats.RAGE_REGENERATION_PER_5] = -50  # Rage decay out of combat.
         # Creatures.


### PR DESCRIPTION
* Refactor power regeneration code and move most constants to `StatManager`
    * Merge power-related methods to remove duplicate logic
    * Use offsets by power type id where possible
    * Regeneration and power tick methods are separate to simplify regen logic to one power/call
    * `StatManager` holds all regen/decay constants and stores them as per 5.
        * Energy regen is slightly nerfed to achieve even values with /5 calculations (5 energy->4 / 2sec)
* Change how mana generation behaves
    * Mana regenerates 1% base mana every tick
    * Actively casting and finishing casts interrupts additional spirit-based mana regeneration for 5 seconds
    * Closes #415
* Decrease Cat Form attack speed from 1.0 to 2.5 (bear form).
    * A guess based on Cat Form giving a haste buff, and feral energy starving quickly with such high attack speed paired with their 'next melee'-abilities
    * Note that this doesn't directly affect attack damage, just energy drain and pushback potential