### PR TITLE
Close #798 #799 #801 #804 #828 #826

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -15388,8 +15388,8 @@ begin not atomic
 
     -- 27/12/2022 1
     if (select count(*) from applied_updates where id='271220221') = 0 then
-        UPDATE `alpha_world`.`item_template` SET `buy_price` = '6' WHERE (`entry` = '2678');
-        UPDATE `alpha_world`.`item_template` SET `buy_price` = '6' WHERE (`entry` = '3371');
+        UPDATE `item_template` SET `buy_price` = '6' WHERE (`entry` = '2678');
+        UPDATE `item_template` SET `buy_price` = '6' WHERE (`entry` = '3371');
         insert into applied_updates values ('271220221');
     end if;
 end $

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -15388,8 +15388,8 @@ begin not atomic
 
     -- 27/12/2022 1
     if (select count(*) from applied_updates where id='271220221') = 0 then
-        UPDATE `item_template` SET `buy_price` = '6' WHERE (`entry` = '2678');
-        UPDATE `item_template` SET `buy_price` = '6' WHERE (`entry` = '3371');
+        UPDATE `item_template` SET `buy_count` = '1' WHERE (`entry` = '2678');
+        UPDATE `item_template` SET `buy_count` = '1' WHERE (`entry` = '3371');
         insert into applied_updates values ('271220221');
     end if;
 end $

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -15385,5 +15385,12 @@ begin not atomic
 
         insert into applied_updates values ('251220221');
     end if;
+
+    -- 27/12/2022 1
+    if (select count(*) from applied_updates where id='271220221') = 0 then
+        UPDATE `alpha_world`.`item_template` SET `buy_price` = '6' WHERE (`entry` = '2678');
+        UPDATE `alpha_world`.`item_template` SET `buy_price` = '6' WHERE (`entry` = '3371');
+        insert into applied_updates values ('271220221');
+    end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -15390,6 +15390,21 @@ begin not atomic
     if (select count(*) from applied_updates where id='271220221') = 0 then
         UPDATE `item_template` SET `buy_count` = '1' WHERE (`entry` = '2678');
         UPDATE `item_template` SET `buy_count` = '1' WHERE (`entry` = '3371');
+		
+		-- Fixes #826
+		-- Trainer Template ID 17 - DRUID
+		-- Spell: Parry
+		INSERT INTO `trainer_template` (`template_entry`, `spell`, `playerspell`, `spellcost`, `talentpointcost`, `skillpointcost`, `reqskill`, `reqskillvalue`, `reqlevel`) VALUES ('17', '3128', '3127', '10', '0', '0', '0', '0', '1');
+		-- Trainer Template ID 17 - DRUID
+		-- Spell: Bear Form - (Rank 1)
+		INSERT INTO `trainer_template` (`template_entry`, `spell`, `playerspell`, `spellcost`, `talentpointcost`, `skillpointcost`, `reqskill`, `reqskillvalue`, `reqlevel`) VALUES ('17', '5488', '5487', '2600', '0', '0', '0', '0', '20');
+		-- Trainer Template ID 17 - DRUID
+		-- Spell: Aquatic Form - (Rank 1)
+		INSERT INTO `trainer_template` (`template_entry`, `spell`, `playerspell`, `spellcost`, `talentpointcost`, `skillpointcost`, `reqskill`, `reqskillvalue`, `reqlevel`) VALUES ('17', '1446', '1066', '8000', '0', '0', '0', '0', '30');
+		-- Trainer Template ID 17 - DRUID
+		-- Spell: Growl - (Rank 1)
+		INSERT INTO `trainer_template` (`template_entry`, `spell`, `playerspell`, `spellcost`, `talentpointcost`, `skillpointcost`, `reqskill`, `reqskillvalue`, `reqlevel`) VALUES ('17', '6796', '6795', '2600', '0', '0', '0', '0', '20');
+		
         insert into applied_updates values ('271220221');
     end if;
 end $

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -59,14 +59,14 @@ class WorldLoader:
         if config.Server.Settings.load_gameobjects:
             WorldLoader.load_gameobject_quest_starters()
             WorldLoader.load_gameobject_quest_finishers()
