### PR TITLE
Spell targeting, unit status effect and First Aid-related bug fixes

### DIFF
--- a/game/world/managers/objects/locks/LockManager.py
+++ b/game/world/managers/objects/locks/LockManager.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 from database.dbc.DbcDatabaseManager import DbcDatabaseManager
 from game.world.managers.objects.units.player.SkillManager import SkillTypes
-from utils.constants.MiscCodes import LockKeyTypes, LockType, ObjectTypeIds
+from utils.constants.MiscCodes import LockKeyTypes, LockTypes, ObjectTypeIds
 from utils.constants.SpellCodes import SpellCheckCastResult
 
 
@@ -41,7 +41,7 @@ class LockManager:
                 if lock_type != lock_info.indexes[index]:
                     continue
 
-                skill_type = LockManager.get_skill_by_lock_type(LockType(lock_info.indexes[index]))
+                skill_type = LockManager.get_skill_by_lock_type(LockTypes(lock_info.indexes[index]))
                 if skill_type != SkillTypes.NONE:
                     required_skill_value = lock_info.skills[index]
                     skill_value = 0 if cast_item or caster.get_type_id() != ObjectTypeIds.ID_PLAYER else \
@@ -57,13 +57,13 @@ class LockManager:
         return OpenLockResult(SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS)
 
     @staticmethod
-    def get_skill_by_lock_type(lock_type: LockType) -> SkillTypes:
-        if lock_type == LockType.LOCKTYPE_PICKLOCK:
+    def get_skill_by_lock_type(lock_type: LockTypes) -> SkillTypes:
+        if lock_type == LockTypes.LOCKTYPE_PICKLOCK:
             return SkillTypes.LOCKPICKING
-        elif lock_type == LockType.LOCKTYPE_HERBALISM:
+        elif lock_type == LockTypes.LOCKTYPE_HERBALISM:
             return SkillTypes.HERBALISM
-        elif lock_type == LockType.LOCKTYPE_MINING:
+        elif lock_type == LockTypes.LOCKTYPE_MINING:
             return SkillTypes.MINING
-        elif lock_type == LockType.LOCKTYPE_FISHING:
+        elif lock_type == LockTypes.LOCKTYPE_FISHING:
             return SkillTypes.FISHING
         return SkillTypes.NONE

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -99,10 +99,15 @@ class EffectTargets:
             return [target]
         return target
 
-    def can_target_friendly(self) -> bool:
-        if self.target_effect.implicit_target_a in FRIENDLY_IMPLICIT_TARGETS or \
-               self.target_effect.implicit_target_b in FRIENDLY_IMPLICIT_TARGETS:
+    def can_target_friendly(self, target=None) -> bool:
+        implicit_targets = {self.target_effect.implicit_target_a, self.target_effect.implicit_target_b}
+
+        if FRIENDLY_IMPLICIT_TARGETS.intersection(implicit_targets):
             return True
+
+        # Neutral targets can target friendly. Use target context if given to resolve.
+        if NEUTRAL_IMPLICIT_TARGETS.intersection(implicit_targets):
+            return not target or not self.casting_spell.spell_caster.can_attack_target(target)
 
         # Spells with implicit target set to 0 can have both friendly and hostile targets.
         # These spells include passives, testing spells and npc spells.
@@ -147,7 +152,6 @@ class EffectTargets:
     def get_resolved_effect_targets_by_type(self, _type) -> list[Union[ObjectManager, Vector]]:
         b_matches_type = False
         # If both A and B are the same type, we should prefer B as it can act as specifying
-        # TODO if issues arise, add table for specifying ImplicitTargets
 
         # Accept B when it's the correct type and not 0.
         # Also check for SPECIFYING_IMPLICIT_TARGETS since in those cases empty targets should still be prioritized.
@@ -566,4 +570,10 @@ FRIENDLY_IMPLICIT_TARGETS = {
     SpellImplicitTargets.TARGET_SINGLE_PARTY,
     SpellImplicitTargets.TARGET_AREAEFFECT_PARTY,  # Power infuses the target's party increasing their Shadow resistance by $s1 for $d.
     # SpellImplicitTargets.TARGET_SCRIPT  # Resolved separately
+}
+
+NEUTRAL_IMPLICIT_TARGETS = {
+    SpellImplicitTargets.TARGET_EFFECT_SELECT,
+    SpellImplicitTargets.TARGET_UNIT,
+    SpellImplicitTargets.TARGET_SCRIPT
 }

