### PR TITLE
Various spell/aura/pet bug fixes + refactoring

### DIFF
--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -325,13 +325,6 @@ class CastingSpell:
                 return True
         return False
 
-    # TODO: need more checks.
-    #  Refer to 'IsPositiveEffect' in SpellEntry.cpp - VMaNGOS
-    def is_positive_spell(self):
-        if not self.initial_target_is_unit_or_player():
-            return False
-        return not self.spell_caster.can_attack_target(self.initial_target)
-
     def has_only_harmful_effects(self):
         return all([effect.is_harmful() for effect in self.get_effects()])
 

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -105,11 +105,11 @@ class EffectTargets:
         # Spells with implicit target set to 0 can have both friendly and hostile targets.
         # These spells include passives, testing spells and npc spells.
         # However, in these cases the target mask seems to be enough to resolve target friendliness.
-        if self.target_effect.implicit_target_a == SpellImplicitTargets.TARGET_INITIAL and \
+        if self.target_effect.implicit_target_a == SpellImplicitTargets.TARGET_INITIAL and not \
                 self.casting_spell.spell_entry.Targets & SpellTargetMask.ENEMIES:
-            return False
+            return True
 
-        return True
+        return False
 
     def resolve_targets(self):
         if not self.simple_targets:

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -350,7 +350,7 @@ class EffectTargets:
         if caster_pet and caster.location.distance(caster_pet.location) < distance:
             units_in_range.append(caster_pet)
 
-        if not caster_is_player or not party_group:
+        if not party_group:
             return units_in_range
 
         for unit in units:

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -55,7 +55,7 @@ class SpellEffectHandler:
             return
 
         damage = effect.get_effect_points()
-        caster.apply_spell_damage(target, damage, casting_spell)
+        caster.apply_spell_damage(target, damage, effect)
 
     @staticmethod
     def handle_heal(casting_spell, effect, caster, target):
@@ -100,7 +100,7 @@ class SpellEffectHandler:
                 casting_spell.requires_combo_points():
             damage_bonus *= casting_spell.spent_combo_points
 
-        caster.apply_spell_damage(target, weapon_damage + damage_bonus, casting_spell)
+        caster.apply_spell_damage(target, weapon_damage + damage_bonus, effect)
 
     @staticmethod
     def handle_add_combo_points(casting_spell, effect, caster, target):
@@ -205,7 +205,7 @@ class SpellEffectHandler:
             return
 
         amount = effect.get_effect_points()
-        caster.apply_spell_damage(target, amount, casting_spell, is_periodic=True)
+        caster.apply_spell_damage(target, amount, effect)
         caster.receive_healing(amount, caster)
 
     @staticmethod

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -550,7 +550,7 @@ class SpellEffectHandler:
         if pet:
             # Since we have no data for what abilities pets had in the wild (or if it even varied in 0.5.3),
             # learn all abilities the pet could have at its current level.
-            caster.pet_manager.teach_active_pet_all_available_spells()
+            caster.pet_manager.initialize_active_pet_spells()
 
     @staticmethod
     def handle_summon_pet(casting_spell, effect, caster, target):

--- a/game/world/managers/objects/spell/aura/AppliedAura.py
+++ b/game/world/managers/objects/spell/aura/AppliedAura.py
@@ -37,16 +37,21 @@ class AppliedAura:
 
         self.index = -1  # Set on application
 
-    def has_duration(self) -> bool:
-        return self.get_duration() != -1
-
     def is_passive(self) -> bool:
         return self.passive
 
     def is_periodic(self) -> bool:
         return self.spell_effect.is_periodic()
 
+    def has_duration(self) -> bool:
+        return self.get_duration() != -1
+
     def get_duration(self):
+        if self.source_spell.get_duration() == -1:
+            # Infinite duration aura.
+            # Don't compare to applied_aura_duration as it's still set for periodic effects.
+            return -1
+
         return self.spell_effect.applied_aura_duration
 
     def get_dispel_mask(self):

--- a/game/world/managers/objects/spell/aura/AuraEffectDummyHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectDummyHandler.py
@@ -69,7 +69,7 @@ class AuraEffectDummyHandler:
         if remove or aura.caster.get_type_id() != ObjectTypeIds.ID_PLAYER:
             return
 
-        totem_entry = aura.source_spell.spell_entry.EffectMiscValue_1
+        totem_entry = aura.spell_effect.misc_value
         totem = MapManager.get_unit_totem_by_totem_entry(aura.caster, totem_entry)
         FarSightManager.add_camera(totem, aura.caster)
 

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -150,7 +150,6 @@ class AuraEffectHandler:
     def handle_periodic_leech(aura, effect_target, remove):
         if not aura.is_past_next_period() or remove:
             return
-        spell = aura.source_spell
         damage = aura.get_effect_points()
         aura.caster.receive_healing(damage, aura.caster)
         aura.caster.apply_spell_damage(effect_target, damage, aura.spell_effect)

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -145,7 +145,7 @@ class AuraEffectHandler:
             return
         spell = aura.source_spell
         damage = aura.get_effect_points()
