### PR TITLE
Profession Trainer Improvements/Bug Fixes

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -16462,5 +16462,31 @@ begin not atomic
         UPDATE `creature_template` SET `trainer_class` = '3' WHERE entry IN (2935, 5006, 5520, 5749, 5750, 5753, 5013, 2872, 2941, 3698, 4882, 4994, 2870, 2942, 4207, 5003, 2878, 3699, 4153, 2881, 2938, 3701, 4206, 5002, 2880, 2939, 3697, 5118, 5005, 2876, 5001, 2940, 5004, 3623, 5008, 5009, 5011, 4621, 5508, 5015, 5507, 5012, 5017, 3525, 4881);
         insert into applied_updates values ('030120231');
     end if;
+
+    -- 05/01/2023 1
+    if (select count(*) from applied_updates where id='050120231') = 0 then
+        -- Alchemy apprentices
+        UPDATE `creature_template` SET `trainer_id` = 505 WHERE entry IN (4609, 2132, 5500, 1246);
+
+        -- Blacksmithing/Weaponsmithing apprentices
+        UPDATE `creature_template` SET `trainer_id` = 506 WHERE entry IN (2116, 2135, 1383, 957, 2117, 2136, 1698);
+
+        -- Cooking apprentices
+        UPDATE `creature_template` SET `trainer_id` = 501 WHERE entry IN (5081);
+
+        -- Engineering apprentices
+        UPDATE `creature_template` SET `trainer_id` = 510 WHERE entry IN (2857, 3412, 4586);
+
+        -- Herbalism apprentices
+        UPDATE `creature_template` SET `trainer_id` = 502 WHERE entry IN (2114);
+
+        -- Leatherworking apprentices
+        UPDATE `creature_template` SET `trainer_id` = 509 WHERE entry IN (1466, 3008, 223);
+
+        -- Tailoring apprentices
+        UPDATE `creature_template` SET `trainer_id` = 507 WHERE entry IN (1300, 2855, 1703, 5567);
+
+        insert into applied_updates values ('050120231');
+    end if;
 end $
 delimiter ;

--- a/game/world/managers/objects/units/creature/utils/TrainerUtils.py
+++ b/game/world/managers/objects/units/creature/utils/TrainerUtils.py
@@ -102,7 +102,7 @@ class TrainerUtils:
         return data
 
     @staticmethod
-    def get_training_list_spell_status(spell, trainer_spell_template, req_level, preceded_spell, player_mgr, fulfills_skill=True):
+    def get_training_list_spell_status(spell: Spell, trainer_spell_template: TrainerTemplate, req_level: int, preceded_spell: int, player_mgr, fulfills_skill: bool =True):
         trainer_spell = DbcDatabaseManager.SpellHolder.spell_get_by_id(trainer_spell_template.spell)
         is_taught_to_pet = trainer_spell.Effect_1 == SpellEffects.SPELL_EFFECT_LEARN_PET_SPELL
         pet_info = player_mgr.pet_manager.get_active_pet_info()

--- a/game/world/managers/objects/units/creature/utils/TrainerUtils.py
+++ b/game/world/managers/objects/units/creature/utils/TrainerUtils.py
@@ -113,7 +113,9 @@ class TrainerUtils:
         if spell.ID in target_spells:
             return TrainerServices.TRAINER_SERVICE_USED
 
-        if not fulfills_skill or (preceded_spell and preceded_spell not in target_spells) or (not player_mgr.skill_manager.has_skill(trainer_spell_template.reqskill) and trainer_spell_template.reqskill != 0):
+        # target.skill_manager.get_total_skill_value(skill_id)
+        if not fulfills_skill or (preceded_spell and preceded_spell not in target_spells) or trainer_spell_template.reqskill != 0 \
+            and (not player_mgr.skill_manager.has_skill(trainer_spell_template.reqskill) or player_mgr.skill_manager.get_total_skill_value(trainer_spell_template.reqskill) < trainer_spell_template.reqskillvalue):
             return TrainerServices.TRAINER_SERVICE_UNAVAILABLE
 
         if player_mgr.level >= req_level:

--- a/game/world/managers/objects/units/creature/utils/TrainerUtils.py
+++ b/game/world/managers/objects/units/creature/utils/TrainerUtils.py
@@ -115,7 +115,7 @@ class TrainerUtils:
 
         # target.skill_manager.get_total_skill_value(skill_id)
         if not fulfills_skill or (preceded_spell and preceded_spell not in target_spells) or trainer_spell_template.reqskill != 0 \
-            and (not player_mgr.skill_manager.has_skill(trainer_spell_template.reqskill) or player_mgr.skill_manager.get_total_skill_value(trainer_spell_template.reqskill) < trainer_spell_template.reqskillvalue):
+                and (not player_mgr.skill_manager.has_skill(trainer_spell_template.reqskill) or player_mgr.skill_manager.get_total_skill_value(trainer_spell_template.reqskill) < trainer_spell_template.reqskillvalue):
             return TrainerServices.TRAINER_SERVICE_UNAVAILABLE
 
         if player_mgr.level >= req_level:

--- a/game/world/opcode_handling/handlers/npc/TrainerBuySpellHandler.py
+++ b/game/world/opcode_handling/handlers/npc/TrainerBuySpellHandler.py
@@ -81,11 +81,12 @@ class TrainerBuySpellHandler(object):
         if fail_reason != -1:
             TrainerBuySpellHandler.send_trainer_buy_fail(player_mgr, player_mgr.guid, training_spell_id, fail_reason)
             return
-        else:
-            player_mgr.remove_talent_points(talent_cost)
-            player_mgr.spell_manager.handle_cast_attempt(training_spell_id, player_mgr, SpellTargetMask.SELF,
-                                                         validate=False)
-            TrainerBuySpellHandler.send_trainer_buy_succeeded(player_mgr, player_mgr.guid, training_spell_id)
+    
+        # Success.
+        player_mgr.remove_talent_points(talent_cost)
+        player_mgr.spell_manager.handle_cast_attempt(training_spell_id, player_mgr, SpellTargetMask.SELF,
+                                                        validate=False)
+        TrainerBuySpellHandler.send_trainer_buy_succeeded(player_mgr, player_mgr.guid, training_spell_id)
 
     @staticmethod
     def handle_trainer_buy_spell(world_session, trainer_guid, training_spell_id):

--- a/game/world/opcode_handling/handlers/npc/TrainerBuySpellHandler.py
+++ b/game/world/opcode_handling/handlers/npc/TrainerBuySpellHandler.py
@@ -31,7 +31,7 @@ class TrainerBuySpellHandler(object):
                 TrainerBuySpellHandler.handle_player_buy_spell(player_mgr, training_spell_id)
             # NPC Trainer.
             else:
-                TrainerBuySpellHandler.handle_trainer_buy_spell(world_session, player_mgr, trainer_guid, training_spell_id)
+                TrainerBuySpellHandler.handle_trainer_buy_spell(world_session, trainer_guid, training_spell_id)
 
         return 0
 

--- a/game/world/opcode_handling/handlers/npc/TrainerBuySpellHandler.py
+++ b/game/world/opcode_handling/handlers/npc/TrainerBuySpellHandler.py
@@ -129,6 +129,7 @@ class TrainerBuySpellHandler(object):
             # Check spell status, fail if spell should be unavailable.
             if verify_status == TrainerServices.TRAINER_SERVICE_UNAVAILABLE:
                 fail_reason = TrainingFailReasons.TRAIN_FAIL_UNAVAILABLE
+                TrainerUtils.send_trainer_list(unit, world_session.player_mgr)
 
         if fail_reason != -1:
             if anti_cheat:


### PR DESCRIPTION
- **Fix server disconnect on buying spell.**
- Added full profession trainer template to apprentice trainers for now, instead of nothing.
- Fixed being able to train profession spells outside of your skill due to client bug (closes #858 ability to train, even when spells appear green.)
- Fixed similar train validation issue for talents; talents showing unavailable spells as available after successful train issue still exists.
- Minor improvements to `TrainerUtils.get_training_list_spell_status()`.