### PR TITLE
Quest.

### DIFF
--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -331,6 +331,9 @@ class GameObjectManager(ObjectManager):
         self.set_uint32(GameObjectFields.GAMEOBJECT_DISPLAYID, self.current_display_id)
         return True
 
+    def is_within_interactable_distance(self, victim):
+        return self.location.distance(victim.location) <= 6.0
+
     # There are only 3 possible animations that can be used here.
     # Effect might depend on the gameobject type, apparently. e.g. Fishing bobber does its animation by sending 0.
     # TODO: See if we can retrieve the animation names.

--- a/game/world/managers/objects/units/player/InventoryManager.py
+++ b/game/world/managers/objects/units/player/InventoryManager.py
@@ -154,6 +154,7 @@ class InventoryManager(object):
 
     def add_item_to_slot(self, dest_bag_slot, dest_slot, entry=0, item=None, item_template=None, count=1,
                          handle_error=True):
+        created_by = 0 if not item else item.item_instance.creator
         if entry != 0 and not item_template:
             item_template = WorldDatabaseManager.ItemTemplateHolder.item_template_get_by_entry(entry)
         if not item_template:
@@ -184,11 +185,13 @@ class InventoryManager(object):
             dest_slot = dest_container.next_available_slot()
             remaining = count
 
+            # Add items to target container.
             if not dest_slot == -1:  # If the target container has a slot open.
-                remaining, item_mgr = dest_container.add_item(item_template, count=count)  # Add items to target container.
+                remaining, item_mgr = dest_container.add_item(item_template, count=count, created_by=created_by)
 
+            # Overflow to inventory.
             if remaining > 0:
-                self.add_item(item_template=item_template, count=remaining)  # Overflow to inventory.
+                self.add_item(item_template=item_template, count=remaining, created_by=created_by)
 
             return True
 
@@ -214,7 +217,7 @@ class InventoryManager(object):
                     self.send_equip_error(InventoryError.BAG_NOT_EQUIPPABLE, item, dest_item)
                 return False
 
-        generated_item = dest_container.set_item(item_template, dest_slot, count=count)
+        generated_item = dest_container.set_item(item_template, dest_slot, count=count, created_by=created_by)
         # Add to containers if a bag was dragged to bag slots
         if dest_container.is_backpack and self.is_bag_pos(dest_slot):
             self.add_bag(dest_slot, generated_item)

--- a/game/world/managers/objects/units/player/quest/QuestManager.py
+++ b/game/world/managers/objects/units/player/quest/QuestManager.py
@@ -727,7 +727,7 @@ class QuestManager(object):
         data += pack('<I', quest.RewOrReqMoney if quest.RewOrReqMoney >= 0 else -quest.RewOrReqMoney)
         self.player_mgr.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_QUESTGIVER_OFFER_REWARD, data))
 
-    def handle_accept_quest(self, quest_id, quest_giver_guid, shared=False):
+    def handle_accept_quest(self, quest_id, quest_giver_guid, shared=False, quest_giver=None, is_item=False):
         if quest_id in self.active_quests:
             self.send_cant_take_quest_response(QuestFailedReasons.QUEST_ALREADY_ON)
             return
@@ -736,8 +736,9 @@ class QuestManager(object):
             self.send_cant_take_quest_response(QuestFailedReasons.QUEST_ONLY_ONE_TIMED)
             return
 
-        quest_item_starter = None
-        if quest_giver_guid:
+        quest_item_starter = None if not is_item else quest_giver
+        # Look for unit quest giver if it was not provided.
+        if quest_giver_guid and not quest_giver:
             quest_giver = None
             high_guid = GuidUtils.extract_high_guid(quest_giver_guid)
 

--- a/game/world/opcode_handling/handlers/quest/QuestGiverAcceptQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverAcceptQuestHandler.py
@@ -18,17 +18,21 @@ class QuestGiverAcceptQuestHandler(object):
 
         if len(reader.data) >= 12:  # Avoid handling empty quest giver accept quest packet.
             guid, quest_id = unpack('<QI', reader.data[:12])
-            high_guid = GuidUtils.extract_high_guid(guid)
-            is_item = False
 
+            is_item = False
             quest_giver = None
-            if high_guid == HighGuid.HIGHGUID_UNIT:
-                quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
-            elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
-                quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
-            elif high_guid == HighGuid.HIGHGUID_ITEM:
-                is_item = True
-                quest_giver = player_mgr.inventory.get_item_by_guid(guid)
+            # Use player known objects first.
+            if guid in player_mgr.known_objects:
+                quest_giver = player_mgr.known_objects[guid]
+            else:
+                high_guid = GuidUtils.extract_high_guid(guid)
+                if high_guid == HighGuid.HIGHGUID_ITEM:
+                    is_item = True
+                    quest_giver = player_mgr.inventory.get_item_by_guid(guid)
+                elif high_guid == HighGuid.HIGHGUID_UNIT:
+                    quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
+                elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
+                    quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
 
             if not quest_giver:
                 Logger.error(f'Error in {reader.opcode_str()}, could not find quest giver with guid of: {guid}.')
