### PR TITLE
Spell miss results implementation + other spell-related fixes

### DIFF
--- a/game/world/managers/CommandManager.py
+++ b/game/world/managers/CommandManager.py
@@ -379,10 +379,16 @@ class CommandManager(object):
             skill_id, skill_value = args.split()
             skill_id = int(skill_id)
             skill_value = int(skill_value)
+            skill = DbcDatabaseManager.SkillHolder.skill_get_by_id(skill_id)
+            if not skill:
+                return -1, 'Invalid skill.'
             if skill_value <= 0:
                 return -1, 'Skill value must be greater than 0.'
+
             if not world_session.player_mgr.skill_manager.set_skill(skill_id, skill_value):
-                return -1, 'Invalid skill.'
+                return -1, "You haven't learned that skill."
+
+            world_session.player_mgr.skill_manager.build_update()
             return 0, 'Skill set.'
         except ValueError:
             return -1, 'Please specify the skill ID and new value.'

--- a/game/world/managers/CommandManager.py
+++ b/game/world/managers/CommandManager.py
@@ -374,6 +374,20 @@ class CommandManager(object):
             return -1, 'please specify one or more valid skill ID(s).'
 
     @staticmethod
+    def setskill(world_session, args):
+        try:
+            skill_id, skill_value = args.split()
+            skill_id = int(skill_id)
+            skill_value = int(skill_value)
+            if skill_value <= 0:
+                return -1, 'Skill value must be greater than 0.'
+            if not world_session.player_mgr.skill_manager.set_skill(skill_id, skill_value):
+                return -1, 'Invalid skill.'
+            return 0, 'Skill set.'
+        except ValueError:
+            return -1, 'Please specify the skill ID and new value.'
+
+    @staticmethod
     def port(world_session, args):
         try:
             x, y, z, map_ = args.split()
