### PR TITLE
Spell crash/bug fixes

### DIFF
--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -154,7 +154,7 @@ class MapManager:
     @staticmethod
     def get_map_by_object(world_object):
         try:
-            return MAPS[world_object.map_id].get(world_object.instance_id)
+            return MAPS[world_object.map_id][world_object.instance_id]
         except (KeyError, AttributeError, TypeError):
             Logger.error(f'Unable to retrieve Map for Id {world_object.map_id}, Instance {world_object.instance_id}')
             return None

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -162,7 +162,7 @@ class MapManager:
     @staticmethod
     def get_map(map_id, instance_id) -> Optional[Map]:
         try:
-            return MAPS[map_id].get(instance_id)
+            return MAPS[map_id][instance_id]
         except (KeyError, AttributeError, TypeError):
             Logger.error(f'Unable to retrieve Map for Id {map_id}, Instance {instance_id}')
             return None

--- a/game/world/managers/objects/ObjectManager.py
+++ b/game/world/managers/objects/ObjectManager.py
@@ -441,10 +441,6 @@ class ObjectManager:
             if target.movement_spline and target.movement_spline.flags == SplineFlags.SPLINEFLAG_FLYING:
                 return False
 
-            # If player is not in a PvP map (PvP system was not added until Patch 0.7).
-            if not MapManager.get_map(target.map_id, target.instance_id).is_pvp():
-                return False
-
         # Creature only checks.
         elif target.get_type_id() == ObjectTypeIds.ID_UNIT:
             # If the unit is evading.

--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -19,6 +19,7 @@ from utils.constants.MiscCodes import ObjectTypeFlags, ObjectTypeIds, HighGuid, 
     GameObjectStates
 from utils.constants.MiscFlags import GameObjectFlags
 from utils.constants.OpCodes import OpCode
+from utils.constants.SpellCodes import SpellMissReason
 from utils.constants.UnitCodes import StandState, UnitFlags
 from utils.constants.UpdateFields import ObjectFields, GameObjectFields, UnitFields
 
@@ -249,7 +250,7 @@ class GameObjectManager(ObjectManager):
 
         spell = spell_effect.casting_spell
         damage_info = spell.get_cast_damage_info(self, target, damage, absorb=0)
-        damage_info.spell_miss_reason = spell.object_target_results[target.guid].result
+        damage_info.spell_miss_reason = SpellMissReason.MISS_REASON_NONE
 
         target.send_spell_cast_debug_info(damage_info, spell)
         target.receive_damage(damage_info, self, casting_spell=spell, is_periodic=is_periodic)

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -131,11 +131,13 @@ class EffectTargets:
             self.previous_targets_b = self.resolved_targets_b
             self.resolved_targets_b = [target for target in self.resolved_targets_b if target.guid != guid]
 
+    # noinspection PyUnresolvedReferences
     def get_effect_target_miss_results(self) -> dict[int, TargetMissInfo]:
         targets = self.get_resolved_effect_targets_by_type(ObjectManager)
         target_info = {}
         for target in targets:
-            if target.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
+            if target.get_type_mask() & ObjectTypeFlags.TYPE_UNIT and \
+                    self.effect_source.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
                 result = target.stat_manager.get_spell_miss_result_against_self(self.casting_spell)
                 target_info[target.guid] = TargetMissInfo(target, *result)
             else:

--- a/game/world/managers/objects/spell/SpellEffect.py
+++ b/game/world/managers/objects/spell/SpellEffect.py
@@ -194,6 +194,10 @@ class SpellEffect:
             return False
 
         targets = self.targets.get_resolved_effect_targets_by_type(ObjectManager)
+        if not targets:
+            # Initial unit target, but primary target type isn't an object.
+            return False
+
         return all([self.casting_spell.object_target_results[target.guid].result != SpellMissReason.MISS_REASON_NONE
                     for target in targets])
 

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -294,8 +294,10 @@ class SpellEffectHandler:
         casting_spell.cast_state = SpellState.SPELL_STATE_ACTIVE
         if not effect.area_aura_holder:
             effect.area_aura_holder = AreaAuraHolder(effect)
+            previous_targets = []
+        else:
+            previous_targets = effect.targets.previous_targets_a if effect.targets.previous_targets_a else []
 
-        previous_targets = effect.targets.previous_targets_a if effect.targets.previous_targets_a else []
         current_targets = effect.targets.resolved_targets_a
 
         new_targets = [unit for unit in current_targets if

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1871,18 +1871,20 @@ class PlayerManager(UnitManager):
 
     # override
     def can_attack_target(self, target):
-        if not target:
+        if not target or target is self:
             return False
 
-        is_enemy = super().can_attack_target(target)
-        if is_enemy:
-            return True
+        if target.get_type_id() == ObjectTypeIds.ID_PLAYER:
+            # Return True if players are dueling.
+            if self.duel_manager and self.duel_manager.is_unit_involved(target) and \
+                    self.duel_manager.duel_state == DuelState.DUEL_STATE_STARTED:
+                return True
 
-        # Return True if players are dueling.
-        if self.duel_manager and target is not self and self.duel_manager.is_unit_involved(target):
-            return self.duel_manager.duel_state == DuelState.DUEL_STATE_STARTED
+            # Only allow pvp in pvp maps (PvP system was not added until Patch 0.7).
+            if not MapManager.get_map(target.map_id, target.instance_id).is_pvp():
+                return False
 
-        return False
+        return super().can_attack_target(target)
 
     # override
     def get_type_mask(self):


### PR DESCRIPTION
* Fix generating targets for proc auras
* Exclude gameobject casts from spell miss logic
* Fix area auras not resolving targets correctly in some cases
* Fix `spell_go` packet miss structure
* Correct `can_attack_target` pvp map check