### PR TITLE
MapManager/Navigation

### DIFF
--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -18,7 +18,9 @@ class WorldLoader:
     def load_data():
         # Map tiles
         MapManager.initialize_maps()
+        MapManager.initialize_namigator()
         MapManager.initialize_area_tables()
+        MapManager.load_map_adt_tiles()
 
         # Below order matters.
 

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -12,16 +12,6 @@ from utils.ConfigManager import config
 from utils.Logger import Logger
 
 
-# Attempt to load Namigator module if enabled.
-if config.Server.Settings.use_nav_tiles:
-    try:
-        from namigator import pathfind
-        MapManager.NAMIGATOR_LOADED = True
-    except ImportError:
-        pathfind = None
-        pass
-
-
 class WorldLoader:
 
     @staticmethod
@@ -29,12 +19,6 @@ class WorldLoader:
         # Map tiles
         MapManager.initialize_maps()
         MapManager.initialize_area_tables()
-
-        if config.Server.Settings.use_nav_tiles and MapManager.NAMIGATOR_LOADED:
-            Logger.success('[Namigator] Module successfully loaded.')
-            WorldLoader.load_navigation()
-        elif config.Server.Settings.use_nav_tiles:
-            Logger.error('[Namigator] Unable to load module.')
 
         # Below order matters.
 
@@ -96,19 +80,6 @@ class WorldLoader:
         WorldLoader.load_guilds()
 
     # World data holders
-
-    @staticmethod
-    def load_navigation():
-        maps = MapManager.get_maps()
-        length = len(maps)
-        count = 0
-
-        for _map in maps:
-            _map.build_navigation(pathfind=pathfind)
-            count += 1
-            Logger.progress('[Namigator] Loading navigation data...', count, length)
-
-        return length
 
     @staticmethod
     def load_gameobject_templates():

--- a/game/world/WorldManager.py
+++ b/game/world/WorldManager.py
@@ -237,7 +237,7 @@ class WorldServerSessionHandler:
         corpses_update_scheduler.start()
 
         # MapManager tile loading.
-        world_session_thread = threading.Thread(target=MapManager.load_pending_tiles)
+        world_session_thread = threading.Thread(target=MapManager.initialize_pending_adt_tiles)
         world_session_thread.daemon = True
         world_session_thread.start()
 

--- a/game/world/WorldManager.py
+++ b/game/world/WorldManager.py
@@ -230,6 +230,13 @@ class WorldServerSessionHandler:
                                         max_instances=1)
         player_update_scheduler.start()
 
+        # Player updates.
+        player_update_known_object_scheduler = BackgroundScheduler()
+        player_update_known_object_scheduler._daemon = True
+        player_update_known_object_scheduler.add_job(WorldSessionStateHandler.update_known_players_objects, 'interval',
+                                                     seconds=1, max_instances=1)
+        player_update_known_object_scheduler.start()
+
         # Corpses updates.
         corpses_update_scheduler = BackgroundScheduler()
         corpses_update_scheduler._daemon = True

--- a/game/world/WorldManager.py
+++ b/game/world/WorldManager.py
@@ -237,9 +237,10 @@ class WorldServerSessionHandler:
         corpses_update_scheduler.start()
 
         # MapManager tile loading.
-        world_session_thread = threading.Thread(target=MapManager.initialize_pending_adt_tiles)
-        world_session_thread.daemon = True
-        world_session_thread.start()
+        tile_loading_scheduler = BackgroundScheduler()
+        tile_loading_scheduler._daemon = True
+        tile_loading_scheduler.add_job(MapManager.initialize_pending_tiles, 'interval', seconds=1.0, max_instances=4)
+        tile_loading_scheduler.start()
 
         # Creature updates.
         creature_update_scheduler = BackgroundScheduler()

--- a/game/world/WorldSessionStateHandler.py
+++ b/game/world/WorldSessionStateHandler.py
@@ -97,6 +97,14 @@ class WorldSessionStateHandler(object):
                     session.player_mgr.update(now)
 
     @staticmethod
+    def update_known_players_objects():
+        for session in WORLD_SESSIONS:
+            if session.player_mgr and session.player_mgr.online:
+                if not session.player_mgr.update_lock and session.player_mgr.update_known_objects_on_tick:
+                    session.player_mgr.update_known_objects_on_tick = False
+                    session.player_mgr.update_known_world_objects()
+
+    @staticmethod
     def save_characters():
         try:
             for session in WorldSessionStateHandler.get_world_sessions():

--- a/game/world/managers/maps/Constants.py
+++ b/game/world/managers/maps/Constants.py
@@ -3,4 +3,4 @@ from utils.ConfigManager import config
 RESOLUTION_ZMAP = int(config.Server.Settings.z_resolution)
 RESOLUTION_LIQUIDS = 128
 RESOLUTION_AREA_INFO = 16