-        aura.caster.apply_spell_damage(effect_target, damage, spell, is_periodic=True)
+        aura.caster.apply_spell_damage(effect_target, damage, aura.spell_effect)
 
     @staticmethod
     def handle_periodic_leech(aura, effect_target, remove):
@@ -154,7 +154,7 @@ class AuraEffectHandler:
         spell = aura.source_spell
         damage = aura.get_effect_points()
         aura.caster.receive_healing(damage, aura.caster)
-        aura.caster.apply_spell_damage(effect_target, damage, spell, is_periodic=True)
+        aura.caster.apply_spell_damage(effect_target, damage, aura.spell_effect)
 
     @staticmethod
     def handle_channel_death_item(aura, effect_target, remove):
@@ -245,7 +245,7 @@ class AuraEffectHandler:
             return
 
         damage = aura.get_effect_points()
-        aura.target.apply_spell_damage(effect_target, damage, aura.source_spell)
+        aura.target.apply_spell_damage(effect_target, damage, aura.spell_effect)
 
     @staticmethod
     # TODO: Spell MISS.
@@ -430,7 +430,7 @@ class AuraEffectHandler:
             return
 
         damage = aura.get_effect_points()
-        aura.target.apply_spell_damage(effect_target, damage, aura.source_spell)
+        aura.target.apply_spell_damage(effect_target, damage, aura.spell_effect)
 
     @staticmethod
     def handle_school_absorb(aura, effect_target, remove):

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -363,8 +363,8 @@ class AuraManager:
         for aura in auras:
             if not aura.passive:
                 is_passive = False
-            is_area_aura = aura.spell_effect.effect_type in {SpellEffects.SPELL_EFFECT_APPLY_AURA,
-                                                             SpellEffects.SPELL_EFFECT_APPLY_AREA_AURA}
+            is_area_aura = aura.spell_effect.effect_type in {SpellEffects.SPELL_EFFECT_APPLY_AREA_AURA,
+                                                             SpellEffects.SPELL_EFFECT_PERSISTENT_AREA_AURA}
             if aura.harmful or \
                     aura.source_spell.spell_entry.Attributes & SpellAttributes.SPELL_ATTR_CANT_CANCEL or \
                     (is_area_aura and aura.caster != self.unit_mgr):

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -24,12 +24,6 @@ class AuraManager:
         aura = AppliedAura(caster, casting_spell, spell_effect, self.unit_mgr)
         self.add_aura(aura)
 
-    def apply_default_auras(self):
-        # Apply default auras for creatures.
-        if self.unit_mgr.get_type_id() == ObjectTypeIds.ID_UNIT:
-            for aura in self.unit_mgr.get_default_auras():
-                self.unit_mgr.spell_manager.handle_cast_attempt(aura, self, SpellTargetMask.SELF, validate=False)
-
     def add_aura(self, aura):
         can_apply = self.can_apply_aura(aura) and self.remove_colliding_effects(aura)
         if not can_apply:

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -20,6 +20,7 @@ from utils.Formulas import UnitFormulas, Distances
 from utils.Logger import Logger
 from utils.constants import CustomCodes
 from utils.constants.MiscCodes import NpcFlags, ObjectTypeIds, UnitDynamicTypes, ObjectTypeFlags
+from utils.constants.SpellCodes import SpellTargetMask
 from utils.constants.UnitCodes import UnitFlags, WeaponMode, CreatureTypes, MovementTypes, SplineFlags, \
     CreatureStaticFlags, PowerTypes, CreatureFlagsExtra, CreatureReactStates, AIReactionStates, UnitStates
 from utils.constants.UpdateFields import ObjectFields, UnitFields
@@ -263,7 +264,7 @@ class CreatureManager(UnitManager):
                     self.mount(self.addon.mount_display_id)
 
             # Cast default auras for this unit.
-            self.aura_manager.apply_default_auras()
+            self.apply_default_auras()
 
             # Stats.
             self.stat_manager.init_stats()
@@ -320,7 +321,7 @@ class CreatureManager(UnitManager):
         return self.location == self.spawn_position and not self.is_moving()
 
     def on_at_home(self):
-        self.aura_manager.apply_default_auras()
+        self.apply_default_auras()
         # Restore original location including orientation.
         self.location = self.spawn_position.copy()
         # Restore original spawn face position.
@@ -416,6 +417,10 @@ class CreatureManager(UnitManager):
                 auras.update({int(aura) for aura in str(self.addon.auras).split()})
 
         return auras
+
+    def apply_default_auras(self):
+        for aura in self.get_default_auras():
+            self.spell_manager.handle_cast_attempt(aura, self, SpellTargetMask.SELF, validate=False)
 
     # override
     # TODO: Quest active escort npc, other cases?


### PR DESCRIPTION
* Implement infinite periodic aura handling
    * Addresses first part of #805. Cooldown reset should happen through `PetManager` once totem logic is added.
* Fix party member targeting for pet spell casts
* Fix bug with harmful auras being resolved as helpful 🤭 
    * Closes #811, closes #800
* Correct bonus application for periodic damage effects
    * Closes #806, nice catch :^)
* Add initial spells to warlock pets (initial spells are determined by the summon spell's `SpellLevel`)
    * Closes #812 
* Add spells to pet action bar automatically  on first summon