-            WorldLoader.load_gameobjects_spawns()
+            #WorldLoader.load_gameobjects_spawns()
         else:
             Logger.info('Skipped game object loading.')
 
         # Creature spawns
         if config.Server.Settings.load_creatures:
             WorldLoader.load_creature_equip_templates()
-            WorldLoader.load_creature_spawns()
+            #WorldLoader.load_creature_spawns()
             WorldLoader.load_creature_on_kill_reputation()
             WorldLoader.load_creature_quest_starters()
             WorldLoader.load_creature_quest_finishers()

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -59,14 +59,14 @@ class WorldLoader:
         if config.Server.Settings.load_gameobjects:
             WorldLoader.load_gameobject_quest_starters()
             WorldLoader.load_gameobject_quest_finishers()
-            #WorldLoader.load_gameobjects_spawns()
+            WorldLoader.load_gameobjects_spawns()
         else:
             Logger.info('Skipped game object loading.')
 
         # Creature spawns
         if config.Server.Settings.load_creatures:
             WorldLoader.load_creature_equip_templates()
-            #WorldLoader.load_creature_spawns()
+            WorldLoader.load_creature_spawns()
             WorldLoader.load_creature_on_kill_reputation()
             WorldLoader.load_creature_quest_starters()
             WorldLoader.load_creature_quest_finishers()

--- a/game/world/managers/objects/farsight/Camera.py
+++ b/game/world/managers/objects/farsight/Camera.py
@@ -41,8 +41,6 @@ class Camera:
             current = player_mgr.get_uint64(PlayerFields.PLAYER_FARSIGHT)
             if current == self.world_object.guid:
                 player_mgr.set_far_sight(0)
-                # Upon returning to players own view, need to force the update so client is aware immediately.
-                player_mgr.force_fields_update()
             del self.players[player_mgr.guid]
 
     def flush(self):

--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -242,7 +242,7 @@ class GameObjectManager(ObjectManager):
     def is_active_object(self):
         return len(self.known_players) > 0
 
-    def apply_spell_damage(self, target, damage, casting_spell, is_periodic=False):
+    def apply_spell_damage(self, target, damage, casting_spell, aura=None, is_periodic=False):
         # Skip if target is invalid or already dead.
         if not target or not target.is_alive:
             return
@@ -251,7 +251,7 @@ class GameObjectManager(ObjectManager):
         damage_info.spell_miss_reason = casting_spell.object_target_results[target.guid].result
 
         target.send_spell_cast_debug_info(damage_info, casting_spell)
-        target.receive_damage(damage_info, self, is_periodic)
+        target.receive_damage(damage_info, self, casting_spell=casting_spell, aura=aura, is_periodic=is_periodic)
 
         # Send environmental damage log packet to the affected player.
         if self.gobject_template.type == GameObjectTypes.TYPE_TRAP and target.get_type_id() == ObjectTypeIds.ID_PLAYER:

--- a/game/world/managers/objects/item/ItemManager.py
+++ b/game/world/managers/objects/item/ItemManager.py
@@ -251,7 +251,7 @@ class ItemManager(ObjectManager):
             item_template.quality,
             item_template.flags,
             item_template.buy_price,
-            item_template.sell_price,
+            int(max(1, item_template.sell_price / item_template.buy_count)),  # Unitary price.
             item_template.inventory_type,
             item_template.allowable_class,
             item_template.allowable_race,

--- a/game/world/managers/objects/spell/SpellEffect.py
+++ b/game/world/managers/objects/spell/SpellEffect.py
@@ -41,6 +41,7 @@ class SpellEffect:
     # Duration and periodic timing info for auras applied by this effect
     applied_aura_duration = -1
     periodic_effect_ticks: Optional[list[int]] = None  # None for distinct uninitialized state.