-SIZE = 533.3333
+ADT_SIZE = 533.3333

--- a/game/world/managers/maps/Map.py
+++ b/game/world/managers/maps/Map.py
@@ -1,10 +1,6 @@
-import traceback
 from enum import IntEnum
-from os import path
 from database.dbc.DbcDatabaseManager import DbcDatabaseManager
 from game.world.managers.maps.GridManager import GridManager
-from utils.Logger import Logger
-from utils.PathManager import PathManager
 
 
 class MapType(IntEnum):
@@ -14,47 +10,10 @@ class MapType(IntEnum):
 
 class Map:
     def __init__(self, map_id, active_cell_callback):
+        self.id = map_id
         self.map_ = DbcDatabaseManager.map_get_by_id(map_id)
         self.grid_manager = GridManager(map_id, active_cell_callback)
         self.name = self.map_.MapName_enUS
-        # TODO: Move map and nav navigation out of Map.
-        #  This data should only be loaded once when instancing is implemented.
-        self.tiles = [[None for r in range(64)] for c in range(64)]
-        self.namigator = None
-        self._loaded_adts = {}
-
-    def has_navigation(self):
-        return self.namigator is not None
-
-    # TODO: Namigator should give us a way to load by adt_x and adt_y without raw locations.
-    def load_adt(self, raw_x, raw_y, adt_x, adt_y):
-        try:
-            if self.namigator is None:
-                return False
-
-            adt_key = f'{adt_x},{adt_y}'
-            if adt_key in self._loaded_adts:
-                return True
-
-            Logger.debug(f'[Namigator] Loading nav ADT {adt_x},{adt_y} for Map {self.name}')
-            n_adt_x, n_adt_y = self.namigator.load_adt_at(raw_x, raw_y)
-            if adt_x != n_adt_x or adt_y != n_adt_y:
-                Logger.warning(f'[Namigator] Loaded different ADT {n_adt_x},{n_adt_y} for Map {self.name}')
-            self._loaded_adts[adt_key] = True
-            return True
-        except:
-            return False
-
-    def build_navigation(self, pathfind):
-        try:
-            nav_root_path = PathManager.get_navs_path()
-            nav_map_path = PathManager.get_nav_map_path(self.name)
-            if not path.exists(nav_root_path) or not path.exists(nav_map_path):
-                Logger.warning(f'[Namigator] Unable to locate data for map {self.name}')
-                return
-            self.namigator = pathfind.Map(nav_root_path, f'{self.name}')
-        except:
-            Logger.error(traceback.format_exc())
 
     def is_dungeon(self):
         return self.map_.IsInMap == MapType.INSTANCE

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -243,7 +243,7 @@ class MapManager:
         z_values = MAPS_NAMIGATOR[map_id].query_z(float(x), float(y))
 
         if len(z_values) == 0:
-            Logger.warning(f'Unable to find Z for Map {map_id} ADT [{adt_x},{adt_y}] X {x} Y {y}')
+            Logger.warning(f'[NAMIGATOR] Unable to find Z for Map {map_id} ADT [{adt_x},{adt_y}] X {x} Y {y}')
             return current_z, True
 
         # We are only interested in the resulting Z near to the Z we know.
@@ -406,7 +406,7 @@ class MapManager:
                 val_4 = MapManager.get_height(map_id, map_tile_x, map_tile_y, tile_local_x + 1, tile_local_y + 1)
                 bottom_height = MapManager._lerp(val_3, val_4, x_normalized)
                 calculated_z = MapManager._lerp(top_height, bottom_height, y_normalized)  # Z
-                # If this Z is quite different, cascade into nav Z, if that also fails, current Z will be returned.
+                # If maps Z is quite different, cascade into nav Z, if that also fails, current Z will be returned.
                 if math.fabs(current_z - calculated_z) >= 1.0 and current_z:
                     return MapManager.calculate_nav_z(map_id, x, y, current_z)
                 return calculated_z, False

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -49,7 +49,7 @@ class MapManager:
 
     @staticmethod
     def initialize_namigator():
-        if not config.Server.Settings.use_nav_tiles or not MapManager.NAMIGATOR_LOADED:
+        if not config.Server.Settings.use_nav_tiles or MapManager.NAMIGATOR_FAILED:
             return
         length = len(MAP_LIST)
         count = 0
@@ -491,7 +491,6 @@ class MapManager:
                 if tile.is_ready() and tile.can_use():
                     return True
                 elif not tile.is_loading() and not tile.is_initialized():
-                    print('Begin Loading')
                     MapManager.enqueue_adt_tile_initialization(map_id, location_x, location_y)
             except:
                 Logger.error(traceback.format_exc())

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -12,6 +12,7 @@ from game.world.managers.maps.Constants import SIZE, RESOLUTION_ZMAP, RESOLUTION
 from game.world.managers.maps.GridManager import GridManager
 from game.world.managers.maps.Map import Map
 from game.world.managers.maps.MapTile import MapTile