@@ -767,6 +781,7 @@ GM_COMMAND_DEFINITIONS = {
     'sskill': [CommandManager.sskill, 'search skills'],
     'lskill': [CommandManager.lskill, 'learn a skill'],
     'lskills': [CommandManager.lskills, 'learn skills'],
+    'setskill': [CommandManager.setskill, 'set a skill level'],
     'port': [CommandManager.port, 'teleport using coordinates'],
     'tickets': [CommandManager.tickets, 'list all tickets'],
     'rticket': [CommandManager.rticket, 'search a ticket'],

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -382,10 +382,11 @@ class CastingSpell:
         return None
 
     def unlock_cooldown_on_trigger(self):
-        return self.spell_entry.Attributes & SpellAttributes.SPELL_ATTR_DISABLED_WHILE_ACTIVE == SpellAttributes.SPELL_ATTR_DISABLED_WHILE_ACTIVE
+        return self.spell_entry.Attributes & SpellAttributes.SPELL_ATTR_DISABLED_WHILE_ACTIVE
 
     def casts_on_swing(self):
-        return self.spell_entry.Attributes & SpellAttributes.SPELL_ATTR_ON_NEXT_SWING_1 == SpellAttributes.SPELL_ATTR_ON_NEXT_SWING_1
+        return self.spell_entry.Attributes & \
+               (SpellAttributes.SPELL_ATTR_ON_NEXT_SWING_1 | SpellAttributes.SPELL_ATTR_ON_NEXT_SWING_2)
 
     def casts_on_ranged_attack(self):
         # Quick Shot has a negative base cast time (-1000000), which will resolve to 0 in get_base_cast_time().

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -226,7 +226,7 @@ class CastingSpell:
     def generates_threat(self):
         return not self.spell_entry.AttributesEx & SpellAttributesEx.SPELL_ATTR_EX_NO_THREAT
 
-    def generates_threat_on_miss(self):
+    def generates_threat_only_on_miss(self):
         return self.spell_entry.AttributesEx & SpellAttributesEx.SPELL_ATTR_EX_THREAT_ON_MISS
 
     def requires_implicit_initial_unit_target(self):

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -11,13 +11,15 @@ from game.world.managers.objects.spell.ExtendedSpellData import SummonedObjectPo
 from game.world.managers.objects.spell.SpellEffectHandler import SpellEffectHandler
 from utils.Logger import Logger
 from utils.constants.MiscCodes import ObjectTypeFlags, ObjectTypeIds
-from utils.constants.SpellCodes import SpellImplicitTargets, SpellMissReason, SpellEffects, SpellTargetMask
+from utils.constants.SpellCodes import SpellImplicitTargets, SpellMissReason, SpellEffects, SpellTargetMask, \
+    SpellHitFlags
 
 
 @dataclass
 class TargetMissInfo:
     target: ObjectManager
     result: SpellMissReason
+    flags: SpellHitFlags
 
 
 class EffectTargets:
@@ -133,8 +135,9 @@ class EffectTargets:
         targets = self.get_resolved_effect_targets_by_type(ObjectManager)
         target_info = {}
         for target in targets:
-            if isinstance(target, ObjectManager):
-                target_info[target.guid] = TargetMissInfo(target, SpellMissReason.MISS_REASON_NONE)  # TODO Misses etc.
+            if target.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
+                result = target.stat_manager.get_spell_miss_result_against_self(self.casting_spell)
+                target_info[target.guid] = TargetMissInfo(target, *result)
         return target_info
 
     def get_resolved_effect_targets_by_type(self, _type) -> list[Union[ObjectManager, Vector]]:

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -12,7 +12,7 @@ from game.world.managers.objects.spell.SpellEffectHandler import SpellEffectHand
 from utils.Logger import Logger
 from utils.constants.MiscCodes import ObjectTypeFlags, ObjectTypeIds
 from utils.constants.SpellCodes import SpellImplicitTargets, SpellMissReason, SpellEffects, SpellTargetMask, \
-    SpellHitFlags
+    SpellHitFlags, SpellMissInfo
 
 
 @dataclass
@@ -138,6 +138,8 @@ class EffectTargets:
             if target.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
                 result = target.stat_manager.get_spell_miss_result_against_self(self.casting_spell)
                 target_info[target.guid] = TargetMissInfo(target, *result)
+            else:
+                target_info[target.guid] = TargetMissInfo(target, SpellMissInfo.SPELL_MISS_NONE, SpellHitFlags.NONE)
         return target_info
 
     def get_resolved_effect_targets_by_type(self, _type) -> list[Union[ObjectManager, Vector]]:

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -673,8 +673,6 @@ class SpellEffectHandler:
         deathbind_map, deathbind_location = target.get_deathbind_coordinates()
         target.teleport(deathbind_map, deathbind_location)
 
-    # TODO: Currently you always succeed.
-    #  This chance should be handled by Spell miss results.
     @staticmethod
     def handle_pick_pocket(casting_spell, effect, caster, target):
         if caster.get_type_id() != ObjectTypeIds.ID_PLAYER:

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -286,21 +286,6 @@ class SpellManager:
 
         casting_spell.resolve_target_info_for_effects()
 
-        if casting_spell.casts_on_swing():
-            # TODO Hackfix for melee spell miss results.
-            # The client seems to expect damage info before spell_go for these spells (checked by attributes & 0x404).
-            # We get around this (?) partially by not sending spell information with SMSG_DAMAGE_DONE (get_damage_done_packet).
-            # This hackfix introduces a bug where the previous combat target is displayed as the target of this result.
-            target = casting_spell.initial_target
-            miss_result = casting_spell.object_target_results[target.guid]
-            if miss_result.result != SpellMissReason.MISS_REASON_NONE:
-                dummy_dmg_info = DamageInfoHolder(attacker=self.caster, target=target,
-                                                  attack_type=casting_spell.get_attack_type(),
-                                                  spell_miss_reason=miss_result.result,
-                                                  hit_info=HitInfo.DEFERRED_LOGGING,
-                                                  spell_id=casting_spell.spell_entry.ID)
-                self.caster.send_attack_state_update(dummy_dmg_info)
-
         # Reset mana regen timer on cast perform.
         # Regen update will handle regen timer resets if a spell is casting,
         # but instants reach perform without update.

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -552,7 +552,7 @@ class SpellManager:
             for miss_info in casting_spell.object_target_results.values():  # Get the last effect application results.
                 if not miss_info.target.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
                     continue
-                miss_info.target.aura_manager.remove_aura_from_spell(casting_spell)
+                miss_info.target.aura_manager.remove_auras_from_spell(casting_spell)
 
         if casting_spell.is_channeled():
             self.handle_channel_end(casting_spell)

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -362,11 +362,19 @@ class SpellManager:
                 if target.guid not in casting_spell.object_target_results:
                     continue
                 info = casting_spell.object_target_results[target.guid]
-                # TODO deflection handling? Swap target/caster for now
-                if info.result == SpellMissReason.MISS_REASON_DEFLECTED:
-                    SpellEffectHandler.apply_effect(casting_spell, effect, info.target, casting_spell.spell_caster)
-                elif info.result == SpellMissReason.MISS_REASON_NONE:
-                    SpellEffectHandler.apply_effect(casting_spell, effect, casting_spell.spell_caster, info.target)
+
+                spell_target = target
+                spell_caster = casting_spell.spell_caster
+                # Swap target/caster on reflect. TODO actual reflect handling - this flag is never set.
+                if info.flags & SpellHitFlags.REFLECTED:
+                    spell_target = casting_spell.spell_caster
+                    spell_caster = target
+
+                if info.result == SpellMissReason.MISS_REASON_NONE:
+                    SpellEffectHandler.apply_effect(casting_spell, effect, spell_caster, spell_target)
+                elif target.get_type_id() == ObjectTypeIds.ID_UNIT and casting_spell.generates_threat() and \
+                        casting_spell.spell_caster.can_attack_target(target):  # Add threat for failed hostile casts.
+                    target.threat_manager.add_threat(casting_spell.spell_caster)
 
             if len(object_targets) > 0:
                 continue  # Prefer unit target for handling (don't attempt to resolve other target types for one effect if unit targets aren't empty)

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -286,6 +286,21 @@ class SpellManager:
 
         casting_spell.resolve_target_info_for_effects()
 
+        if casting_spell.casts_on_swing():
+            # TODO Hackfix for melee spell miss results.
+            # The client seems to expect damage info before spell_go for these spells (checked by attributes & 0x404).
+            # We get around this (?) partially by not sending spell information with SMSG_DAMAGE_DONE (get_damage_done_packet).
+            # This hackfix introduces a bug where the previous combat target is displayed as the target of this result.
+            target = casting_spell.initial_target
+            miss_result = casting_spell.object_target_results[target.guid]
+            if miss_result.result != SpellMissReason.MISS_REASON_NONE:
+                dummy_dmg_info = DamageInfoHolder(attacker=self.caster, target=target,
+                                                  attack_type=casting_spell.get_attack_type(),
+                                                  spell_miss_reason=miss_result.result,
+                                                  hit_info=HitInfo.DEFERRED_LOGGING,
+                                                  spell_id=casting_spell.spell_entry.ID)
+                self.caster.send_attack_state_update(dummy_dmg_info)
+
         # Reset mana regen timer on cast perform.
         # Regen update will handle regen timer resets if a spell is casting,
         # but instants reach perform without update.
@@ -421,7 +436,7 @@ class SpellManager:
         melee_ability.spell_attack_type = attack_type
 
         melee_ability.cast_state = SpellState.SPELL_STATE_CASTING
-        self.perform_spell_cast(melee_ability, False)
+        self.perform_spell_cast(melee_ability, validate=False)
         return True
 
     def get_queued_melee_ability(self) -> Optional[CastingSpell]:

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -130,6 +130,9 @@ class AuraManager:
         }
 
         for aura in list(self.active_auras.values()):
