### PR TITLE
Spell cast speed modifiers / spell-related fixes / refactoring

### DIFF
--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -160,7 +160,8 @@ class CastingSpell:
 
         effect.targets.resolve_targets()
         effect_info = effect.targets.get_effect_target_miss_results()
-        self.object_target_results = self.object_target_results | effect_info
+        # Prioritize previous effects' results.
+        self.object_target_results = effect_info | self.object_target_results
 
     def get_attack_type(self):
         return self.spell_attack_type if self.spell_attack_type != -1 else 0

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -42,6 +42,10 @@ class CastingSpell:
     spell_visual_entry: SpellVisual
     _effects: list[Optional[SpellEffect]]
 
+    cast_time_: Optional[int] = None
+    duration_: Optional[int] = None
+    base_duration_: Optional[int] = None  # Duration without aura modifiers.
+
     cast_start_timestamp: float
     cast_end_timestamp: float
     spell_impact_timestamps: dict[int, float]
@@ -65,8 +69,10 @@ class CastingSpell:
         self.dynamic_object = None
         self.duration_entry = DbcDatabaseManager.spell_duration_get_by_id(spell.DurationIndex)
         self.range_entry = DbcDatabaseManager.spell_range_get_by_id(spell.RangeIndex)
+
         self.cast_time_entry = DbcDatabaseManager.spell_cast_time_get_by_id(spell.CastingTimeIndex)
-        self.cast_end_timestamp = self.get_base_cast_time()/1000 + time.time()
+
+        self.cast_end_timestamp = self.get_cast_time() / 1000 + time.time()
         self.spell_visual_entry = DbcDatabaseManager.spell_visual_get_by_id(spell.SpellVisualID)
 
         if self.spell_caster.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
@@ -81,6 +87,11 @@ class CastingSpell:
         # Item target casts (enchants) have target item info in equipment requirements - ignore.
         if spell.EquippedItemClass == ItemClasses.ITEM_CLASS_WEAPON and not self.initial_target_is_item():
             self.spell_attack_type = AttackTypes.RANGED_ATTACK if self.is_ranged_weapon_attack() else AttackTypes.BASE_ATTACK
+
+        # Resolve cast time and duration on init (ie. apply any cast time modifiers on cast start).
+        self.cast_time_ = self.get_cast_time()
+        self.duration_ = self.get_duration()
+        self.base_duration_ = self.get_duration(apply_mods=False)
 
         self.cast_state = SpellState.SPELL_STATE_PREPARING
         self.spell_impact_timestamps = {}
@@ -390,7 +401,7 @@ class CastingSpell:
                (SpellAttributes.SPELL_ATTR_ON_NEXT_SWING_1 | SpellAttributes.SPELL_ATTR_ON_NEXT_SWING_2)
 
     def casts_on_ranged_attack(self):
-        # Quick Shot has a negative base cast time (-1000000), which will resolve to 0 in get_base_cast_time().
+        # Quick Shot has a negative base cast time (-1000000), which will resolve to 0.
         # Ranged attacks occurring on next ranged have a base cast time of 0.
         if not self.cast_time_entry or self.cast_time_entry.Base < 0:
             return False  # No entry or Quick Shot.
@@ -429,7 +440,10 @@ class CastingSpell:
             level = self.spell_entry.BaseLevel
         return max(level - self.spell_entry.SpellLevel, 0)
 
-    def get_base_cast_time(self):
+    def get_cast_time(self):
+        if self.cast_time_ is not None:
+            return self.cast_time_
+
         if self.is_instant_cast():
             return 0
 
@@ -442,18 +456,16 @@ class CastingSpell:
 
         caster_is_unit = self.spell_caster.get_type_mask() & ObjectTypeFlags.TYPE_UNIT
 