+from game.world.managers.maps.Namigator import Namigator
 from game.world.managers.objects.farsight.FarSightManager import FarSightManager
 from utils.ConfigManager import config
 from utils.Logger import Logger
@@ -22,7 +23,7 @@ MAP_LIST: list[int] = DbcDatabaseManager.map_get_all_ids()
 # Holds .map files tiles information per Map.
 MAPS_TILES = dict()
 # Holds namigator instances per Map.
-MAPS_NAMIGATOR: dict[int, object] = dict()
+MAPS_NAMIGATOR: dict[int, Namigator] = dict()
 # Holds maps which have no navigation data in alpha.
 MAPS_NO_NAVIGATION = {2, 13, 25, 29, 30, 34, 35, 37, 42, 43, 44, 47, 48, 70, 90, 109, 129}
 AREAS = {}
@@ -294,11 +295,11 @@ class MapManager:
             return True
 
         # We don't have navs loaded for a given map, return True.
-        if not MAPS[source_object.map_id].has_navigation():
+        if source_object.map_ not in MAPS_NAMIGATOR:
             return True
 
-        failed, in_place, path = MapManager.calculate_path(source_object.map_, source_object.location,
-                                                           target_object.location)
+        failed, in_place, navigation_path = MapManager.calculate_path(source_object.map_, source_object.location,
+                                                                      target_object.location)
         return not failed
 
     @staticmethod
@@ -377,7 +378,7 @@ class MapManager:
         if not MapManager._check_tile_load(map_id, x, y, map_tile_x, map_tile_y):
             return False
 
-        return MAPS[map_id].tiles[map_tile_x][map_tile_y] is not None
+        return True
 
     @staticmethod
     def calculate_z_for_object(world_object):
@@ -525,7 +526,7 @@ class MapManager:
             map_tile_y = int(map_tile_y - 1)
             map_tile_local_y = int(-map_tile_local_y - 1)
 
-        return MAPS[map_id].tiles[map_tile_x][map_tile_y].z_height_map[map_tile_local_x][map_tile_local_y]
+        return MAPS_TILES[map_id][map_tile_x][map_tile_y].get_z_at(map_tile_local_x, map_tile_local_y)
 
     @staticmethod
     def validate_map_coord(coord):

--- a/game/world/managers/maps/MapTile.py
+++ b/game/world/managers/maps/MapTile.py
@@ -38,6 +38,9 @@ class MapTile(object):
             return None
         return self.area_information[cell_x][cell_y]
 
+    def get_z_at(self, cell_x, cell_y):
+        return self.z_height_map[cell_x][cell_y]
+
     def is_initialized(self):
         return self.initialized
 

--- a/game/world/managers/maps/MapTile.py
+++ b/game/world/managers/maps/MapTile.py
@@ -5,6 +5,7 @@ from game.world.managers.maps.AreaInformation import AreaInformation
 from game.world.managers.maps.Constants import RESOLUTION_ZMAP, RESOLUTION_LIQUIDS, RESOLUTION_AREA_INFO
 from game.world.managers.maps.LiquidInformation import LiquidInformation
 from network.packet.PacketReader import PacketReader
+from utils.ConfigManager import config
 from utils.Logger import Logger
 from utils.PathManager import PathManager
 
@@ -12,55 +13,82 @@ from utils.PathManager import PathManager
 class MapTile(object):
     EXPECTED_VERSION = 'ACMAP_1.40'
 
-    def __init__(self, map_id, tile_x, tile_y):
+    def __init__(self, map_id, adt_x, adt_y):
         self.initialized = False
-        self.is_valid = False
-        self.cell_x = tile_x
-        self.cell_y = tile_y
+        self.ready = False
+        self.has_maps = False
+        self.has_navigation = False
+        self.adt_x = adt_x
+        self.adt_y = adt_y
         self.cell_map = map_id
-        self.area_information = [[None for r in range(RESOLUTION_AREA_INFO)] for c in range(RESOLUTION_AREA_INFO)]
-        self.liquid_information = [[None for r in range(RESOLUTION_LIQUIDS)] for c in range(RESOLUTION_LIQUIDS)]
-        self.z_height_map = [[0 for r in range(RESOLUTION_ZMAP)] for c in range(RESOLUTION_ZMAP)]
-        self.load()
+        self.area_information = None
+        self.liquid_information = None
+        self.z_height_map = None
 