@@ -38,6 +42,7 @@ class QuestGiverAcceptQuestHandler(object):
                 return 0
             elif player_mgr.quest_manager.is_quest_log_full():
                 player_mgr.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_QUESTLOG_FULL))
-            else:
-                player_mgr.quest_manager.handle_accept_quest(quest_id, guid, shared=False)
+            elif is_item or quest_giver.is_within_interactable_distance(player_mgr):
+                player_mgr.quest_manager.handle_accept_quest(quest_id, guid, shared=False, quest_giver=quest_giver,
+                                                             is_item=is_item)
         return 0

--- a/game/world/opcode_handling/handlers/quest/QuestGiverChooseRewardHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverChooseRewardHandler.py
@@ -17,17 +17,21 @@ class QuestGiverChooseRewardHandler(object):
 
         if len(reader.data) >= 16:  # Avoid handling empty quest giver choose reward packet.
             guid, quest_id, item_choice = unpack('<Q2I', reader.data[:16])
-            high_guid = GuidUtils.extract_high_guid(guid)
-            is_item = False
 
+            is_item = False
             quest_giver = None
-            if high_guid == HighGuid.HIGHGUID_UNIT:
-                quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
-            elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
-                quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
-            elif high_guid == HighGuid.HIGHGUID_ITEM:
-                is_item = True
-                quest_giver = player_mgr.inventory.get_item_by_guid(guid)
+            # Use player known objects first.
+            if guid in player_mgr.known_objects:
+                quest_giver = player_mgr.known_objects[guid]
+            else:
+                high_guid = GuidUtils.extract_high_guid(guid)
+                if high_guid == HighGuid.HIGHGUID_ITEM:
+                    is_item = True
+                    quest_giver = player_mgr.inventory.get_item_by_guid(guid)
+                elif high_guid == HighGuid.HIGHGUID_UNIT:
+                    quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
+                elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
+                    quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
 
             if not quest_giver:
                 Logger.error(f'Error in {reader.opcode_str()}, could not find quest giver with guid: {guid}.')
@@ -36,5 +40,6 @@ class QuestGiverChooseRewardHandler(object):
                 Logger.warning(f'{reader.opcode_str()}, quest giver with guid: {guid} is hostile.')
                 return 0
 
-            player_mgr.quest_manager.handle_choose_reward(quest_giver, quest_id, item_choice)
+            if is_item or quest_giver.is_within_interactable_distance(player_mgr):
+                player_mgr.quest_manager.handle_choose_reward(quest_giver, quest_id, item_choice)
         return 0

--- a/game/world/opcode_handling/handlers/quest/QuestGiverCompleteQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverCompleteQuestHandler.py
@@ -17,17 +17,21 @@ class QuestGiverCompleteQuestHandler(object):
 
         if len(reader.data) >= 12:  # Avoid handling empty quest giver complete quest packet.
             guid, quest_id = unpack('<QI', reader.data[:12])
-            high_guid = GuidUtils.extract_high_guid(guid)
-            is_item = False
 
+            is_item = False
             quest_giver = None
-            if high_guid == HighGuid.HIGHGUID_UNIT:
-                quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
-            elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
-                quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
-            elif high_guid == HighGuid.HIGHGUID_ITEM:
-                is_item = True
-                quest_giver = player_mgr.inventory.get_item_by_guid(guid)
+            # Use player known objects first.
+            if guid in player_mgr.known_objects:
+                quest_giver = player_mgr.known_objects[guid]
+            else:
+                high_guid = GuidUtils.extract_high_guid(guid)
+                if high_guid == HighGuid.HIGHGUID_ITEM:
+                    is_item = True
+                    quest_giver = player_mgr.inventory.get_item_by_guid(guid)
+                elif high_guid == HighGuid.HIGHGUID_UNIT:
+                    quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
+                elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
+                    quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
 
             if not quest_giver:
                 Logger.error(f'Error in {reader.opcode_str()}, could not find quest giver with guid of: {guid}.')
@@ -36,5 +40,6 @@ class QuestGiverCompleteQuestHandler(object):
                 Logger.warning(f'{reader.opcode_str()}, quest giver with guid: {guid} is hostile.')
                 return 0
 
-            player_mgr.quest_manager.handle_complete_quest(quest_id, guid)
+            if is_item or quest_giver.is_within_interactable_distance(player_mgr):
+                player_mgr.quest_manager.handle_complete_quest(quest_id, guid)
         return 0

--- a/game/world/opcode_handling/handlers/quest/QuestGiverHelloHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverHelloHandler.py
@@ -17,17 +17,21 @@ class QuestGiverHelloHandler(object):
 
         if len(reader.data) >= 8:  # Avoid handling empty quest giver hello packet.
             guid = unpack('<Q', reader.data[:8])[0]
-            high_guid = GuidUtils.extract_high_guid(guid)
-            is_item = False
 