-        if caster_is_unit and self.spell_entry.Attributes & (SpellAttributes.SPELL_ATTR_IS_ABILITY |
-                                                             SpellAttributes.SPELL_ATTR_TRADESPELL):
-            # TODO: This calculation should probably be out of 'base' cast time.
-            mod_cast_speed = self.spell_caster.get_uint32(UnitFields.UNIT_MOD_CAST_SPEED)
-            cast_time = int(cast_time * (1.0 + mod_cast_speed / 100.0))
-
         if self.is_ranged_weapon_attack() and caster_is_unit:
             # Ranged attack tooltips are unfinished, so this is partially a guess.
             # All ranged attacks without delay seem to say "next ranged".
             # Ranged attacks with delay (cast time) say "attack speed + X (delay) sec".
             ranged_delay = self.spell_caster.stat_manager.get_total_stat(UnitStats.RANGED_DELAY)
             cast_time += ranged_delay
+
+        if caster_is_unit and not self.spell_entry.Attributes & (SpellAttributes.SPELL_ATTR_TRADESPELL |
+                                                                 SpellAttributes.SPELL_ATTR_IS_ABILITY):
+            cast_time = self.spell_caster.stat_manager.apply_bonuses_for_value(cast_time, UnitStats.SPELL_CASTING_SPEED)
 
         return max(0, cast_time)
 
@@ -471,16 +483,28 @@ class CastingSpell:
 
         return mana_cost + power_cost_mod
 
-    def get_duration(self):
+    def get_duration(self, apply_mods=True):
         if not self.duration_entry:
             return 0
         base_duration = self.duration_entry.Duration
         if base_duration == -1:
             return -1  # Permanent.
 
-        gain_per_level = self.duration_entry.DurationPerLevel * self.caster_effective_level
         combo_gain = max(0, self.spent_combo_points - 1) * base_duration