-    # TODO: Namigator should give us a way to load by adt_x and adt_y without raw locations.
-    def load_adt(self, raw_x, raw_y, adt_x, adt_y):
+    def can_use(self):
+        return self.initialized and self.ready and (self.has_maps or self.has_navigation)
+
+    def get_liquids_at(self, cell_x, cell_y):
+        if not self.has_maps or not self.liquid_information:
+            return None
+        return self.liquid_information[cell_x][cell_y]
+
+    def get_area_at(self, cell_x, cell_y):
+        if not self.has_maps or not self.area_information:
+            return None
+        return self.area_information[cell_x][cell_y]
+
+    def is_initialized(self):
+        return self.initialized
+
+    def is_ready(self):
+        return self.ready
+
+    def is_loading(self):
+        return self.initialized and not self.ready
+
+    def initialize(self, namigator):
+        if self.initialized:
+            return
+        # Set as initialized to avoid another load() call from another thread.
+        self.initialized = True
+        self.has_maps = self.load_maps_data()
+        self.has_navigation = self.load_namigator_data(namigator)
+        self.ready = True
+
+    def load_namigator_data(self, namigator):
+        if not config.Server.Settings.use_nav_tiles or not namigator:
+            return False
         try:
-            if self.namigator is None:
-                return False
-
-            adt_key = f'{adt_x},{adt_y}'
-            if adt_key in self._loaded_adts:
-                return True
-
-            Logger.debug(f'[Namigator] Loading nav ADT {adt_x},{adt_y} for Map {self.name}')
-            n_adt_x, n_adt_y = self.namigator.load_adt_at(raw_x, raw_y)
+            Logger.debug(f'[Namigator] Loading nav ADT, Map:{self.cell_map} Tile:{self.adt_x},{self.adt_y}')
             # Notice, namigator has inverted coordinates.
-            if adt_x != n_adt_y or adt_y != n_adt_x:
-                Logger.warning(f'[Namigator] Loaded different ADT {n_adt_x},{n_adt_y} for Map {self.name}')
-            self._loaded_adts[adt_key] = True
+            namigator.load_adt(self.adt_y, self.adt_x)
+            self.has_navigation = True
             return True
         except:
             return False
 
-    def load(self):
-        # Set as initialized to avoid another load() call from another thread.
-        self.initialized = True
-
-        filename = f'{self.cell_map:03}{self.cell_x:02}{self.cell_y:02}.map'
+    def load_maps_data(self):
+        if not config.Server.Settings.use_map_tiles:
+            return False
+        filename = f'{self.cell_map:03}{self.adt_x:02}{self.adt_y:02}.map'
         maps_path = PathManager.get_map_file_path(filename)
-        Logger.debug(f'[Maps] Loading map file: {filename}, Map:{self.cell_map} Tile:{self.cell_x},{self.cell_y}')
+        Logger.debug(f'[Maps] Loading map file: {filename}, Map:{self.cell_map} Tile:{self.adt_x},{self.adt_y}')
 
         if not path.exists(maps_path):
             Logger.warning(f'[Maps] Unable to locate map file: {filename}, '
-                           f'Map:{self.cell_map} Tile:{self.cell_x},{self.cell_y}')
-            return
+                           f'Map:{self.cell_map} Tile:{self.adt_x},{self.adt_y}')
+            return False
         else:
+            self.area_information = [[None for r in range(RESOLUTION_AREA_INFO)] for c in range(RESOLUTION_AREA_INFO)]
+            self.liquid_information = [[None for r in range(RESOLUTION_LIQUIDS)] for c in range(RESOLUTION_LIQUIDS)]
+            self.z_height_map = [[0 for r in range(RESOLUTION_ZMAP)] for c in range(RESOLUTION_ZMAP)]
+
             with open(maps_path, "rb") as map_tiles:
                 version = PacketReader.read_string(map_tiles.read(10), 0)
                 if version != MapTile.EXPECTED_VERSION:
                     Logger.error(f'[Maps] Unexpected map version. Expected "{MapTile.EXPECTED_VERSION}", found "{version}".')
-                    return
+                    return False
 
                 # Height Map
                 for x in range(RESOLUTION_ZMAP):
@@ -90,9 +118,7 @@ class MapTile(object):
                         height = unpack('<f', map_tiles.read(4))[0]
                         # noinspection PyTypeChecker
                         self.liquid_information[x][y] = LiquidInformation(liquid_type, height)
-
-        # This is a valid tile, set as loaded.
-        self.is_valid = True
+        return True
 
     @staticmethod
     def validate_version():

--- a/game/world/managers/maps/MapTile.py
+++ b/game/world/managers/maps/MapTile.py
@@ -23,6 +23,26 @@ class MapTile(object):
         self.z_height_map = [[0 for r in range(RESOLUTION_ZMAP)] for c in range(RESOLUTION_ZMAP)]
         self.load()
 