--- a/game/world/managers/objects/spell/ExtendedSpellData.py
+++ b/game/world/managers/objects/spell/ExtendedSpellData.py
@@ -207,7 +207,8 @@ class SummonedObjectPositions:
 
 
 class ProfessionInfo:
-    PROFESSION_MAX_SKILL_VALUES = {
+    _PROFESSION_SPELLS = {
+        129: (3273, 3274),        # First Aid
         164: (2018, 3100, 3538),  # Blacksmithing
         165: (2108, 3104, 3811),  # Leatherworking
         171: (2259, 3101, 3464),  # Alchemy
@@ -221,8 +222,11 @@ class ProfessionInfo:
     }
 
     @staticmethod
-    def get_max_skill_value(profession_spell_id, player):
-        prof_spells = ProfessionInfo.PROFESSION_MAX_SKILL_VALUES[profession_spell_id]
+    def get_max_skill_value(skill_id, player):
+        prof_spells = ProfessionInfo._PROFESSION_SPELLS.get(skill_id, ())
+        if not prof_spells:
+            return 0
+
         known = player.spell_manager.spells.keys() & prof_spells
         if not known:
             return 0

--- a/game/world/managers/objects/spell/ExtendedSpellData.py
+++ b/game/world/managers/objects/spell/ExtendedSpellData.py
@@ -234,9 +234,9 @@ class ProfessionInfo:
 
     @staticmethod
     def get_profession_skill_id_for_spell(spell_id):
-        for profession_spell_id, prof_spells in ProfessionInfo.PROFESSION_MAX_SKILL_VALUES.items():
+        for skill_id, prof_spells in ProfessionInfo._PROFESSION_SPELLS.items():
             if spell_id in prof_spells:
-                return profession_spell_id
+                return skill_id
         return 0
 
 
@@ -248,7 +248,7 @@ class UnitSpellsValidator:
     #  https://github.com/The-Alpha-Project/alpha-core/issues/383
     #  Might be that these spells were not used in alpha.
     #  e.g. Frost Breath, Glacial Roar, crashes both on Unit and Player. (Cast reaches server, crashes before reply)
-    _INVALID_PRECAST_SPELLS_ = {
+    _INVALID_PRECAST_SPELLS = {
         3131,  # Frost Breath
         3129,  # Frost Breath
         3143,  # Glacial Roar
@@ -257,7 +257,7 @@ class UnitSpellsValidator:
 
     @staticmethod
     def spell_has_valid_cast(casting_spell):
-        return casting_spell.spell_entry.ID not in UnitSpellsValidator._INVALID_PRECAST_SPELLS_
+        return casting_spell.spell_entry.ID not in UnitSpellsValidator._INVALID_PRECAST_SPELLS
 
 
 class SpellEffectMechanics:

--- a/game/world/managers/objects/spell/SpellEffect.py
+++ b/game/world/managers/objects/spell/SpellEffect.py
@@ -149,7 +149,7 @@ class SpellEffect:
         # Effect harmfulness is resolved before actual target resolution.
         # Instead of analyzing resolved targets,
         # take into account initial target friendliness and the nature of the effect's implicit targets.
-        can_target_friendly = self.targets.can_target_friendly()
+        can_target_friendly = self.targets.can_target_friendly(target=self.casting_spell.initial_target)
 
         if self.effect_type == SpellEffects.SPELL_EFFECT_APPLY_AURA:
             if self.casting_spell.spell_entry.Attributes & SpellAttributes.SPELL_ATTR_AURA_IS_DEBUFF:

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -92,7 +92,7 @@ class SpellManager:
         # Check if this skill requires a 'cast ui' spell. e.g. Poisons frame.
         if skill and spell.Effect_1 != SpellEffects.SPELL_EFFECT_SPELL_CAST_UI:
             cast_ui_spells = self.caster.skill_manager.get_cast_ui_spells_for_skill_id(skill.ID)
-            if not self.spells.keys() & cast_ui_spells:  # Player doesn't have any cast UI for this spell yet.
+            if cast_ui_spells and not self.spells.keys() & cast_ui_spells:  # Player doesn't have any cast UI for this spell yet.
                 # Get cast UI with lowest spell ID (lowest rank where applicable).
                 cast_ui_spell = min(cast_ui_spells)
                 if self.can_learn_spell(cast_ui_spell):

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -79,11 +79,6 @@ class SpellManager:
         if related_profession_skill and not self.caster.skill_manager.has_skill(related_profession_skill):
             if not self.caster.skill_manager.add_skill(related_profession_skill):
                 return False
-            else:
-                # Check if this profession skill requires a 'cast ui' spell.
-                cast_ui_spell = self.caster.skill_manager.get_cast_ui_spell_for_skill_id(related_profession_skill)
-                if cast_ui_spell and cast_ui_spell.ID != spell_id and self.can_learn_spell(cast_ui_spell.ID):
-                    self.learn_spell(cast_ui_spell.ID)
         # If the player already knows the skill, update max skill level.
         elif related_profession_skill:
             self.caster.skill_manager.update_skills_max_value()
@@ -95,10 +90,13 @@ class SpellManager:
                 return False
 
         # Check if this skill requires a 'cast ui' spell. e.g. Poisons frame.
-        if skill:
-            cast_ui_spell = self.caster.skill_manager.get_cast_ui_spell_for_skill_id(skill.ID)
-            if cast_ui_spell and cast_ui_spell.ID != spell_id and self.can_learn_spell(cast_ui_spell.ID):
-                self.learn_spell(cast_ui_spell.ID)
+        if skill and spell.Effect_1 != SpellEffects.SPELL_EFFECT_SPELL_CAST_UI:
+            cast_ui_spells = self.caster.skill_manager.get_cast_ui_spells_for_skill_id(skill.ID)
+            if not self.spells.keys() & cast_ui_spells:  # Player doesn't have any cast UI for this spell yet.
+                # Get cast UI with lowest spell ID (lowest rank where applicable).
+                cast_ui_spell = min(cast_ui_spells)
+                if self.can_learn_spell(cast_ui_spell):
+                    self.learn_spell(cast_ui_spell)
 
         db_spell = CharacterSpell()
         db_spell.guid = self.caster.guid

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -304,7 +304,7 @@ class AuraEffectHandler:
             effect_target.interrupt_looting()
 
         # Root (or unroot) unit.
-        effect_target.set_root(not remove)
+        effect_target.set_root(not remove, aura.index)
 
         if not remove:
             effect_target.spell_manager.remove_casts(remove_active=False)
@@ -358,7 +358,7 @@ class AuraEffectHandler:
 
     @staticmethod
     def handle_mod_root(aura, effect_target, remove):
-        effect_target.set_root(not remove)
+        effect_target.set_root(not remove, aura.index)
 
     @staticmethod
     def handle_mod_stealth(aura, effect_target, remove):

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -223,26 +223,14 @@ class AuraEffectHandler:
         if effect_target.get_type_id() != ObjectTypeIds.ID_PLAYER:
             return
 
-        flag = effect_target.get_uint32(PlayerFields.PLAYER_TRACK_CREATURES)
-        if not remove:
-            flag |= (1 << (aura.spell_effect.misc_value - 1))
-        else:
-            flag &= ~(1 << (aura.spell_effect.misc_value - 1))
-
-        effect_target.set_uint32(PlayerFields.PLAYER_TRACK_CREATURES, flag)
+        effect_target.set_tracked_creature_type(aura.spell_effect.misc_value, not remove, aura.index)
 
     @staticmethod
     def handle_track_resources(aura, effect_target, remove):
         if effect_target.get_type_id() != ObjectTypeIds.ID_PLAYER:
             return
 
-        flag = effect_target.get_uint32(PlayerFields.PLAYER_TRACK_RESOURCES)
-        if not remove:
-            flag |= (1 << (aura.spell_effect.misc_value - 1))
-        else:
-            flag &= ~(1 << (aura.spell_effect.misc_value - 1))
-
-        effect_target.set_uint32(PlayerFields.PLAYER_TRACK_RESOURCES, flag)
+        effect_target.set_tracked_resource_type(aura.spell_effect.misc_value, not remove, aura.index)
 
     @staticmethod
     def handle_proc_trigger_damage(aura, effect_target, remove):
@@ -275,51 +263,16 @@ class AuraEffectHandler:
 
     @staticmethod
     def handle_mod_disarm(aura, effect_target, remove):
-        if not remove:
-            effect_target.unit_flags |= UnitFlags.UNIT_FLAG_DISARMED
-        else:
-            effect_target.unit_flags &= ~UnitFlags.UNIT_FLAG_DISARMED
-
-        effect_target.set_uint32(UnitFields.UNIT_FIELD_FLAGS, effect_target.unit_flags)
+        effect_target.set_unit_flag(UnitFlags.UNIT_FLAG_DISARMED, not remove, aura.index)
         effect_target.stat_manager.apply_bonuses()
 
     @staticmethod
     def handle_mod_stalked(aura, effect_target, remove):
-        dyn_flags = effect_target.get_uint32(UnitFields.UNIT_DYNAMIC_FLAGS)
-        if not remove:
-            dyn_flags |= UnitDynamicTypes.UNIT_DYNAMIC_TRACK_UNIT
-        else:
-            dyn_flags &= ~ UnitDynamicTypes.UNIT_DYNAMIC_TRACK_UNIT
-
-        effect_target.set_uint32(UnitFields.UNIT_DYNAMIC_FLAGS, dyn_flags)
+        effect_target.set_dynamic_type_flag(UnitDynamicTypes.UNIT_DYNAMIC_TRACK_UNIT, not remove, aura.index)
 
     @staticmethod
     def handle_mod_stun(aura, effect_target, remove):
-        # Player specific.
-        if not remove and effect_target.get_type_id() == ObjectTypeIds.ID_PLAYER:
-            # Don't stun if player is flying.
-            if effect_target.pending_taxi_destination:
-                return
-            # Release loot if any.
-            effect_target.interrupt_looting()
-
-        # Root (or unroot) unit.
-        effect_target.set_root(not remove, aura.index)
-
-        if not remove:
-            effect_target.spell_manager.remove_casts(remove_active=False)
-            effect_target.set_current_target(0)
-            effect_target.unit_state |= UnitStates.STUNNED
-            effect_target.unit_flags |= UnitFlags.UNIT_FLAG_DISABLE_ROTATE
-            effect_target.stop_movement()
-        else:
-            # Restore combat target if any.
-            if effect_target.combat_target and effect_target.combat_target.is_alive:
-                effect_target.set_current_target(effect_target.combat_target.guid)
-            effect_target.unit_state &= ~UnitStates.STUNNED
-            effect_target.unit_flags &= ~UnitFlags.UNIT_FLAG_DISABLE_ROTATE
-
-        effect_target.set_uint32(UnitFields.UNIT_FIELD_FLAGS, effect_target.unit_flags)
+        effect_target.set_stunned(not remove, aura.index)
 
     @staticmethod
     def handle_mod_pacify_silence(aura, effect_target, remove):
@@ -328,19 +281,11 @@ class AuraEffectHandler:
 
     @staticmethod
     def handle_mod_silence(aura, effect_target, remove):
-        if remove:
-            effect_target.unit_state &= ~UnitStates.SILENCED
-        else:
-            effect_target.unit_state |= UnitStates.SILENCED
+        effect_target.set_unit_state(UnitStates.SILENCED, not remove, aura.index)
 
     @staticmethod
     def handle_mod_pacify(aura, effect_target, remove):
-        if remove:
-            effect_target.unit_flags &= ~UnitFlags.UNIT_FLAG_PACIFIED
-        else:
-            effect_target.unit_flags |= UnitFlags.UNIT_FLAG_PACIFIED
-
-        effect_target.set_uint32(UnitFields.UNIT_FIELD_FLAGS, effect_target.unit_flags)
+        effect_target.set_unit_flag(UnitFlags.UNIT_FLAG_PACIFIED, not remove, aura.index)
 
     @staticmethod
     def handle_transform(aura, effect_target, remove):
@@ -358,7 +303,7 @@ class AuraEffectHandler:
 
     @staticmethod
     def handle_mod_root(aura, effect_target, remove):
-        effect_target.set_root(not remove, aura.index)
+        effect_target.set_rooted(not remove, aura.index)
 
     @staticmethod
     def handle_mod_stealth(aura, effect_target, remove):

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -307,7 +307,7 @@ class AuraEffectHandler:
 
     @staticmethod
     def handle_mod_stealth(aura, effect_target, remove):
-        effect_target.set_stealthed(active=not remove)
+        effect_target.set_stealthed(not remove, aura.index)
         if remove:
             effect_target.stat_manager.remove_aura_stat_bonus(aura.index)
             return
@@ -326,7 +326,7 @@ class AuraEffectHandler:
 
     @staticmethod
     def handle_mod_invisibility(aura, effect_target, remove):
-        effect_target.set_stealthed(active=not remove)
+        effect_target.set_stealthed(not remove, aura.index)
         if remove:
             effect_target.stat_manager.remove_aura_stat_bonus(aura.index)
             return

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -941,16 +941,6 @@ class UnitManager(ObjectManager):
         self.stand_state = stand_state
         self.aura_manager.check_aura_interrupts(changed_stand_state=True)
 
-    def is_stealthed(self):
-        return self.unit_flags & UnitFlags.UNIT_FLAG_SNEAK == UnitFlags.UNIT_FLAG_SNEAK
-
-    def set_stealthed(self, active):
-        if active:
-            self.unit_flags |= UnitFlags.UNIT_FLAG_SNEAK
-        else:
-            self.unit_flags &= ~UnitFlags.UNIT_FLAG_SNEAK
-        self.set_uint32(UnitFields.UNIT_FIELD_FLAGS, self.unit_flags)
-
     def set_sanctuary(self, active, time_secs=0):
         if active:
             self.unit_state |= UnitStates.SANCTUARY
@@ -1055,6 +1045,12 @@ class UnitManager(ObjectManager):
             alert = alert_range >= distance > visible_distance
 
         return distance <= visible_distance, alert
+
+    def is_stealthed(self) -> bool:
+        return self.unit_flags & UnitFlags.UNIT_FLAG_SNEAK == UnitFlags.UNIT_FLAG_SNEAK
+
+    def set_stealthed(self, active, index=-1) -> bool:
+        return self.set_unit_flag(UnitFlags.UNIT_FLAG_SNEAK, active, index)
 
     def set_rooted(self, active, index=-1) -> bool:
         is_rooted = self.set_move_flag(MoveFlags.MOVEFLAG_ROOTED, active, index)

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -1143,10 +1143,6 @@ class UnitManager(ObjectManager):
 
         return len(effects) > 0  # Return True if this flag should be set for the unit.
 
-    def _is_effect_unit_flag_set(self, flag_type, flag) -> bool:
-        return flag_type not in self._flag_effects or \
-            flag not in self._flag_effects[flag_type]
-
     def play_emote(self, emote):
         if emote != 0:
             data = pack('<IQ', emote, self.guid)

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -196,6 +196,8 @@ class UnitManager(ObjectManager):
         self._immunities = {}
         # School absorb.
         self._school_absorbs = {}
+        # Root effects.
+        self._root_effects = set()
 
         self.has_moved = False
         self.has_turned = False
@@ -1068,15 +1070,18 @@ class UnitManager(ObjectManager):
 
         return distance <= visible_distance, alert
 
-    def set_root(self, active):
+    def set_root(self, active, index=-1):
         if active:
             # Stop movement if needed.
             self.stop_movement()
             self.movement_flags |= MoveFlags.MOVEFLAG_ROOTED
             self.unit_state |= UnitStates.ROOTED
-        else:
+            self._root_effects.add(index)
+        elif not self._root_effects:
             self.movement_flags &= ~MoveFlags.MOVEFLAG_ROOTED
             self.unit_state &= ~UnitStates.ROOTED
+        else:
+            self._root_effects.remove(index)
 
     def play_emote(self, emote):
         if emote != 0:

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -759,12 +759,17 @@ class PlayerManager(UnitManager):
         # Notify surrounding for proximity checks.
         self._on_relocation()
 
-    def set_root(self, active):
-        super().set_root(active)
-        if active:
+    def set_root(self, active, index=-1):
+        super().set_root(active, index)
+        effect_count = len(self._root_effects)
+
+        if effect_count == 1:
             opcode = OpCode.SMSG_FORCE_MOVE_ROOT
-        else:
+        elif not effect_count:
             opcode = OpCode.SMSG_FORCE_MOVE_UNROOT
+        else:
+            return
+
         self.enqueue_packet(PacketWriter.get_packet(opcode))
 
     # override

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -35,7 +35,7 @@ from utils.GuidUtils import GuidUtils
 from utils.Logger import Logger
 from utils.constants.DuelCodes import *
 from utils.constants.ItemCodes import InventoryTypes
-from utils.constants.MiscCodes import ChatFlags, LootTypes, LiquidTypes, MountResults, DismountResults
+from utils.constants.MiscCodes import ChatFlags, LootTypes, LiquidTypes, MountResults, DismountResults, LockTypes
 from utils.constants.MiscCodes import ObjectTypeFlags, ObjectTypeIds, PlayerFlags, WhoPartyStatus, HighGuid, \
     AttackTypes, MoveFlags
 from utils.constants.SpellCodes import SpellTargetMask
@@ -796,7 +796,7 @@ class PlayerManager(UnitManager):
         self.set_uint32(PlayerFields.PLAYER_TRACK_CREATURES, current_flags)
 
     def set_tracked_resource_type(self, lock_type, active, index=-1):
-        is_tracking = self._set_effect_flag_state(CreatureTypes, lock_type, active, index)
+        is_tracking = self._set_effect_flag_state(LockTypes, lock_type, active, index)
         current_flags = self.get_uint32(PlayerFields.PLAYER_TRACK_RESOURCES)
         if is_tracking:
             current_flags |= (1 << (lock_type - 1))

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -891,9 +891,9 @@ class PlayerManager(UnitManager):
         self.set_uint32(UnitFields.UNIT_FIELD_BYTES_0, self.bytes_0)
 
     # override
-    def set_stealthed(self, active):
-        super().set_stealthed(active)
-        if not active:
+    def set_stealthed(self, active, index=-1):
+        stealthed = super().set_stealthed(active, index)
+        if not stealthed:
             # Notify surrounding units about fading stealth for proximity aggro.
             self._on_relocation()
 

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -16,7 +16,7 @@ from utils.ConfigManager import config
 from utils.Formulas import PlayerFormulas
 from utils.Logger import Logger
 from utils.constants.ItemCodes import ItemClasses, ItemSubClasses, InventoryError
-from utils.constants.MiscCodes import SkillCategories, Languages, AttackTypes, LockType
+from utils.constants.MiscCodes import SkillCategories, Languages, AttackTypes, LockTypes
 from utils.constants.OpCodes import OpCode
 from utils.constants.SpellCodes import SpellCheckCastResult, SpellEffects
 from utils.constants.UpdateFields import PlayerFields
@@ -583,7 +583,7 @@ class SkillManager(object):
         self.build_update()
         return True
 
-    def get_unlocking_attempt_result(self, lock_type: LockType, lock_id: int,
+    def get_unlocking_attempt_result(self, lock_type: LockTypes, lock_id: int,
                                      used_item: Optional[ItemManager] = None,
                                      bonus_skill: int = 0) -> SpellCheckCastResult:
         from game.world.managers.objects.locks.LockManager import LockManager

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -509,15 +509,6 @@ class SkillManager(object):
         skill = DbcDatabaseManager.SkillHolder.skill_get_by_id(skill_line_ability.SkillLine)
         return skill, skill_line_ability
 
-    def get_cast_ui_spell_for_skill_id(self, skill_id):
-        skill_line_spells = DbcDatabaseManager.SkillLineAbilityHolder.spells_get_by_skill_id(skill_id)
-        for spell_id in skill_line_spells:
-            spell = DbcDatabaseManager.SpellHolder.spell_get_by_id(spell_id)
-            if spell and spell.Effect_1 == SpellEffects.SPELL_EFFECT_SPELL_CAST_UI:
-                return spell
-
-        return None
-
     def get_skill_info_for_spell_id(self, spell_id):
         race = self.player_mgr.race
         class_ = self.player_mgr.class_
@@ -712,6 +703,18 @@ class SkillManager(object):
             return LANG_DESCRIPTION[language_id].skill_id
         return -1
 
+    @staticmethod
+    def get_cast_ui_spells_for_skill_id(skill_id) -> set[int]:
+        skill_line_spells = DbcDatabaseManager.SkillLineAbilityHolder.spells_get_by_skill_id(skill_id)
+        spells = set()
+        for spell_id in skill_line_spells:
+            spell = DbcDatabaseManager.SpellHolder.spell_get_by_id(spell_id)
+
+            if spell and spell.Effect_1 == SpellEffects.SPELL_EFFECT_SPELL_CAST_UI:
+                spells.add(spell.ID)
+
+        return spells
+
     def get_skill_for_spell_id(self, spell_id):
         skill_line_ability = DbcDatabaseManager.SkillLineAbilityHolder.skill_line_ability_get_by_spell_race_and_class(
             spell_id, self.player_mgr.race, self.player_mgr.class_)
@@ -734,12 +737,8 @@ class SkillManager(object):
             # Language, Riding
             if skill.CategoryID == SkillCategories.MAX_SKILL:
                 return skill.MaxRank
-            elif skill.CategoryID == SkillCategories.CLASS_SKILL:
-                # Professions.
-                return ExtendedSpellData.ProfessionInfo.get_max_skill_value(skill_id, self.player_mgr)
-            else:
-                return (level * 5) + 25
-
+            # Secondary skills of other categories are all professions.
+            return ExtendedSpellData.ProfessionInfo.get_max_skill_value(skill_id, self.player_mgr)
         return 0
 
     def can_dual_wield(self):

--- a/game/world/opcode_handling/handlers/player/LogoutCancelHandler.py
+++ b/game/world/opcode_handling/handlers/player/LogoutCancelHandler.py
@@ -14,7 +14,7 @@ class LogoutCancelHandler(object):
             return res
 
         player_mgr.set_stand_state(StandState.UNIT_STANDING)
-        player_mgr.set_root(False)
+        player_mgr.set_rooted(False)
         player_mgr.logout_timer = -1
         player_mgr.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_LOGOUT_CANCEL_ACK))
 

--- a/game/world/opcode_handling/handlers/player/LogoutRequestHandler.py
+++ b/game/world/opcode_handling/handlers/player/LogoutRequestHandler.py
@@ -20,7 +20,7 @@ class LogoutRequestHandler(object):
             res = LogoutResponseCodes.LOGOUT_PROCEED
             if not player_mgr.is_swimming():
                 player_mgr.set_stand_state(StandState.UNIT_SITTING)
-            player_mgr.set_root(True)
+            player_mgr.set_rooted(True)
             player_mgr.logout_timer = 20
         player_mgr.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_LOGOUT_RESPONSE, pack('<B', res)))
 