-        return min(base_duration + gain_per_level, self.duration_entry.MaxDuration) + combo_gain
+        if self.duration_ is not None and self.base_duration_ is not None:
+            return (self.duration_ if apply_mods else self.base_duration_) + combo_gain
+
+        gain_per_level = self.duration_entry.DurationPerLevel * self.caster_effective_level
+
+        base_duration = min(base_duration + gain_per_level, self.duration_entry.MaxDuration)
+        if not self.spell_caster.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
+            return base_duration
+
+        # Apply casting speed modifiers for channeled spells.
+        if self.is_channeled() and apply_mods:
+            return self.spell_caster.stat_manager.apply_bonuses_for_value(base_duration, UnitStats.SPELL_CASTING_SPEED)
+
+        return base_duration
 
     def get_cast_damage_info(self, attacker, victim, damage, absorb, healing=False):
         damage_info = DamageInfoHolder(attacker=attacker, target=victim,
@@ -537,33 +561,28 @@ class CastingSpell:
         if self.spell_caster.get_type_id() != ObjectTypeIds.ID_PLAYER:
             return
 
-        # TODO Did pushback resistance exist?
         curr_time = time.time()
-        remaining_cast_before_pushback = self.cast_end_timestamp - curr_time
+        remaining_cast_before_pushback = (self.cast_end_timestamp - curr_time) * 1000
 
         if self.is_channeled() and self.cast_state == SpellState.SPELL_STATE_ACTIVE and self.get_duration() != -1:
-            channel_length = self.get_duration() / 1000  # /1000 for seconds.
+            channel_length = self.get_duration()
             final_opcode = OpCode.MSG_CHANNEL_UPDATE
-            pushback_length_sec = min(remaining_cast_before_pushback, channel_length * 0.25)
+            pushback_length = channel_length * 0.25
             for effect in self.get_effects():
-                if remaining_cast_before_pushback <= pushback_length_sec:
-                    # Applied aura duration is not timestamp based so it's stored in milliseconds.
-                    # To avoid rounding issues, set to zero instead of subtracting if pushback leads to channel stop.
-                    effect.applied_aura_duration = 0
-                else:
-                    effect.applied_aura_duration -= pushback_length_sec * 1000  # aura duration is stored as millis.
+                effect.applied_aura_duration -= pushback_length
                 effect.remove_old_periodic_effect_ticks()
 
-            self.cast_end_timestamp -= pushback_length_sec
-            data = pack('<I', int((remaining_cast_before_pushback - pushback_length_sec)*1000))  # *1000 for millis.
+            pushback_length = min(remaining_cast_before_pushback, pushback_length)
+            self.cast_end_timestamp -= pushback_length / 1000
+            data = pack('<I', int(remaining_cast_before_pushback - pushback_length))
 
         elif self.cast_state == SpellState.SPELL_STATE_CASTING:
             final_opcode = OpCode.SMSG_SPELL_DELAYED
-            cast_progress_seconds = self.get_base_cast_time()/1000 - remaining_cast_before_pushback  # base cast time in seconds.
-            pushback_length_sec = min(cast_progress_seconds, 0.5)  # Push back 0.5s or to beginning of cast.
+            cast_progress = self.get_cast_time() - remaining_cast_before_pushback
+            pushback_length = min(cast_progress, 500)  # Push back 0.5s or to beginning of cast.
 
-            self.cast_end_timestamp += pushback_length_sec
-            data = pack('<QI', self.spell_caster.guid, int(pushback_length_sec * 1000))  # *1000 for millis.
+            self.cast_end_timestamp += pushback_length / 1000
+            data = pack('<QI', self.spell_caster.guid, int(pushback_length))
         else:
             return
 

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -465,7 +465,7 @@ class CastingSpell:
             mana_cost = self.spell_caster.base_mana * self.spell_entry.ManaCostPct / 100
 
         if self.spell_caster.get_type_id() == ObjectTypeIds.ID_PLAYER:
-            mana_cost = self.spell_caster.stat_manager.apply_bonuses_for_value(mana_cost, UnitStats.SCHOOL_POWER_COST,
+            mana_cost = self.spell_caster.stat_manager.apply_bonuses_for_value(mana_cost, UnitStats.SPELL_SCHOOL_POWER_COST,
                                                                                misc_value=self.spell_entry.School)
         # ManaCostPerLevel is not used by anything relevant, ignore for now (only 271/4513/7290) TODO
 

--- a/game/world/managers/objects/spell/SpellEffect.py
+++ b/game/world/managers/objects/spell/SpellEffect.py
@@ -10,7 +10,7 @@ from game.world.managers.objects.spell.aura.AuraEffectHandler import PERIODIC_AU
 from game.world.managers.objects.spell.EffectTargets import EffectTargets
 from game.world.managers.objects.spell.aura.AreaAuraHolder import AreaAuraHolder
 from utils.constants.MiscCodes import ObjectTypeFlags
-from utils.constants.SpellCodes import SpellEffects, SpellAttributes, SpellAttributesEx, SpellImmunity
+from utils.constants.SpellCodes import SpellEffects, SpellAttributes, SpellAttributesEx, SpellImmunity, SpellMissReason
 
 
 class SpellEffect:
@@ -178,6 +178,16 @@ class SpellEffect:
             return True
 
         return False
+
+    def can_miss(self):
+        return self.effect_type not in {SpellEffects.SPELL_EFFECT_LEAP}
+
+    def is_full_miss(self):
+        if not self.casting_spell.object_target_results:
+            return False
+        targets = self.targets.get_resolved_effect_targets_by_type(ObjectManager)
+        return all([self.casting_spell.object_target_results[target.guid].result != SpellMissReason.MISS_REASON_NONE
+                    for target in targets])
 
     # noinspection PyUnusedLocal
     def load_effect(self, spell, index):

--- a/game/world/managers/objects/spell/SpellEffect.py
+++ b/game/world/managers/objects/spell/SpellEffect.py
@@ -188,6 +188,11 @@ class SpellEffect:
     def is_full_miss(self):
         if not self.casting_spell.object_target_results:
             return False
+
+        if not self.casting_spell.initial_target_is_unit_or_player():
+            # Don't consider non-unit-targeted spells for "full misses", as the initial target is unmissable.
+            return False
+
         targets = self.targets.get_resolved_effect_targets_by_type(ObjectManager)
         return all([self.casting_spell.object_target_results[target.guid].result != SpellMissReason.MISS_REASON_NONE
                     for target in targets])

--- a/game/world/managers/objects/spell/SpellEffect.py
+++ b/game/world/managers/objects/spell/SpellEffect.py
@@ -56,6 +56,10 @@ class SpellEffect:
         is_periodic = self.aura_type in PERIODIC_AURA_EFFECTS or AuraEffectDummyHandler.is_periodic(casting_spell.spell_entry.ID)
         # Descriptions of periodic effects with a period of 0 either imply regeneration every 5s or say "per tick".
         self.aura_period = (self.aura_period if self.aura_period else 5000) if is_periodic else 0
+        if is_periodic and casting_spell.is_channeled():
+            # Account for channel time modifiers.
+            tick_count = int(self.casting_spell.get_duration(apply_mods=False) / self.aura_period)
+            self.aura_period = int(self.casting_spell.get_duration() / tick_count)
 
     def update_effect_aura(self, timestamp):
         if self.applied_aura_duration == -1:
@@ -90,7 +94,6 @@ class SpellEffect:
         duration = self.casting_spell.get_duration()
         if not self.is_periodic():
             return []
-
 
         if duration == -1:
             tick_count = 1  # Generate first tick for infinite duration spells.

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -827,10 +827,10 @@ class SpellEffectHandler:
     def handle_spell_defense_passive(casting_spell, effect, caster, target):
         pass  # Only "SPELLDEFENSE (DND)", obsolete
 
-    AREA_SPELL_EFFECTS = [
+    AREA_SPELL_EFFECTS = {
         SpellEffects.SPELL_EFFECT_PERSISTENT_AREA_AURA,
         SpellEffects.SPELL_EFFECT_APPLY_AREA_AURA
-    ]
+    }
 
 
 SPELL_EFFECTS = {

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -347,18 +347,19 @@ class SpellManager:
             if update and update_index != effect.effect_index:
                 continue
 
+            object_targets = effect.targets.get_resolved_effect_targets_by_type(ObjectManager)
+
             if not update:
                 if effect.is_full_miss():
                     # Don't apply following effects if the previous one results in a full miss.
                     # TODO Needs thorough testing to ensure this is correct.
+                    [target.threat_manager.add_threat(casting_spell.spell_caster) for target in object_targets]
                     break
                 effect.start_aura_duration()
 
             if effect.effect_type in SpellEffectHandler.AREA_SPELL_EFFECTS:
                 SpellEffectHandler.apply_effect(casting_spell, effect, casting_spell.spell_caster, None)
                 continue
-
-            object_targets = effect.targets.get_resolved_effect_targets_by_type(ObjectManager)
 
             for target in object_targets:
                 if partial_targets and target.guid not in partial_targets:

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -354,6 +354,7 @@ class SpellManager:
                     # Don't apply following effects if the previous one results in a full miss.
                     # TODO Needs thorough testing to ensure this is correct.
                     [target.threat_manager.add_threat(casting_spell.spell_caster) for target in object_targets]
+                    remove = True
                     break
                 effect.start_aura_duration()
 

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -352,7 +352,6 @@ class SpellManager:
             if not update:
                 if effect.is_full_miss():
                     # Don't apply following effects if the previous one results in a full miss.
-                    # TODO Needs thorough testing to ensure this is correct.
                     [target.threat_manager.add_threat(casting_spell.spell_caster) for target in object_targets]
                     remove = True
                     break

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -692,7 +692,7 @@ class SpellManager:
             cast_flags |= SpellCastFlags.CAST_FLAG_PROC
 
         data = [source_guid, self.caster.guid,
-                casting_spell.spell_entry.ID, cast_flags, casting_spell.get_base_cast_time(),
+                casting_spell.spell_entry.ID, cast_flags, casting_spell.get_cast_time(),
                 casting_spell.spell_target_mask]
 
         signature = '<2QIHiH'  # source, caster, ID, flags, delay .. (targets, opt. ammo displayID / inventorytype).

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -348,6 +348,10 @@ class SpellManager:
                 continue
 
             if not update:
+                if effect.is_full_miss():
+                    # Don't apply following effects if the previous one results in a full miss.
+                    # TODO Needs thorough testing to ensure this is correct.
+                    break
                 effect.start_aura_duration()
 
             if effect.effect_type in SpellEffectHandler.AREA_SPELL_EFFECTS:

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -650,7 +650,7 @@ class AuraEffectHandler:
             effect_target.stat_manager.remove_aura_stat_bonus(aura.index)
             return
         amount = aura.get_effect_points()
-        effect_target.stat_manager.apply_aura_stat_bonus(aura.index, UnitStats.SCHOOL_POWER_COST, amount,
+        effect_target.stat_manager.apply_aura_stat_bonus(aura.index, UnitStats.SPELL_SCHOOL_POWER_COST, amount,
                                                          misc_value=aura.spell_effect.misc_value)
 
     @staticmethod

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -628,17 +628,11 @@ class AuraEffectHandler:
             effect_target.stat_manager.remove_aura_stat_bonus(aura.index)
             return
 
-        # Any item, affects main, off and ranged.
-        if aura.source_spell.spell_entry.EquippedItemClass == -1:
-            amount = aura.get_effect_points() / 100
-            effect_target.stat_manager.apply_aura_stat_bonus(aura.index, UnitStats.SPELL_ITEM_GLOBAL_CRITICAL_MODS,
-                                                             amount=amount)
-        # ItemSubClass specific.
-        else:
-            item_subclass_mask = aura.source_spell.spell_entry.EquippedItemSubclass
-            amount = aura.get_effect_points() / 100
-            effect_target.stat_manager.apply_aura_stat_bonus(aura.index, UnitStats.SPELL_ITEM_CRITICAL_MODS,
-                                                             amount=amount, misc_value=item_subclass_mask)
+        amount = aura.get_effect_points() / 100
+        item_class = aura.source_spell.spell_entry.EquippedItemClass
+        misc_value = aura.source_spell.spell_entry.EquippedItemSubclass if item_class != -1 else -1
+        effect_target.stat_manager.apply_aura_stat_bonus(aura.index, UnitStats.MELEE_CRITICAL,
+                                                         amount=amount, misc_value=misc_value)
 
     @staticmethod
     def handle_mod_school_crit_chance(aura, effect_target, remove):
@@ -646,7 +640,7 @@ class AuraEffectHandler:
             effect_target.stat_manager.remove_aura_stat_bonus(aura.index)
             return
         amount = aura.get_effect_points() / 100
-        effect_target.stat_manager.apply_aura_stat_bonus(aura.index, UnitStats.SCHOOL_CRITICAL,
+        effect_target.stat_manager.apply_aura_stat_bonus(aura.index, UnitStats.SPELL_SCHOOL_CRITICAL,
                                                          amount=amount,
                                                          misc_value=aura.spell_effect.misc_value)
 

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -748,6 +748,15 @@ class AuraEffectHandler:
                                                          amount, percentual=True)
 
     @staticmethod
+    def handle_mod_casting_speed(aura, effect_target, remove):
+        if remove:
+            effect_target.stat_manager.remove_aura_stat_bonus(aura.index, percentual=True)
+            return
+        amount = aura.get_effect_points()
+        effect_target.stat_manager.apply_aura_stat_bonus(aura.index, UnitStats.SPELL_CASTING_SPEED, amount,
+                                                         percentual=True)
+
+    @staticmethod
     def handle_mod_parry_chance(aura, effect_target, remove):
         if remove:
             effect_target.stat_manager.remove_aura_stat_bonus(aura.index, percentual=False)
@@ -846,6 +855,7 @@ AURA_EFFECTS = {
     AuraTypes.SPELL_AURA_MOD_DECREASE_SPEED: AuraEffectHandler.handle_decrease_speed,
     AuraTypes.SPELL_AURA_MOD_INCREASE_SWIM_SPEED: AuraEffectHandler.handle_increase_swim_speed,
     AuraTypes.SPELL_AURA_MOD_ATTACKSPEED: AuraEffectHandler.handle_mod_attack_speed,
+    AuraTypes.SPELL_AURA_MOD_CASTING_SPEED_NOT_STACK: AuraEffectHandler.handle_mod_casting_speed,
 
 
     AuraTypes.SPELL_AURA_MOD_PARRY_PERCENT: AuraEffectHandler.handle_mod_parry_chance,

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -341,7 +341,7 @@ class AuraManager:
 
         # Some area effect auras (paladin auras, tranq etc.) are tied to spell effects.
         # Cancel cast on aura cancel, canceling the auras as well.
-        self.unit_mgr.spell_manager.remove_cast(aura.source_spell, interrupted=not canceled)
+        self.unit_mgr.spell_manager.remove_cast(aura.source_spell)
 
         # Some spells start cooldown on aura remove, handle that case here.
         if aura.source_spell.unlock_cooldown_on_trigger():

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -435,7 +435,8 @@ class UnitManager(ObjectManager):
                                        attack_type=attack_type,
                                        damage_school_mask=SpellSchoolMask.SPELL_SCHOOL_MASK_NORMAL)
 
-        damage_info.hit_info = victim.stat_manager.get_attack_result_against_self(self, attack_type, dual_wield_penalty)
+        damage_info.hit_info = victim.stat_manager.get_attack_result_against_self(self, attack_type,
+                                                                                  dual_wield_penalty=dual_wield_penalty)
 
         damage_info.base_damage = self.calculate_base_attack_damage(attack_type, SpellSchools.SPELL_SCHOOL_NORMAL, victim)
         damage_info.target_state = VictimStates.VS_WOUND  # Default state on successful attack.

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -54,7 +54,7 @@ class UnitStats(IntFlag):
     MELEE_CRITICAL = auto()
     SPELL_CRITICAL = auto()
     SPELL_SCHOOL_CRITICAL = auto()
-    SCHOOL_POWER_COST = auto()
+    SPELL_SCHOOL_POWER_COST = auto()
     SPELL_CASTING_SPEED_NON_STACKING = auto()
 
     DAMAGE_DONE = auto()

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -13,6 +13,7 @@ from utils.constants.SpellCodes import SpellSchools, SpellImmunity, SpellHitFlag
 from utils.constants.UnitCodes import PowerTypes, Classes, Races, UnitFlags
 from utils.constants.UpdateFields import UnitFields
 
+
 # Stats that are modified by aura effects and items.
 # Use auto indexing to make expanding much easier.
 class UnitStats(IntFlag):
@@ -779,7 +780,7 @@ class StatManager(object):
             return SpellMissReason.MISS_REASON_NONE, hit_flags
 
         # Use base attack formulas for next melee swing and ranged spells.
-        if casting_spell.casts_on_swing() or casting_spell.casts_on_ranged_attack():
+        if casting_spell.casts_on_swing() or casting_spell.is_ranged_weapon_attack():
             # Note that dual wield penalty is not applied to spells.
             # TODO Consider skill for the spell-specific category instead of weapon skill?
             result_info = self.get_attack_result_against_self(caster, casting_spell.get_attack_type())

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -780,7 +780,8 @@ class StatManager(object):
             hit_flags |= SpellHitFlags.CRIT
 
         # Spells cast on friendly targets should always hit.
-        if not caster.can_attack_target(self.unit_mgr):
+        if not caster.can_attack_target(self.unit_mgr) or \
+                any([not effect.can_miss() for effect in casting_spell.get_effects()]):
             return SpellMissReason.MISS_REASON_NONE, hit_flags
 
         # Use base attack formulas for next melee swing and ranged spells.

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -51,13 +51,11 @@ class UnitStats(IntFlag):
 
     PROC_CHANCE = auto()
 
-    CRITICAL = auto()
+    MELEE_CRITICAL = auto()
     SPELL_CRITICAL = auto()
-    SPELL_ITEM_CRITICAL_MODS = auto()
-    SPELL_ITEM_GLOBAL_CRITICAL_MODS = auto()
-    SPELL_CASTING_SPEED_NON_STACKING = auto()
-    SCHOOL_CRITICAL = auto()
+    SPELL_SCHOOL_CRITICAL = auto()
     SCHOOL_POWER_COST = auto()
+    SPELL_CASTING_SPEED_NON_STACKING = auto()
 
     DAMAGE_DONE = auto()
     DAMAGE_DONE_SCHOOL = auto()
@@ -185,7 +183,7 @@ class StatManager(object):
             self.base_stats[UnitStats.DODGE_CHANCE] = BASE_DODGE_CHANCE_CREATURE / 100
             # Players have block scaling, assign flat 5% to creatures.
             self.base_stats[UnitStats.BLOCK_CHANCE] = BASE_BLOCK_PARRY_CHANCE / 100
-            self.base_stats[UnitStats.CRITICAL] = BASE_MELEE_CRITICAL_CHANCE / 100
+            self.base_stats[UnitStats.MELEE_CRITICAL] = BASE_MELEE_CRITICAL_CHANCE / 100
             self.base_stats[UnitStats.SPELL_CRITICAL] = BASE_SPELL_CRITICAL_CHANCE / 100
             self.unit_mgr.base_hp = self.unit_mgr.max_health
             self.unit_mgr.base_mana = self.unit_mgr.max_power_1
@@ -318,7 +316,7 @@ class StatManager(object):
 
         return bonus
 
-    # Returns a list of bonuses for a stat from auras. Needed for separating negative and positive resistance bonuses for the client.
+    # Returns a list of bonuses for a stat from auras.
     def get_aura_stat_bonuses(self, stat_type: UnitStats, percentual=False, misc_value=-1, misc_value_is_mask=False) -> list[int]:
         bonuses = []
         if percentual:
@@ -537,7 +535,7 @@ class StatManager(object):
         class_rate = (scaling[0] * (60 - self.unit_mgr.level) +
                       scaling[1] * (self.unit_mgr.level - 1)) / 59
         critical_bonus = strength / class_rate / 100
-        self.base_stats[UnitStats.CRITICAL] = critical_bonus
+        self.base_stats[UnitStats.MELEE_CRITICAL] = critical_bonus
 
     def update_base_dodge_chance(self):
         if self.unit_mgr.get_type_id() != ObjectTypeIds.ID_PLAYER:
@@ -723,19 +721,11 @@ class StatManager(object):
         if self.unit_mgr.can_block(attacker.location) and roll < block_chance:
             return HitInfo.BLOCK
 
-        attacker_critical_chance = attacker.stat_manager.get_total_stat(UnitStats.CRITICAL, accept_float=True)
+        attacker_weapon_mask = 1 << attack_weapon.item_template.subclass if attack_weapon else -1
 
-        # Check for spell crit mods for item class/subclass.
-        if attacker.get_type_id() == ObjectTypeIds.ID_PLAYER and attack_weapon:
-            # ItemSubClass specific.
-            item_subclass_mask = 1 << attack_weapon.item_template.subclass
-            attacker_critical_chance += attacker.stat_manager.get_total_stat(UnitStats.SPELL_ITEM_CRITICAL_MODS,
-                                                                             misc_value=item_subclass_mask,
-                                                                             accept_float=True,
-                                                                             misc_value_is_mask=True)
-            # General main, off, ranged. ItemClass -1.
-            attacker_critical_chance += attacker.stat_manager.get_total_stat(UnitStats.SPELL_ITEM_GLOBAL_CRITICAL_MODS,
-                                                                             accept_float=True)
+        attacker_critical_chance = attacker.stat_manager.get_total_stat(UnitStats.MELEE_CRITICAL, accept_float=True,
+                                                                        misc_value=attacker_weapon_mask,
+                                                                        misc_value_is_mask=attacker_weapon_mask != -1)
 
         if self.unit_mgr.get_type_id() == ObjectTypeIds.ID_PLAYER:
             # Player: +- 0.04% for each rating difference.
@@ -768,17 +758,6 @@ class StatManager(object):
         spell_school = casting_spell.spell_entry.School
         caster = casting_spell.spell_caster
 
-        critical_type = UnitStats.CRITICAL if spell_school == SpellSchools.SPELL_SCHOOL_NORMAL else UnitStats.SPELL_CRITICAL
-        crit_chance = caster.stat_manager.get_total_stat(critical_type, accept_float=True)
-
-        # If using base SPELL_CRITICAL, check if school critical enhancements exist.
-        if critical_type != UnitStats.CRITICAL:
-            crit_chance += caster.stat_manager.get_total_stat(UnitStats.SCHOOL_CRITICAL, misc_value=spell_school,
-                                                              accept_float=True, misc_value_is_mask=True)
-
-        if random.random() < crit_chance:
-            hit_flags |= SpellHitFlags.CRIT
-
         # Spells cast on friendly targets should always hit.
         if not caster.can_attack_target(self.unit_mgr) or \
                 any([not effect.can_miss() for effect in casting_spell.get_effects()]):
@@ -789,6 +768,9 @@ class StatManager(object):
             # Note that dual wield penalty is not applied to spells.
             # TODO Consider skill for the spell-specific category instead of weapon skill?
             result_info = self.get_attack_result_against_self(caster, casting_spell.get_attack_type())
+            if result_info & HitInfo.CRITICAL_HIT:
+                hit_flags |= SpellHitFlags.CRIT
+
             if result_info & HitInfo.PARRY:
                 miss_reason = SpellMissReason.MISS_REASON_PARRIED
             elif result_info & HitInfo.DODGE:
@@ -801,7 +783,12 @@ class StatManager(object):
                 miss_reason = SpellMissReason.MISS_REASON_NONE
             return miss_reason, hit_flags
 
-        # Non-physical spell resist chance.
+        # Add base spell crit and school-specific crit modifiers.
+        crit_chance = caster.stat_manager.get_total_stat(UnitStats.SPELL_CRITICAL, accept_float=True)
+        crit_chance += caster.stat_manager.get_total_stat(UnitStats.SPELL_SCHOOL_CRITICAL, misc_value=spell_school,
+                                                          accept_float=True)
+        if random.random() < crit_chance:
+            hit_flags |= SpellHitFlags.CRIT
 
         # TODO Research is needed on how resist mechanics worked in alpha.
         # 0.7 patch notes:

--- a/utils/constants/SpellCodes.py
+++ b/utils/constants/SpellCodes.py
@@ -257,11 +257,11 @@ class SpellSchoolMask(IntEnum):
 
 
 class SpellState(IntEnum):
-    SPELL_STATE_PREPARING = 0  # cast time delay period non channeled spell
-    SPELL_STATE_CASTING = 1  # channeled time period spell casting state
-    SPELL_STATE_FINISHED = 2  # cast finished to success or fail
-    SPELL_STATE_DELAYED = 3  # spell casted but need time to hit target(s)
-    SPELL_STATE_ACTIVE = 4  # Spell has been cast successfully. Effects should be applied on update (channels, range-limited auras) and InterruptFlags should be checked.
+    SPELL_STATE_PREPARING = 0  # Spell initialization.
+    SPELL_STATE_CASTING = 1  # Spell has been initialized and validated.
+    SPELL_STATE_FINISHED = 2  # Cast has finished successfully. Effects are applied immediately after.
+    SPELL_STATE_DELAYED = 3  # Cast is waiting for impact delay or next swing.
+    SPELL_STATE_ACTIVE = 4  # Spell has cast successfully and is either channeling or applying an area aura.
 
 
 class CurrentSpellType(IntEnum):


### PR DESCRIPTION
* Add handling for cast speed modifiers
    * Values for spell cast time/channel time now snapshot at the start of the cast
* Improve effect miss results handling
    * Skip applying subsequent spell effects if one results in a full miss
    * Exclude `SPELL_EFFECT_LEAP` from miss handling (charge can no longer resist)
    * Fix some ranged abilities using incorrect miss logic
* Fix spell pushback applying twice on auto attacks (closes #850, closes #569)
* Simplify crit aura mod handling