+    # TODO: Namigator should give us a way to load by adt_x and adt_y without raw locations.
+    def load_adt(self, raw_x, raw_y, adt_x, adt_y):
+        try:
+            if self.namigator is None:
+                return False
+
+            adt_key = f'{adt_x},{adt_y}'
+            if adt_key in self._loaded_adts:
+                return True
+
+            Logger.debug(f'[Namigator] Loading nav ADT {adt_x},{adt_y} for Map {self.name}')
+            n_adt_x, n_adt_y = self.namigator.load_adt_at(raw_x, raw_y)
+            # Notice, namigator has inverted coordinates.
+            if adt_x != n_adt_y or adt_y != n_adt_x:
+                Logger.warning(f'[Namigator] Loaded different ADT {n_adt_x},{n_adt_y} for Map {self.name}')
+            self._loaded_adts[adt_key] = True
+            return True
+        except:
+            return False
+
     def load(self):
         # Set as initialized to avoid another load() call from another thread.
         self.initialized = True

--- a/game/world/managers/maps/MapTile.py
+++ b/game/world/managers/maps/MapTile.py
@@ -1,3 +1,4 @@
+from enum import IntEnum
 from os import path
 from struct import unpack
 
@@ -8,6 +9,12 @@ from network.packet.PacketReader import PacketReader
 from utils.ConfigManager import config
 from utils.Logger import Logger
 from utils.PathManager import PathManager
+
+
+class MapTileStates(IntEnum):
+    READY = 0
+    LOADING = 1
+    UNUSABLE = 2
 
 
 class MapTile(object):

--- a/game/world/managers/maps/Namigator.py
+++ b/game/world/managers/maps/Namigator.py
@@ -1,0 +1,14 @@
+# Interface
+class Namigator:
+
+    def query_z(self, x, y):
+        pass
+
+    def line_of_sight(self, start_x, start_y, start_z, end_x, end_y, end_z):
+        pass
+
+    def find_path(self, start_x, start_y, start_z, end_x, end_y, end_z):
+        pass
+
+    def load_adt(self, adt_x, adt_y):
+        pass

--- a/game/world/managers/objects/ObjectManager.py
+++ b/game/world/managers/objects/ObjectManager.py
@@ -145,7 +145,7 @@ class ObjectManager:
 
         return data
 
-    def get_heartbeat_packet(self):
+    def get_heartbeat_packet(self, movement_flag=None):
         data = pack(
             '<2Q9fI',
             self.guid,
@@ -159,7 +159,7 @@ class ObjectManager:
             self.location.z,
             self.location.o,
             self.pitch,
-            self.movement_flags,
+            movement_flag if movement_flag else self.movement_flags,
         )
         return PacketWriter.get_packet(OpCode.MSG_MOVE_HEARTBEAT, data)
 

--- a/game/world/managers/objects/ObjectManager.py
+++ b/game/world/managers/objects/ObjectManager.py
@@ -145,6 +145,24 @@ class ObjectManager:
 
         return data
 
+    def get_heartbeat_packet(self):
+        data = pack(
+            '<2Q9fI',
+            self.guid,
+            self.transport_id,
+            self.transport.x,
+            self.transport.y,
+            self.transport.z,
+            self.transport.o,
+            self.location.x,
+            self.location.y,
+            self.location.z,
+            self.location.o,
+            self.pitch,
+            self.movement_flags,
+        )
+        return PacketWriter.get_packet(OpCode.MSG_MOVE_HEARTBEAT, data)
+
     def get_movement_update_packet(self):
         # Base structure.
         data = self._get_base_structure(UpdateTypes.MOVEMENT)

--- a/game/world/managers/objects/ObjectManager.py
+++ b/game/world/managers/objects/ObjectManager.py
@@ -1,4 +1,3 @@
-import time
 from struct import pack, unpack
 
 from database.dbc.DbcDatabaseManager import DbcDatabaseManager
@@ -9,7 +8,7 @@ from network.packet.update.UpdatePacketFactory import UpdatePacketFactory
 from utils.ConfigManager import config
 from utils.GuidUtils import GuidUtils
 from utils.Logger import Logger
-from utils.constants.MiscCodes import ObjectTypeFlags, ObjectTypeIds, UpdateTypes, LiquidTypes
+from utils.constants.MiscCodes import ObjectTypeFlags, ObjectTypeIds, UpdateTypes, LiquidTypes, MoveFlags
 from utils.constants.OpCodes import OpCode
 from utils.constants.UnitCodes import SplineFlags, UnitReaction, UnitFlags, UnitStates
 from utils.constants.UpdateFields \
@@ -145,7 +144,8 @@ class ObjectManager:
 
         return data
 
-    def get_heartbeat_packet(self, movement_flag=None):
+    def get_heartbeat_packet(self):
+        movement_flags = self.movement_flags | MoveFlags.MOVEFLAG_MOVED
         data = pack(
             '<2Q9fI',
             self.guid,
@@ -159,7 +159,7 @@ class ObjectManager:
             self.location.z,
             self.location.o,
             self.pitch,
-            movement_flag if movement_flag else self.movement_flags,
+            movement_flags,
         )
         return PacketWriter.get_packet(OpCode.MSG_MOVE_HEARTBEAT, data)
 