+            is_item = False
             quest_giver = None
-            if high_guid == HighGuid.HIGHGUID_UNIT:
-                quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
-            elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
-                quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
-            elif high_guid == HighGuid.HIGHGUID_ITEM:
-                is_item = True
-                quest_giver = player_mgr.inventory.get_item_by_guid(guid)
+            # Use player known objects first.
+            if guid in player_mgr.known_objects:
+                quest_giver = player_mgr.known_objects[guid]
+            else:
+                high_guid = GuidUtils.extract_high_guid(guid)
+                if high_guid == HighGuid.HIGHGUID_ITEM:
+                    is_item = True
+                    quest_giver = player_mgr.inventory.get_item_by_guid(guid)
+                elif high_guid == HighGuid.HIGHGUID_UNIT:
+                    quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
+                elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
+                    quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
 
             if not quest_giver:
                 Logger.error(f'Error in {reader.opcode_str()}, could not find quest giver with guid of: {guid}')
@@ -39,7 +43,7 @@ class QuestGiverHelloHandler(object):
             # TODO: Stop the npc if it's moving
             # TODO: Remove feign death from player
             # TODO: If the gossip menu is already open, do nothing
-            if quest_giver.is_within_interactable_distance(player_mgr):
+            if is_item or quest_giver.is_within_interactable_distance(player_mgr):
                 player_mgr.quest_manager.handle_quest_giver_hello(quest_giver, guid)
 
         return 0

--- a/game/world/opcode_handling/handlers/quest/QuestGiverRequestReward.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverRequestReward.py
@@ -17,17 +17,21 @@ class QuestGiverRequestReward(object):
 
         if len(reader.data) >= 12:  # Avoid handling empty quest giver request reward packet.
             guid, quest_id = unpack('<QI', reader.data[:12])
-            high_guid = GuidUtils.extract_high_guid(guid)
-            is_item = False
 
+            is_item = False
             quest_giver = None
-            if high_guid == HighGuid.HIGHGUID_UNIT:
-                quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
-            elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
-                quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
-            elif high_guid == HighGuid.HIGHGUID_ITEM:
-                is_item = True
-                quest_giver = player_mgr.inventory.get_item_by_guid(guid)
+            # Use player known objects first.
+            if guid in player_mgr.known_objects:
+                quest_giver = player_mgr.known_objects[guid]
+            else:
+                high_guid = GuidUtils.extract_high_guid(guid)
+                if high_guid == HighGuid.HIGHGUID_ITEM:
+                    is_item = True
+                    quest_giver = player_mgr.inventory.get_item_by_guid(guid)
+                elif high_guid == HighGuid.HIGHGUID_UNIT:
+                    quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
+                elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
+                    quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
 
             if not quest_giver:
                 Logger.error(f'Error in {reader.opcode_str()}, could not find quest giver with guid: {guid}.')
@@ -36,5 +40,6 @@ class QuestGiverRequestReward(object):
                 Logger.warning(f'{reader.opcode_str()}, quest giver with guid: {guid} is hostile.')
                 return 0
 
-            player_mgr.quest_manager.handle_request_reward(guid, quest_id)
+            if is_item or quest_giver.is_within_interactable_distance(player_mgr):
+                player_mgr.quest_manager.handle_request_reward(guid, quest_id)
         return 0

--- a/game/world/opcode_handling/handlers/quest/QuestGiverStatusHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverStatusHandler.py
@@ -17,15 +17,19 @@ class QuestGiverStatusHandler(object):
 
         if len(reader.data) >= 8:  # Avoid handling empty quest giver status packet.
             guid = unpack('<Q', reader.data[:8])[0]
-            high_guid = GuidUtils.extract_high_guid(guid)
 
             quest_giver = None
-            if high_guid == HighGuid.HIGHGUID_UNIT:
-                quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
-            elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
-                quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
-            elif high_guid == HighGuid.HIGHGUID_ITEM:
-                quest_giver = player_mgr.inventory.get_item_by_guid(guid)
+            # Use player known objects first.
+            if guid in player_mgr.known_objects:
+                quest_giver = player_mgr.known_objects[guid]
+            else:
+                high_guid = GuidUtils.extract_high_guid(guid)
+                if high_guid == HighGuid.HIGHGUID_ITEM:
+                    quest_giver = player_mgr.inventory.get_item_by_guid(guid)
+                elif high_guid == HighGuid.HIGHGUID_UNIT:
+                    quest_giver = MapManager.get_surrounding_unit_by_guid(player_mgr, guid)
+                elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:
+                    quest_giver = MapManager.get_surrounding_gameobject_by_guid(player_mgr, guid)
 
             if not quest_giver:
                 Logger.error(f'Error in {reader.opcode_str()}, could not find quest giver with guid of: {guid}')


### PR DESCRIPTION
- Quest opcode handlers - Rely on player known objects dictionary before using MapManager lookups for the given quest giver unit.
- Splitting items which have the creator attribute set should no longer remove it.