### PR TITLE
QOL: Add ability for gm accounts to be auto created

### DIFF
--- a/database/realm/RealmDatabaseManager.py
+++ b/database/realm/RealmDatabaseManager.py
@@ -46,7 +46,10 @@ class RealmDatabaseManager(object):
     @staticmethod
     def account_create(username, password, ip):
         realm_db_session = SessionHolder()
-        account = Account(name=username, password=password, ip=ip, gmlevel=0)
+        if not config.Server.Settings.auto_create_gm_accounts:
+            account = Account(name=username, password=password, ip=ip, gmlevel=0)
+        else:
+            account = Account(name=username, password=password, ip=ip, gmlevel=1)
         realm_db_session.add(account)
         realm_db_session.flush()
         realm_db_session.refresh(account)

--- a/etc/config/config.yml.dist
+++ b/etc/config/config.yml.dist
@@ -1,5 +1,5 @@
 Version:
-    current: 3
+    current: 4
 
 Database:
     Connection:
@@ -29,6 +29,7 @@ Server:
 
     Settings:
         auto_create_accounts: True
+        auto_create_gm_accounts: False
         blizzlike_names: True  # If True, names won't have any restriction as it was back in the day
         xp_rate: 1.0
         # Debug level values (you can combine them as a mask):

--- a/utils/ConfigManager.py
+++ b/utils/ConfigManager.py
@@ -5,7 +5,7 @@ from utils.PathManager import PathManager
 
 
 class ConfigManager:
-    EXPECTED_VERSION = 3
+    EXPECTED_VERSION = 4
 
     def __init__(self):
         self.config = None


### PR DESCRIPTION
QOL improvement: added ability for GM accounts to be auto created via a config option, disabled by default.