@@ -375,7 +375,7 @@ class ObjectManager:
         pass
 
     # override
-    def is_on_water(self):
+    def is_over_water(self):
         liquid_information = MapManager.get_liquid_information(self.map_, self.location.x, self.location.y,
                                                                self.location.z)
         map_z = MapManager.calculate_z_for_object(self)[0]
@@ -385,7 +385,8 @@ class ObjectManager:
     def is_under_water(self):
         liquid_information = MapManager.get_liquid_information(self.map_, self.location.x, self.location.y,
                                                                self.location.z)
-        return liquid_information and self.location.z + (self.current_scale * 2) < liquid_information.height
+
+        return liquid_information and self.location.z + (self.current_scale * 1.8) < liquid_information.height
 
     # override
     def is_in_deep_water(self):

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -24,8 +24,7 @@ from utils.constants.ItemCodes import EnchantmentSlots, InventoryError, ItemClas
 from utils.constants.MiscCodes import ObjectTypeFlags, ObjectTypeIds, AttackTypes, \
     GameObjectStates, DynamicObjectTypes
 from utils.constants.SpellCodes import AuraTypes, SpellEffects, SpellState, SpellTargetMask, DispelType
-from utils.constants.UnitCodes import UnitFlags, UnitStates
-from utils.constants.UpdateFields import UnitFields
+from utils.constants.UnitCodes import UnitFlags
 
 
 class SpellEffectHandler:

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -125,8 +125,8 @@ class AuraManager:
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_CAST: cast_spell is not None,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NEGATIVE_SPELL: negative_aura_applied,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_DAMAGE: received_damage,
-            SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NOT_ABOVEWATER: self.unit_mgr.is_on_water(),
-            SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NOT_UNDERWATER: not self.unit_mgr.is_on_water(),
+            SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NOT_ABOVEWATER: self.unit_mgr.is_over_water(),
+            SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NOT_UNDERWATER: not self.unit_mgr.is_over_water(),
         }
 
         for aura in list(self.active_auras.values()):

--- a/game/world/managers/objects/units/MovementManager.py
+++ b/game/world/managers/objects/units/MovementManager.py
@@ -127,7 +127,7 @@ class MovementManager:
 
         waypoints_data = b''
         waypoints_length = len(waypoints)
-        last_waypoint = self.unit.location
+        last_waypoint = self.unit.location.copy()
         total_distance = 0
         total_time = 0
         current_id = 0

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -461,6 +461,7 @@ class CreatureManager(UnitManager):
         spawn_distance = self.location.distance(self.spawn_position)
         target_distance = self.location.distance(self.combat_target.location)
         combat_position_distance = UnitFormulas.combat_distance(self, self.combat_target)
+        target_under_water = self.combat_target.is_under_water()
 
         if not self.is_pet():
             # In 0.5.3, evade mechanic was only based on distance, the correct distance remains unknown.
@@ -481,8 +482,7 @@ class CreatureManager(UnitManager):
                 if not self.can_swim():
                     self.threat_manager.remove_unit_threat(self.combat_target)
                     return
-            else:
-                if not self.can_exit_water():
+                if not self.can_exit_water() and not target_under_water:
                     self.threat_manager.remove_unit_threat(self.combat_target)
                     return
 
@@ -504,7 +504,7 @@ class CreatureManager(UnitManager):
                 return
 
         # Use direct combat location if target is over water.
-        if not self.combat_target.movement_flags & MoveFlags.MOVEFLAG_SWIMMING:
+        if not target_under_water:
             failed, in_place, path = MapManager.calculate_path(self.map_, self.location.copy(), combat_location)
             if not failed and not in_place:
                 combat_location = path[0]

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -1,5 +1,4 @@
 import math
-import time
 from random import randint
 
 from database.dbc.DbcDatabaseManager import DbcDatabaseManager
@@ -19,7 +18,7 @@ from utils.ByteUtils import ByteUtils
 from utils.Formulas import UnitFormulas, Distances
 from utils.Logger import Logger
 from utils.constants import CustomCodes
-from utils.constants.MiscCodes import NpcFlags, ObjectTypeIds, UnitDynamicTypes, ObjectTypeFlags
+from utils.constants.MiscCodes import NpcFlags, ObjectTypeIds, UnitDynamicTypes, ObjectTypeFlags, MoveFlags
 from utils.constants.UnitCodes import UnitFlags, WeaponMode, CreatureTypes, MovementTypes, SplineFlags, \
     CreatureStaticFlags, PowerTypes, CreatureFlagsExtra, CreatureReactStates, AIReactionStates, UnitStates
 from utils.constants.UpdateFields import ObjectFields, UnitFields