+            if aura.passive:
+                continue  # Skip secondary components of active auras. No passive spells have aura interrupts.
+
             # An interrupt for sitting does not exist.
             # Food/drink spells do claim that the player must remain seated.
             # In later versions an aurainterrupt exists for this purpose.
@@ -327,6 +330,10 @@ class AuraManager:
         AuraEffectHandler.handle_aura_effect_change(aura, aura.target, remove=True)
         if not self.active_auras.pop(aura.index, None):
             return
+
+        # Cancel other effects of this aura.
+        self.remove_auras_from_spell(aura.source_spell)
+
         # Some area effect auras (paladin auras, tranq etc.) are tied to spell effects.
         # Cancel cast on aura cancel, canceling the auras as well.
         self.unit_mgr.spell_manager.remove_cast(aura.source_spell, interrupted=not canceled)
@@ -349,13 +356,10 @@ class AuraManager:
                 continue
             self.remove_aura(aura, canceled=True)
 
-    def remove_aura_from_spell(self, casting_spell):
-        effects = casting_spell.get_effects()
-        auras = []
+    def remove_auras_from_spell(self, casting_spell):
         for aura in list(self.active_auras.values()):
-            if aura.spell_effect in effects:
+            if aura.source_spell is casting_spell:
                 self.remove_aura(aura)