--- a/tools/ClassTrainersSkillsGenerator.py
+++ b/tools/ClassTrainersSkillsGenerator.py
@@ -4,6 +4,7 @@ from database.dbc.DbcDatabaseManager import DbcDatabaseManager
 from database.dbc.DbcModels import Spell
 from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.WorldLoader import WorldLoader
+from game.world.managers.objects.units.player.SkillManager import SkillLineType
 from utils.constants.MiscCodes import SkillCategories, TrainerTypes
 from utils.constants.SpellCodes import SpellImplicitTargets
 from utils.constants.UnitCodes import Races, Classes
@@ -108,7 +109,7 @@ class ClassTrainersSkillGenerator:
     @staticmethod
     def validate_skill(skill, race_mask, class_mask):
         # Only interested in weapon skills.
-        if skill.CategoryID != SkillCategories.WEAPON_SKILL:  # Weapons
+        if skill.CategoryID != SkillCategories.COMBAT_SKILL and skill.SkillType == SkillLineType.PRIMARY:
             return False
 
         skill_race_mask = skill.RaceMask
@@ -121,9 +122,6 @@ class ClassTrainersSkillGenerator:
         if skill_race_mask and not skill_race_mask & race_mask:
             return False
         if skill_class_mask and not skill_class_mask & class_mask:
-            return False
-        # Skip First Aid related.
-        if 'First Aid' in skill.DisplayName_enUS:
             return False
 
         return True

--- a/utils/constants/MiscCodes.py
+++ b/utils/constants/MiscCodes.py
@@ -884,7 +884,7 @@ class LockKeyTypes(IntEnum):
     LOCK_KEY_SKILL = 2
 
 
-class LockType(IntEnum):
+class LockTypes(IntEnum):
     LOCKTYPE_NONE = 0
     LOCKTYPE_PICKLOCK = 1
     LOCKTYPE_HERBALISM = 2

--- a/utils/constants/MiscCodes.py
+++ b/utils/constants/MiscCodes.py
@@ -351,7 +351,7 @@ class QuestFailedReasons(IntEnum):
 
 class SkillCategories(IntEnum):
     MAX_SKILL = 1  # These are always max when added i.e. language/riding
-    WEAPON_SKILL = 2
+    COMBAT_SKILL = 2
     CLASS_SKILL = 3
     SECONDARY_SKILL = 4
 


### PR DESCRIPTION
* Fix applying passive area auras on login / simplify resolving passive targets
* Fix targeting checks for spells with both friendly and hostile implicit targets
* Fix First Aid max skill and skill gain logic
* Fix and refactor loading cast UI on spell learn
* Track aura indices for all unit state/flag changes caused by aura effects (closes #526)