@@ -435,6 +434,13 @@ class CreatureManager(UnitManager):
                     self.random_movement_wait_time = randint(1, 12)
                     self.last_random_movement = now
 
+    # TODO: There are some creatures like crabs or murlocs that apparently couldn't swim in earlier versions
+    #  but are spawned inside the water at this moment since most spawns come from Vanilla data. These mobs
+    #  will currently bug out when you try to engage in combat with them. Also seems like a lot of humanoids
+    #  couldn't swim before patch 1.3.0:
+    #  World of Warcraft Client Patch 1.3.0 (2005-03-22)
+    #   - Most humanoids NPCs have gained the ability to swim.
+    #  This might only refer to creatures not having swimming animations.
     def _perform_combat_movement(self):
         # Avoid moving while casting, no combat target, evading, target already dead or self stunned.
         if self.is_casting() or self.is_totem() or not self.combat_target or self.is_evading or not self.combat_target.is_alive or \
@@ -444,7 +450,7 @@ class CreatureManager(UnitManager):
         # Check if target is player and is online.
         target_is_player = self.combat_target.get_type_id() == ObjectTypeIds.ID_PLAYER
         if target_is_player and not self.combat_target.online:
-            self.leave_combat()
+            self.threat_manager.remove_unit_threat(self.combat_target)
             return
 
         spawn_distance = self.location.distance(self.spawn_position)
@@ -457,23 +463,8 @@ class CreatureManager(UnitManager):
             #     "Creature pursuit is now timer based rather than distance based."
             if spawn_distance > Distances.CREATURE_EVADE_DISTANCE  \
                     or target_distance > Distances.CREATURE_EVADE_DISTANCE:
-                self.leave_combat()
+                self.threat_manager.remove_unit_threat(self.combat_target)
                 return
-
-            # TODO: There are some creatures like crabs or murlocs that apparently couldn't swim in earlier versions
-            #  but are spawned inside the water at this moment since most spawns come from Vanilla data. These mobs
-            #  will currently bug out when you try to engage in combat with them. Also seems like a lot of humanoids
-            #  couldn't swim before patch 1.3.0:
-            #  World of Warcraft Client Patch 1.3.0 (2005-03-22)
-            #   - Most humanoids NPCs have gained the ability to swim.
-            if self.is_on_water():
-                if not self.can_swim():
-                    self.leave_combat()
-                    return
-            else:
-                if not self.can_exit_water():
-                    self.leave_combat()
-                    return
 
         # If this creature is not facing the attacker, update its orientation.
         if not self.location.has_in_arc(self.combat_target.location, math.pi):
@@ -488,29 +479,28 @@ class CreatureManager(UnitManager):
         if round(target_distance) <= round(combat_position_distance) or self.location == combat_location:
             return
 
-        # If already going to the correct spot, don't do anything.
-        if len(self.movement_manager.pending_waypoints) > 0 \
-                and self.movement_manager.pending_waypoints[0].location == combat_location:
-            return
+        if len(self.movement_manager.pending_waypoints) > 0:
+            # Avoid moving due floating point precision.
+            if self.movement_manager.pending_waypoints[0].location.distance(combat_location) < 0.1:
+                return
 
-        failed, in_place, path = MapManager.calculate_path(self.map_, self.location.copy(), combat_location)
-        if not failed and not in_place:
-            combat_location = path[0]
-        elif in_place:
-            return
-        # Unable to find a path while Namigator is enabled, log warning and use combat location directly.
-        elif MapManager.NAMIGATOR_LOADED:
-            Logger.warning(f'Unable to find navigation path, map {self.map_} loc {self.location} end {combat_location}')
-
-        if self.is_on_water():
-            # Force destination Z to target Z.
-            combat_location.z = self.combat_target.location.z
-            # TODO: Find how to actually trigger swim animation and which spline flag to use.
-            #  VMaNGOS uses UNIT_FLAG_USE_SWIM_ANIMATION, we don't have that.
-            self.movement_manager.send_move_normal([combat_location], self.swim_speed, SplineFlags.SPLINEFLAG_FLYING)
+        is_on_water = self.is_on_water()
+        # Use direct combat location while on water.
+        if not is_on_water:
+            failed, in_place, path = MapManager.calculate_path(self.map_, self.location.copy(), combat_location)
+            if not failed and not in_place:
+                combat_location = path[0]
+            elif in_place:
+                return
+            # Unable to find a path while Namigator is enabled, log warning and use combat location directly.
+            elif MapManager.NAMIGATOR_LOADED:
+                Logger.warning(f'Unable to find navigation path, map {self.map_} loc {self.location} end {combat_location}')
+        # Use raw combat location and target Z while on water.
         else:
-            self.movement_manager.send_move_normal([combat_location], self.running_speed,
-                                                   SplineFlags.SPLINEFLAG_RUNMODE)
+            combat_location.z = self.combat_target.location.z
+
+        self.movement_manager.send_move_normal([combat_location], self.running_speed,
+                                               SplineFlags.SPLINEFLAG_RUNMODE)
 
     # override
     def update(self, now):