-        return auras
 
     def build_update(self):
         [self.write_aura_to_unit(aura, send_duration=False) for aura in list(self.active_auras.values())]

--- a/game/world/managers/objects/units/DamageInfoHolder.py
+++ b/game/world/managers/objects/units/DamageInfoHolder.py
@@ -54,7 +54,7 @@ class DamageInfoHolder:
             flags |= WorldTextFlags.MISS_ABSORBED
 
         # Spell ID (0 allows client to display damage from dots and cast on swing spells).
-        data = pack('<Q2IiIQ', self.target.guid, self.total_damage, self.base_damage, flags, 0, self.attacker.guid)
+        data = pack('<Q2IiIQ', self.target.guid, self.total_damage, self.base_damage, flags, self.spell_id, self.attacker.guid)
         return PacketWriter.get_packet(OpCode.SMSG_DAMAGE_DONE, data)
 
     def get_attacker_state_update_spell_info_packet(self):
@@ -82,7 +82,7 @@ class DamageInfoHolder:
                     self.absorb,
                     self.target_state,
                     self.resist,
-                    0, 0,
+                    0, self.spell_id,
                     self.proc_victim_spell)
         return PacketWriter.get_packet(OpCode.SMSG_ATTACKERSTATEUPDATE, data)
 

--- a/game/world/managers/objects/units/DamageInfoHolder.py
+++ b/game/world/managers/objects/units/DamageInfoHolder.py
@@ -53,7 +53,6 @@ class DamageInfoHolder:
             flags &= ~(WorldTextFlags.NORMAL_DAMAGE | WorldTextFlags.CRIT)
             flags |= WorldTextFlags.MISS_ABSORBED
 
-        # Spell ID (0 allows client to display damage from dots and cast on swing spells).
         data = pack('<Q2IiIQ', self.target.guid, self.total_damage, self.base_damage, flags, self.spell_id, self.attacker.guid)
         return PacketWriter.get_packet(OpCode.SMSG_DAMAGE_DONE, data)
 

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -387,8 +387,6 @@ class UnitManager(ObjectManager):
         if not victim or not self.is_alive or not victim.is_alive or victim.unit_state & UnitStates.SANCTUARY:
             return
 
-        damage_info = self.calculate_melee_damage(victim, attack_type)
-
         if attack_type == AttackTypes.BASE_ATTACK:
             # No recent extra attack only at any non-extra attack.
             if not extra and self.extra_attacks > 0:
@@ -401,6 +399,8 @@ class UnitManager(ObjectManager):
                                                spell_id=melee_spell.spell_entry.ID, hit_info=HitInfo.DEFERRED_LOGGING)
                 self.send_attack_state_update(damage_info)
                 return
+
+        damage_info = self.calculate_melee_damage(victim, attack_type)
 
         if damage_info.total_damage > 0:
             victim.spell_manager.check_spell_interrupts(received_auto_attack=True, hit_info=damage_info.hit_info)

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -698,7 +698,7 @@ class UnitManager(ObjectManager):
         #     "Critical hits with ranged weapons now do 100% extra damage."
         # We assume that ranged crits dealt 50% increased damage instead of 100%. The other option could be 200% but
         # 50% sounds more logical.
-        if damage_info.hit_info & SpellHitFlags.CRIT:
+        if damage_info.hit_info & SpellHitFlags.CRIT and not spell_effect.is_periodic():
             is_ranged = damage_info.attack_type == AttackTypes.RANGED_ATTACK
             crit_multiplier = 1.50 if is_ranged else 2.0
             damage_info.proc_ex = ProcFlagsExLegacy.CRITICAL_HIT
@@ -736,8 +736,7 @@ class UnitManager(ObjectManager):
             self.generate_rage(damage_info, is_attacking=False)
 
         # TODO: Threat calculation.
-        # No damage but source spell generates threat on miss.
-        if casting_spell and damage_info.total_damage == 0 and casting_spell.generates_threat_on_miss():
+        if casting_spell and damage_info.total_damage == 0:
             self.threat_manager.add_threat(source)
             return True
         # Spell and does not generate threat.

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -687,8 +687,8 @@ class UnitManager(ObjectManager):
             damage_info.base_damage = self.stat_manager.apply_bonuses_for_damage(base_damage, spell_school,
                                                                                  target, subclass)
 