+    periodic_total_ticks: int = -1
     last_update_timestamp = -1
 
     area_aura_holder: Optional[AreaAuraHolder] = None
@@ -73,6 +74,9 @@ class SpellEffect:
         return self.periodic_effect_ticks is not None and \
                len(self.periodic_effect_ticks) > 0 and self.periodic_effect_ticks[-1] >= self.applied_aura_duration
 
+    def periodic_was_already_active(self):
+        return self.has_periodic_ticks_remaining() and len(self.periodic_effect_ticks) < self.periodic_total_ticks
+
     def has_periodic_ticks_remaining(self):
         if not self.is_periodic() or not self.casting_spell.duration_entry:
             return False
@@ -104,6 +108,7 @@ class SpellEffect:
 
         if self.is_periodic():
             self.periodic_effect_ticks = self.generate_periodic_effect_ticks()
+            self.periodic_total_ticks = len(self.periodic_effect_ticks)
 
     def is_periodic(self):
         return self.aura_period != 0

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -693,6 +693,7 @@ class SpellEffectHandler:
         duration = casting_spell.get_duration() / 1000
         dyn_object = DynamicObjectManager.spawn_from_spell_effect(effect,
                                                                   DynamicObjectTypes.DYNAMIC_OBJECT_FARSIGHT_FOCUS,
+                                                                  orientation=caster.location.o,
                                                                   ttl=duration)
         FarSightManager.add_camera(dyn_object, caster)
 

--- a/game/world/managers/objects/spell/aura/AppliedAura.py
+++ b/game/world/managers/objects/spell/aura/AppliedAura.py
@@ -1,7 +1,6 @@
 from game.world.managers.objects.spell import ExtendedSpellData
-from game.world.managers.objects.spell.aura.AuraEffectDummyHandler import AuraEffectDummyHandler
 from game.world.managers.objects.spell.aura.AuraEffectHandler import AuraEffectHandler
-from utils.constants.SpellCodes import SpellEffects, SpellState, SpellAttributes, DispelType
+from utils.constants.SpellCodes import SpellEffects, DispelType
 
 
 class AppliedAura:
@@ -55,6 +54,9 @@ class AppliedAura:
 
     def get_effect_points(self):
         return self.spell_effect.get_effect_points() * self.applied_stacks
+
+    def periodic_was_already_active(self) -> bool:
+        return self.spell_effect.periodic_was_already_active()
 
     def is_past_next_period(self) -> bool:
         return self.spell_effect.is_past_next_period()

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -143,18 +143,16 @@ class AuraEffectHandler:
     def handle_periodic_damage(aura, effect_target, remove):
         if not aura.is_past_next_period() or remove:
             return
-        spell = aura.source_spell
         damage = aura.get_effect_points()
-        aura.caster.apply_spell_damage(effect_target, damage, spell, is_periodic=True)
+        aura.caster.apply_spell_damage(effect_target, damage, aura.source_spell, aura, is_periodic=True)
 
     @staticmethod
     def handle_periodic_leech(aura, effect_target, remove):
         if not aura.is_past_next_period() or remove:
             return
-        spell = aura.source_spell
         damage = aura.get_effect_points()
         aura.caster.receive_healing(damage, aura.caster)
-        aura.caster.apply_spell_damage(effect_target, damage, spell, is_periodic=True)
+        aura.caster.apply_spell_damage(effect_target, damage, aura.source_spell, aura, is_periodic=True)
 
     @staticmethod
     def handle_channel_death_item(aura, effect_target, remove):
@@ -245,7 +243,7 @@ class AuraEffectHandler:
             return
 
         damage = aura.get_effect_points()
-        aura.target.apply_spell_damage(effect_target, damage, aura.source_spell)
+        aura.target.apply_spell_damage(effect_target, damage, aura.source_spell, aura)
 
     @staticmethod
     # TODO: Spell MISS.
@@ -430,7 +428,7 @@ class AuraEffectHandler:
             return
 
         damage = aura.get_effect_points()