@@ -754,7 +744,17 @@ class CreatureManager(UnitManager):
         )
 
     def _on_relocation(self):
+        self._update_swimming_state()
         self.object_ai.movement_inform()
+
+    def _update_swimming_state(self):
+        is_on_water = self.is_on_water()
+        if is_on_water and not self.movement_flags & MoveFlags.MOVEFLAG_SWIMMING:
+            self.movement_flags |= MoveFlags.MOVEFLAG_SWIMMING
+            MapManager.send_surrounding(self.get_heartbeat_packet(), self)
+        elif not is_on_water and self.movement_flags & MoveFlags.MOVEFLAG_SWIMMING:
+            self.movement_flags &= ~MoveFlags.MOVEFLAG_SWIMMING
+            MapManager.send_surrounding(self.get_heartbeat_packet(), self)
 
     # override
     def notify_moved_in_line_of_sight(self, target):

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1567,11 +1567,6 @@ class PlayerManager(UnitManager):
             self.player.totaltime += elapsed
             self.player.leveltime += elapsed
 
-            # Update known objects if needed.
-            if self.update_known_objects_on_tick:
-                self.update_known_objects_on_tick = False
-                self.update_known_world_objects()
-
             # Stealth detect.
             self.units_stealth_detection_check(elapsed)
             # Regeneration.

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -709,7 +709,7 @@ class PlayerManager(UnitManager):
         # Notify movement data to surrounding players when teleporting within the same map
         # (for example when using Charge)
         if not changed_map:
-            heart_beat_packet = self.get_heartbeat_packet(movement_flag=MoveFlags.MOVEFLAG_MOVED)
+            heart_beat_packet = self.get_heartbeat_packet()
             MapManager.send_surrounding(heart_beat_packet, self, False)
 
         # TODO: Wrap pending teleport data in a new holder object?
@@ -1167,7 +1167,7 @@ class PlayerManager(UnitManager):
         return self.movement_flags & MoveFlags.MOVEFLAG_SWIMMING and self.is_alive
 
     # override
-    def is_on_water(self):
+    def is_over_water(self):
         self.liquid_information = MapManager.get_liquid_information(self.map_, self.location.x, self.location.y, self.location.z)
         return self.liquid_information and self.liquid_information.height > self.location.z
 

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -706,12 +706,11 @@ class PlayerManager(UnitManager):
         # Get us in a new cell.
         MapManager.update_object(self)
 
-        # Notify movement data to surrounding players when teleporting within the same map (for example when using
-        # Charge).
-        # TODO: Can we somehow send MSG_MOVE_HEARTBEAT instead?
+        # Notify movement data to surrounding players when teleporting within the same map
+        # (for example when using Charge)
         if not changed_map:
-            movement_packet = PacketWriter.get_packet(OpCode.SMSG_UPDATE_OBJECT, self.get_movement_update_packet())
-            MapManager.send_surrounding(movement_packet, self, False)
+            heart_beat_packet = self.get_heartbeat_packet(movement_flag=MoveFlags.MOVEFLAG_MOVED)
+            MapManager.send_surrounding(heart_beat_packet, self, False)
 
         # TODO: Wrap pending teleport data in a new holder object?
         self.pending_teleport_recovery_percentage = -1

--- a/game/world/opcode_handling/handlers/player/MovementHandler.py
+++ b/game/world/opcode_handling/handlers/player/MovementHandler.py
@@ -9,7 +9,6 @@ from utils.Logger import Logger
 from utils.constants.MiscCodes import MoveFlags
 from utils.constants.OpCodes import OpCode
 from utils.constants.UnitCodes import StandState
-from utils.constants.UpdateFields import UnitFields
 
 
 class MovementHandler:

--- a/utils/ConfigManager.py
+++ b/utils/ConfigManager.py
@@ -5,7 +5,7 @@ from utils.PathManager import PathManager
 
 
 class ConfigManager:
-    EXPECTED_VERSION = 4
+    EXPECTED_VERSION = 5
 
     def __init__(self):
         self.config = None


### PR DESCRIPTION
- Decouple maps/navs tiles from Map obj. (Need 1 instance only once instancing is implemented and multiple Map objs are allocated)
- Initialize Tiles (.map and .nav) without blocking player/creature thread. (Will rely on current Z while loading)
- Update known world objects for players will now also be called on another thread except when forced.
- Adjacent .navs will now also be initialized upon a cell becoming active. (Requires latest namigator)
- Stop generating paths infinetely while already in combat reach due precision error in distance between actors.
- Mob chasing should no longer call LeaveCombat when player goes out of range, will now remove from threat list and select another target if available.
- Refactor MapTile.
- Set Swimming moveflag for npcs.