-        damage_info.hit_info = target.stat_manager.get_spell_attack_result_against_self(self, spell_school,
-                                                                                        is_periodic=spell_effect.is_periodic())
+        spell_miss_info = spell.object_target_results[target.guid]
+        damage_info.hit_info = spell_miss_info.flags
 
         if miss_reason in {SpellMissReason.MISS_REASON_EVADED, SpellMissReason.MISS_REASON_IMMUNE}:
             damage_info.target_state = VictimStates.VS_IMMUNE

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -423,7 +423,7 @@ class UnitManager(ObjectManager):
          for unit in [damage_info.attacker, damage_info.target]]
 
     def calculate_melee_damage(self, victim, attack_type):
-        dual_wield_penalty = 0.19 if self.has_offhand_weapon() else 0
+        dual_wield_penalty = 0.19 if self.has_offhand_weapon() and attack_type != AttackTypes.RANGED_ATTACK else 0
 
         damage_info = DamageInfoHolder(attacker=self, target=victim,
                                        attack_type=attack_type,

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -332,7 +332,7 @@ class SkillManager(object):
 
     def set_skill(self, skill_id, current_value, max_value=-1):
         if skill_id not in self.skills:
-            return
+            return False
 
         skill = self.skills[skill_id]
         skill.value = current_value
@@ -341,6 +341,7 @@ class SkillManager(object):
             skill.max = max_value
 
         RealmDatabaseManager.character_update_skill(skill)
+        return True
 
     def update_skills_max_value(self):
         for skill_id, skill in self.skills.items():

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -621,7 +621,9 @@ class SkillManager(object):
             if self.get_total_skill_value(req_skill) < req_skill_value:
                 return InventoryError.BAG_SKILL_MISMATCH
 
-        if item_class not in {ItemClasses.ITEM_CLASS_WEAPON, ItemClasses.ITEM_CLASS_ARMOR}:
+        if item_class not in {ItemClasses.ITEM_CLASS_WEAPON, ItemClasses.ITEM_CLASS_ARMOR} or \
+                item_class == ItemClasses.ITEM_CLASS_WEAPON and \
+                item_template.subclass == ItemSubClasses.ITEM_SUBCLASS_MISC_WEAPON:
             return InventoryError.BAG_OK  # No proficiency needed for misc. equipment.
 
         if item_class not in self.proficiencies:

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -764,6 +764,7 @@ class StatManager(object):
         # Use base attack formulas for next melee swing and ranged spells.
         if casting_spell.casts_on_swing() or casting_spell.casts_on_ranged_attack():
             # Note that dual wield penalty is not applied to spells.
+            # TODO Consider skill for the spell-specific category instead of weapon skill?
             result_info = self.get_attack_result_against_self(caster, casting_spell.get_attack_type())
             if result_info & HitInfo.PARRY:
                 miss_reason = SpellMissReason.MISS_REASON_PARRIED

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -760,8 +760,8 @@ class StatManager(object):
         if not caster.can_attack_target(self.unit_mgr):
             return SpellMissReason.MISS_REASON_NONE, hit_flags
 
-        # Use base attack formulas for physical spells.
-        if spell_school == SpellSchools.SPELL_SCHOOL_NORMAL:
+        # Use base attack formulas for melee/ranged spells.
+        if casting_spell.casts_on_swing() or casting_spell.casts_on_ranged_attack():
             # Note that dual wield penalty is not applied to spells.
             result_info = self.get_attack_result_against_self(caster, casting_spell.get_attack_type())
             if result_info & HitInfo.PARRY:

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -760,7 +760,7 @@ class StatManager(object):
         if not caster.can_attack_target(self.unit_mgr):
             return SpellMissReason.MISS_REASON_NONE, hit_flags
 
-        # Use base attack formulas for melee/ranged spells.
+        # Use base attack formulas for next melee swing and ranged spells.
         if casting_spell.casts_on_swing() or casting_spell.casts_on_ranged_attack():
             # Note that dual wield penalty is not applied to spells.
             result_info = self.get_attack_result_against_self(caster, casting_spell.get_attack_type())

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -788,10 +788,13 @@ class StatManager(object):
         # The below formulas are guesses. They're based on both partial and full resist formulas from VMaNGOS,
         # applied in a way that seems to make sense for our use case.
 
+        skill_value = -1
         if caster.get_type_id() == ObjectTypeIds.ID_PLAYER:
             _, skill, _ = caster.skill_manager.get_skill_info_for_spell_id(casting_spell.spell_entry.ID)
-            skill_value = caster.skill_manager.get_total_skill_value(skill.ID)
-        else:
+            # Use skill level if one exists for the spell, otherwise fall back to max possible skill.
+            skill_value = caster.skill_manager.get_total_skill_value(skill.ID) if skill else -1
+
+        if skill_value == -1:
             skill_value = caster.level * 5
 
         # Base spell miss chance from SpellCaster::MagicSpellHitChance.
@@ -812,7 +815,8 @@ class StatManager(object):
             resist_mod = self.get_total_stat(UnitStats.RESISTANCE_START + spell_school)
         else:
             # Calculate resistance for creatures.
-            # This is the formula for innate resistance used for partial resists in VMaNGOS
+            # This is the formula for innate resistance used for partial resists in VMaNGOS,
+            # with level adjusted 63->28.
             # (SpellCaster::GetSpellResistChance)
             resist_mod = (8 * rating_difference * skill_value) / 5 / 28
 

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -689,7 +689,8 @@ class StatManager(object):
             miss_chance += rating_difference * 0.0004 if rating_difference > 0 else rating_difference * 0.0002
         else:
             #  2% + 0.4% if defense rating is >10 points higher than attack rating, otherwise 0.1%.
-            miss_chance += rating_difference * 0.001 if rating_difference <= 10 else 0.02 + rating_difference * 0.004
+            miss_chance += rating_difference * 0.001 if rating_difference <= 10 else \
+                0.02 + (rating_difference - 10) * 0.004
 
         # Prior to version 1.8, dual wield's miss chance had a hard cap of 19%,
         # meaning that all dual-wield auto-attacks had a minimum 19% miss chance

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -659,7 +659,7 @@ class StatManager(object):
         gain = self.get_total_stat(UnitStats.INTELLECT) * 0.0002
         return gain if gain <= 0.10 else 0.10  # Cap at 10% (Guessed in VMaNGOS)
 
-    def get_attack_result_against_self(self, attacker, attack_type, dual_wield_penalty=0):
+    def get_attack_result_against_self(self, attacker, attack_type, dual_wield_penalty=0) -> HitInfo:
         # TODO Based on vanilla calculations.
         # Evading, return miss and handle on calling method.
         if self.unit_mgr.is_evading:
@@ -684,12 +684,12 @@ class StatManager(object):
         base_miss = 0.05 + dual_wield_penalty
         if self.unit_mgr.get_type_id() == ObjectTypeIds.ID_PLAYER:
             # 0.04% Bonus against players when the defender has a higher combat rating,
-            # 0.02% Bonus when the attacker has a higher combat rating.
+            # 0.02% Penalty when the attacker has a higher combat rating.
             miss_chance = base_miss + rating_difference * 0.0004 if rating_difference > 0 else base_miss + rating_difference * 0.0002
         else:
-            #  0.4% if defense rating is >10 points higher than attack rating, otherwise 0.1%.
+            #  2% + 0.4% if defense rating is >10 points higher than attack rating, otherwise 0.1%.
             miss_chance = base_miss + rating_difference * 0.001 if rating_difference <= 10 \
-                else base_miss + 1 + (rating_difference - 10) * 0.004
+                else base_miss + 0.02 + (rating_difference - 10) * 0.004
 
         # Prior to version 1.8, dual wield's miss chance had a hard cap of 19%,
         # meaning that all dual-wield auto-attacks had a minimum 19% miss chance


### PR DESCRIPTION
* Add spell miss result handling as described in #238.
    * Closes #238, closes #333, closes #544
    * Spell miss (resist) formulas are guessed. Alpha does not have partial resists. The used formulas are a mix of partial resist/full resist formulas from VMaNGOS, and use spell-specific skills instead of level.
    * TODO: Melee spells should use their corresponding spell skills, but are currently using weapon skill.
    * TODO: Spell immunity handling should be refactored to better fit these changes.
* Fix melee hit chance calculation for higher-level targets and adjust related formulas
    * Melee combat with lower skill is much less punishing now
* Fix some melee swing spells being instant
* Use melee skill gain formulas for spell skills
* Add a more proper fix for melee spell combat logging
* Fix dual wield penalty applying to ranged attacks
* Fix auras sometimes having only some of their effects removed
* Fix equip check for misc. weapons
* Add command for setting skill level