-        aura.target.apply_spell_damage(effect_target, damage, aura.source_spell)
+        aura.target.apply_spell_damage(effect_target, damage, aura.source_spell, aura)
 
     @staticmethod
     def handle_school_absorb(aura, effect_target, remove):

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -266,7 +266,7 @@ class AuraEffectHandler:
 
     @staticmethod
     def handle_water_breathing(aura, effect_target, remove):
-        effect_target.mirror_timers_manager.update_water_breathing()
+        effect_target.mirror_timers_manager.update_water_breathing(state=not remove)
 
     @staticmethod
     def handle_mod_disarm(aura, effect_target, remove):

--- a/game/world/managers/objects/timers/MirrorTimer.py
+++ b/game/world/managers/objects/timers/MirrorTimer.py
@@ -2,7 +2,6 @@ from struct import pack
 from network.packet.PacketWriter import PacketWriter
 from utils.constants.MiscCodes import MirrorTimerTypes
 from utils.constants.OpCodes import OpCode
-from utils.constants.SpellCodes import AuraTypes
 
 
 class MirrorTimer(object):
@@ -61,8 +60,8 @@ class MirrorTimer(object):
             return MirrorTimerTypes.FATIGUE.value
         return self.type.value
 
-    def update_water_breathing(self):
-        self.has_water_breathing = self.owner.aura_manager.get_auras_by_type(AuraTypes.SPELL_AURA_WATER_BREATHING)
+    def update_water_breathing(self, state):
+        self.has_water_breathing = state
         self.send_full_update()
 
     def send_full_update(self):

--- a/game/world/managers/objects/timers/MirrorTimersManager.py
+++ b/game/world/managers/objects/timers/MirrorTimersManager.py
@@ -18,8 +18,8 @@ class MirrorTimersManager(object):
         self.timers[MirrorTimerTypes.FATIGUE] = MirrorTimer(self.owner, MirrorTimerTypes.FATIGUE, 1, 60)
         self.timers[MirrorTimerTypes.FEIGNDEATH] = MirrorTimer(self.owner, MirrorTimerTypes.FEIGNDEATH, 1, 300)
 
-    def update_water_breathing(self):
-        self.timers[MirrorTimerTypes.BREATH].update_water_breathing()
+    def update_water_breathing(self, state):
+        self.timers[MirrorTimerTypes.BREATH].update_water_breathing(state)
 
     def stop_all(self):
         for timer in self.timers.values():

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -698,16 +698,16 @@ class UnitManager(ObjectManager):
 
         return damage_info
 
-    def deal_damage(self, target, damage_info, is_periodic=False, casting_spell=None):
+    def deal_damage(self, target, damage_info, casting_spell=None, aura=None, is_periodic=False):
         if not target or not target.is_alive:
             return
 
         if target.is_evading:
             return
 
-        target.receive_damage(damage_info, source=self, is_periodic=is_periodic, casting_spell=casting_spell)
+        target.receive_damage(damage_info, source=self, casting_spell=casting_spell, aura=aura, is_periodic=is_periodic)
 
-    def receive_damage(self, damage_info, source=None, is_periodic=False, casting_spell=None):
+    def receive_damage(self, damage_info, source=None, casting_spell=None, aura=None, is_periodic=False):
         # This method will return whether or not the unit is suitable to keep receiving damage.
         if not self.is_alive:
             return False
@@ -728,6 +728,12 @@ class UnitManager(ObjectManager):
         # No damage but source spell generates threat on miss.
         if casting_spell and damage_info.total_damage == 0 and casting_spell.generates_threat_on_miss():
             self.threat_manager.add_threat(source)
+            return True
+        # Spell and does not generate threat.
+        elif casting_spell and not casting_spell.generates_threat():
+            return True
+        # Lingering auras ticking dots should not modify threat table after leaving combat.
+        elif aura and is_periodic and aura.periodic_was_already_active() and not self.threat_manager.has_aggro_from(source):
             return True
 
         self.threat_manager.add_threat(source, damage_info.total_damage)
@@ -755,7 +761,7 @@ class UnitManager(ObjectManager):
         self.set_power_value(self.get_power_value() + amount)
         return True
 
-    def apply_spell_damage(self, target, damage, casting_spell, is_periodic=False):
+    def apply_spell_damage(self, target, damage, casting_spell, aura=None, is_periodic=False):
         # Skip if target is invalid or already dead.
         if not target or not target.is_alive:
             return False
@@ -788,7 +794,7 @@ class UnitManager(ObjectManager):
             target.handle_combat_skill_gain(damage_info)
 
         self.send_spell_cast_debug_info(damage_info, casting_spell)
-        self.deal_damage(target, damage_info, is_periodic=is_periodic, casting_spell=casting_spell)
+        self.deal_damage(target, damage_info, casting_spell=casting_spell, aura=aura, is_periodic=is_periodic)
         return True
 
     def apply_spell_healing(self, target, value, casting_spell, is_periodic=False):

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -607,11 +607,12 @@ class CreatureManager(UnitManager):
         return False
 
     # override
-    def receive_damage(self, damage_info, source=None, is_periodic=False, casting_spell=None):
+    def receive_damage(self, damage_info, source=None, casting_spell=None, aura=None, is_periodic=False):
         if not self.is_spawned:
             return False
 
-        if not super().receive_damage(damage_info, source, is_periodic):
+        if not super().receive_damage(damage_info, source, casting_spell=casting_spell,
+                                      aura=aura, is_periodic=is_periodic):
             return False
 
         # Handle COMBAT_PING creature static flag.

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1519,11 +1519,12 @@ class PlayerManager(UnitManager):
         self.set_uint64(UnitFields.UNIT_FIELD_COMBO_TARGET, self.combo_target)
 
     # override
-    def receive_damage(self, damage_info, source=None, is_periodic=False, casting_spell=None):
+    def receive_damage(self, damage_info, source=None, casting_spell=None, aura=None, is_periodic=False):
         if self.is_god:
             return False
 
-        return super().receive_damage(damage_info, source, is_periodic=False)
+        return super().receive_damage(damage_info, source, casting_spell=casting_spell,
+                                      aura=aura, is_periodic=is_periodic)
 
     # override
     def receive_healing(self, amount, source=None):

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1455,6 +1455,8 @@ class PlayerManager(UnitManager):
 
     def set_far_sight(self, guid):
         self.set_uint64(PlayerFields.PLAYER_FARSIGHT, guid)
+        # Upon changing players view camera, need to force the update so client is aware immediately.
+        self.force_fields_update()
 
     def set_charmed_by(self, charmer, subtype=0, movement_type=None, remove=False):
         # Charmer must be set here not in parent.

--- a/game/world/opcode_handling/handlers/npc/SellItemHandler.py
+++ b/game/world/opcode_handling/handlers/npc/SellItemHandler.py
@@ -52,5 +52,6 @@ class SellItemHandler(object):
                 else:
                     world_session.player_mgr.inventory.remove_item(container_slot, slot)
 
-                world_session.player_mgr.mod_money(price * sell_amount)
+                unitary_price = int(max(1, item.item_template.sell_price / item.item_template.buy_count))
+                world_session.player_mgr.mod_money(unitary_price * sell_amount)
         return 0


### PR DESCRIPTION
Closes #798

- Regarding 'Switching to Sentry Totem vision when having Far Sight active makes the caster stuck in place.': This is client related, we have no control over Sentry Totem right click behavior (Client does not trigger anything to the server) and having multiple Far Sight cameras spawned by the same player, we might be lacking a condition that probably allowed only 1 spell with SPELL_ATTR_EX_FARSIGHT at all times.

Closes #799
Closes #801
Closes #828
Closes #826

Closes #804

- Regarding this issue, Sentry Totem does need to instantly change view point upon cast. Also, I was not able to reproduce the mentioned crash.