### PR TITLE
Aura interrupt and spell fixes, spell refactoring

### DIFF
--- a/game/world/managers/objects/ai/BasicCreatureAI.py
+++ b/game/world/managers/objects/ai/BasicCreatureAI.py
@@ -45,10 +45,10 @@ class BasicCreatureAI(CreatureAI):
                 continue
             # Sanctuary.
             if victim.unit_state & UnitStates.SANCTUARY:
-                return False
+                continue
             # Check for stealth/invisibility.
             can_detect_victim, alert = self.creature.can_detect_target(victim, victim_distance)
-            if alert and victim.get_type_id() == ObjectTypeIds.ID_PLAYER:
+            if alert and victim.get_type_id() == ObjectTypeIds.ID_PLAYER and not victim.beast_master:
                 self.send_ai_reaction(victim, AIReactionStates.AI_REACT_ALERT)
             if not can_detect_victim:
                 continue

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -32,6 +32,9 @@ class CastingSpell:
     source_item = None
     initial_target = None
     targeted_unit_on_cast_start = None
+    triggered = False
+    triggered_by_spell = None
+    creature_spell = None
 
     object_target_results: dict[int, TargetMissInfo] = {}  # Assigned on cast - contains guids and results on successful hits/misses/blocks etc.
     spell_target_mask: SpellTargetMask
@@ -56,13 +59,15 @@ class CastingSpell:
 
     dynamic_object: Optional[DynamicObjectManager]
 
-    def __init__(self, spell, caster, initial_target, target_mask, source_item=None, triggered=False, creature_spell=None):
+    def __init__(self, spell, caster, initial_target, target_mask, source_item=None,
+                 triggered=False, triggered_by_spell=None, creature_spell=None):
         self.spell_entry = spell
         self.spell_caster = caster
         self.source_item = source_item
         self.initial_target = initial_target
         self.spell_target_mask = target_mask
-        self.triggered = triggered
+        self.triggered = triggered or triggered_by_spell is not None
+        self.triggered_by_spell = triggered_by_spell
         self.creature_spell = creature_spell
 
         self.dynamic_object = None

--- a/game/world/managers/objects/spell/SpellEffect.py
+++ b/game/world/managers/objects/spell/SpellEffect.py
@@ -183,7 +183,7 @@ class SpellEffect:
         return False
 
     def can_miss(self):
-        return self.effect_type not in {SpellEffects.SPELL_EFFECT_LEAP}
+        return self.effect_type not in {SpellEffects.SPELL_EFFECT_LEAP, SpellEffects.SPELL_EFFECT_SCRIPT_EFFECT}
 
     def is_full_miss(self):
         if not self.casting_spell.object_target_results:

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -820,13 +820,6 @@ class SpellManager:
         data = pack('<I', 0)
         self.caster.enqueue_packet(PacketWriter.get_packet(OpCode.MSG_CHANNEL_UPDATE, data))
 
-    def play_spell_visual(self, visual_id):
-        # Must match an existing ID in the SpellVisualKit dbc.
-        data = pack('<QI', self.caster.guid, visual_id)
-        packet = PacketWriter.get_packet(OpCode.SMSG_PLAY_SPELL_VISUAL, data)
-        MapManager.send_surrounding(packet, self.caster,
-                                    include_self=self.caster.get_type_id() == ObjectTypeIds.ID_PLAYER)
-
     def send_login_effect(self):
         chr_race = DbcDatabaseManager.chr_races_get_by_race(self.caster.race)
         self.handle_cast_attempt(chr_race.LoginEffectSpellID, self.caster, SpellTargetMask.SELF, validate=False)
@@ -1064,8 +1057,8 @@ class SpellManager:
 
         # Target validation.
         validation_target = casting_spell.initial_target
-        # In the case of the spell requiring a unit target but being cast on self,
-        # validate the spell against the caster's current unit selection instead or the caster pet.
+        # In the case of the spell requiring another unit target but being cast on self,
+        # validate the spell against the caster's current unit selection or pet instead.
         if casting_spell.spell_target_mask == SpellTargetMask.SELF:
             if casting_spell.requires_implicit_initial_unit_target():
                 validation_target = casting_spell.targeted_unit_on_cast_start
@@ -1084,12 +1077,14 @@ class SpellManager:
             self.send_cast_result(casting_spell, result)
             return False
 
-        if casting_spell.initial_target_is_unit_or_player() and not \
-                (casting_spell.is_area_of_effect_spell() and validation_target is self.caster):
+        # Unit target checks.
+        if casting_spell.initial_target_is_unit_or_player():
             # Basic effect harmfulness/attackability check for fully harmful spells.
             # For unit-targeted AoE spells, skip validation for self casts.
             # The client checks this for player casts, but not pet casts.
-            if not self.caster.can_attack_target(validation_target) and casting_spell.has_only_harmful_effects():
+            if (not casting_spell.is_area_of_effect_spell() or validation_target is not self.caster) and \
+                    casting_spell.has_only_harmful_effects() and \
+                    not self.caster.can_attack_target(validation_target):
                 self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS)
                 return False
 
@@ -1108,10 +1103,32 @@ class SpellManager:
                     self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_UNIT_NOT_INFRONT)
                 return False
 
-        is_terrain = casting_spell.initial_target_is_terrain()
-        is_self = not is_terrain and self.caster == validation_target
+            # Aura bounce check.
+            if not validation_target.aura_manager.are_spell_effects_applicable(casting_spell):
+                self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_AURA_BOUNCED)
+                return False
+
+            # Creature type check.
+            if validation_target is not self.caster:
+                req_creature_type_mask = casting_spell.spell_entry.TargetCreatureType
+                target_creature_type_mask = 1 << (validation_target.creature_type - 1)
+                if req_creature_type_mask and not req_creature_type_mask & target_creature_type_mask:
+                    error = SpellCheckCastResult.SPELL_FAILED_TARGET_IS_PLAYER if \
+                        validation_target.get_type_id() == ObjectTypeIds.ID_PLAYER \
+                        else SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS
+
+                    self.send_cast_result(casting_spell, error)
+                    return False
+
+            # Target power type check (mana drain etc.)
+            if not casting_spell.is_target_power_type_valid(validation_target):
+                self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS)
+                return False
+
         # Range validations. Skip for fishing as generated targets will always be valid.
-        if not casting_spell.is_fishing_spell() and not casting_spell.initial_target_is_item() and not is_self:
+        is_terrain = casting_spell.initial_target_is_terrain()
+        if not casting_spell.is_fishing_spell() and not casting_spell.initial_target_is_item() and \
+                validation_target is not self.caster:
             # Check if the caster is within range of the (world) target to cast the spell.
             target_loc = validation_target if is_terrain else validation_target.location
             if casting_spell.range_entry.RangeMin > 0 or casting_spell.range_entry.RangeMax > 0:
@@ -1149,39 +1166,17 @@ class SpellManager:
                 self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS)
                 return False
 
-        # Aura bounce check.
-        if casting_spell.initial_target_is_unit_or_player():
-            if not validation_target.aura_manager.are_spell_effects_applicable(casting_spell):
-                self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_AURA_BOUNCED)
-                return False
-
-        # Creature type check.
-        if casting_spell.initial_target_is_unit_or_player() and validation_target is not self.caster:
-            req_creature_type_mask = casting_spell.spell_entry.TargetCreatureType
-            target_creature_type_mask = 1 << (validation_target.creature_type - 1)
-            if req_creature_type_mask and not req_creature_type_mask & target_creature_type_mask:
-                error = SpellCheckCastResult.SPELL_FAILED_TARGET_IS_PLAYER if \
-                    validation_target.get_type_id() == ObjectTypeIds.ID_PLAYER \
-                    else SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS
-
-                self.send_cast_result(casting_spell, error)
-                return False
-
         # Effect-specific validation.
 
-        # Target power type check (mana drain etc.)
-        if casting_spell.initial_target_is_unit_or_player() and \
-                not casting_spell.is_target_power_type_valid(validation_target):
-            self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS)
-            return False
-
         # Enchanting checks.
-        if casting_spell.is_enchantment_spell():
+        has_temporary_enchant_effect = casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_ENCHANT_ITEM_TEMPORARY)
+        if has_temporary_enchant_effect or \
+                casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_ENCHANT_ITEM_PERMANENT):
             # TODO: We don't have EquippedItemInventoryTypeMask, so we have no way to validate inventory slots.
             #  e.g. Enchant bracers would still work on legs, chest, etc. So maybe they had some filtering by name?
 
             # Do not allow temporary enchantments in trade slot.
-            if casting_spell.is_temporary_enchant_spell():
+            if has_temporary_enchant_effect:
                 # TODO: Further research needed, we have neither SPELL_FAILED_NOT_TRADEABLE or 'Slot' in
                 #   SpellItemEnchantment. Refer to VMaNGOS Spell.cpp 7822.
                 if casting_spell.initial_target.get_owner_guid() != casting_spell.spell_caster.guid:
@@ -1256,7 +1251,7 @@ class SpellManager:
             return False
 
         # Pickpocketing target validity check.
-        if casting_spell.is_pickpocket_spell():
+        if casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_PICKPOCKET):
             if not self.caster.can_attack_target(validation_target):
                 self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_TARGET_FRIENDLY)
                 return False
@@ -1270,7 +1265,7 @@ class SpellManager:
                 return False
 
         # Duel target check.
-        if casting_spell.is_duel_spell():
+        if casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_DUEL):
             # Duel cast attempt on a unit.
             if validation_target.get_type_id() != ObjectTypeIds.ID_PLAYER:
                 self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS)
@@ -1284,7 +1279,9 @@ class SpellManager:
                 return False
 
         # Lock/chest checks.
-        if casting_spell.is_unlocking_spell():
+        open_lock_effect = casting_spell.get_effect_by_type(SpellEffects.SPELL_EFFECT_OPEN_LOCK,
+                                                            SpellEffects.SPELL_EFFECT_OPEN_LOCK_ITEM)
+        if open_lock_effect:
             # Already unlocked.
             if not validation_target.lock:
                 self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_ALREADY_OPEN)
@@ -1302,26 +1299,24 @@ class SpellManager:
                 self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_ALREADY_OPEN)
                 return False
 
-            # OPEN_LOCK spells can provide bonus skill.
-            if casting_spell.is_unlocking_spell():
-                lock_effect = casting_spell.get_lock_effect()
-                bonus_skill = lock_effect.get_effect_simple_points()
+            # Unlock spells can provide bonus skill.
+            bonus_skill = open_lock_effect.get_effect_simple_points()
 
-                # Skill checks and random failure chance.
-                if casting_spell.cast_state == SpellState.SPELL_STATE_PREPARING:
-                    # Skill check only on initial validation.
-                    unlock_result = LockManager.can_open_lock(self.caster, lock_effect.misc_value, validation_target.lock,
-                                                              cast_item=casting_spell.source_item, bonus_points=bonus_skill)
-                    unlock_result = unlock_result.result
-                else:
-                    # Include failure chance on cast.
-                    unlock_result = self.caster.skill_manager.get_unlocking_attempt_result(lock_effect.misc_value,
-                                                                                           validation_target.lock,
-                                                                                           used_item=casting_spell.source_item,
-                                                                                           bonus_skill=bonus_skill)
-                if unlock_result != SpellCheckCastResult.SPELL_NO_ERROR:
-                    self.send_cast_result(casting_spell, unlock_result)
-                    return False
+            # Skill checks and random failure chance.
+            if casting_spell.cast_state == SpellState.SPELL_STATE_PREPARING:
+                # Skill check only on initial validation.
+                unlock_result = LockManager.can_open_lock(self.caster, open_lock_effect.misc_value, validation_target.lock,
+                                                          cast_item=casting_spell.source_item, bonus_points=bonus_skill)
+                unlock_result = unlock_result.result
+            else:
+                # Include failure chance on cast.
+                unlock_result = self.caster.skill_manager.get_unlocking_attempt_result(open_lock_effect.misc_value,
+                                                                                       validation_target.lock,
+                                                                                       used_item=casting_spell.source_item,
+                                                                                       bonus_skill=bonus_skill)
+            if unlock_result != SpellCheckCastResult.SPELL_NO_ERROR:
+                self.send_cast_result(casting_spell, unlock_result)
+                return False
 
         # Special case of Ritual of Summoning.
         summoning_channel_id = 698

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -261,8 +261,10 @@ class SpellManager:
         self.start_spell_cast(spell, spell_target, target_mask, triggered=triggered)
 
     def try_initialize_spell(self, spell: Spell, spell_target, target_mask, source_item=None,
-                             triggered=False, validate=True, creature_spell=None) -> Optional[CastingSpell]:
-        spell = CastingSpell(spell, self.caster, spell_target, target_mask, source_item, triggered=triggered,
+                             triggered=False, triggered_by_spell=None,
+                             validate=True, creature_spell=None) -> Optional[CastingSpell]:
+        spell = CastingSpell(spell, self.caster, spell_target, target_mask, source_item,
+                             triggered=triggered, triggered_by_spell=triggered_by_spell,
                              creature_spell=creature_spell)
         if not validate:
             return spell

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -116,8 +116,9 @@ class AuraEffectHandler:
         initialized_spell = effect_target.spell_manager.try_initialize_spell(trigger_spell,
                                                                              source_spell.initial_target,
                                                                              source_spell.spell_target_mask,
-                                                                             triggered=True, validate=False)
-        
+                                                                             triggered_by_spell=source_spell,
+                                                                             validate=False)
+
         # Also copy initial target selection as periodically triggered spells shouldn't be able to change their target.
         initialized_spell.targeted_unit_on_cast_start = source_spell.targeted_unit_on_cast_start
         effect_target.spell_manager.start_spell_cast(initialized_spell=initialized_spell)
@@ -215,7 +216,7 @@ class AuraEffectHandler:
         caster = aura.target
         spell = caster.spell_manager.try_initialize_spell(new_spell_entry, caster,
                                                           aura.source_spell.spell_target_mask,
-                                                          validate=False, triggered=True)
+                                                          validate=False, triggered_by_spell=aura.source_spell)
 
         # If an effect of this spell can't target friendly, set the cast target to the effect target.
         # Effect target will be set to the second (non-self) target in the proc call. (see AuraManager.check_aura_procs)

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -142,6 +142,11 @@ class AuraManager:
                 self.remove_aura(aura)
                 continue
 
+            # Some stealth auras don't have correct interrupt flags set (5916, 6408), but should be removed on attack.
+            if aura.spell_effect.aura_type == AuraTypes.SPELL_AURA_MOD_STEALTH and started_attack:
+                self.remove_aura(aura)
+                continue
+
             for flag, condition in flag_cases.items():
                 if flag == SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_ACTION and \
                      aura.spell_effect.aura_type == AuraTypes.SPELL_AURA_MOD_STEALTH and \

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -117,7 +117,6 @@ class AuraManager:
     def check_aura_interrupts(self, moved=False, turned=False, changed_stand_state=False, negative_aura_applied=False,
                               received_damage=False, enter_combat=False, attacked=False,
                               cast_spell: Optional[CastingSpell] = None):
-        # Add once movement information is passed to update.
         flag_cases = {
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_ENTER_COMBAT: enter_combat,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NOT_MOUNTED: self.unit_mgr.unit_flags & UnitFlags.UNIT_MASK_MOUNTED,

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -115,14 +115,15 @@ class AuraManager:
         return True
 
     def check_aura_interrupts(self, moved=False, turned=False, changed_stand_state=False, negative_aura_applied=False,
-                              received_damage=False, enter_combat=False, cast_spell: Optional[CastingSpell] = None):
+                              received_damage=False, enter_combat=False, started_attack=False,
+                              cast_spell: Optional[CastingSpell] = None):
         # Add once movement information is passed to update.
         flag_cases = {
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_ENTER_COMBAT: enter_combat,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NOT_MOUNTED: self.unit_mgr.unit_flags & UnitFlags.UNIT_MASK_MOUNTED,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_MOVE: moved,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_TURNING: turned,
-            SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_CAST: cast_spell is not None,
+            SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_ACTION: cast_spell is not None or started_attack,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NEGATIVE_SPELL: negative_aura_applied,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_DAMAGE: received_damage,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NOT_ABOVEWATER: self.unit_mgr.is_over_water(),
@@ -142,7 +143,7 @@ class AuraManager:
                 continue
 
             for flag, condition in flag_cases.items():
-                if flag == SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_CAST and \
+                if flag == SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_ACTION and \
                      aura.spell_effect.aura_type == AuraTypes.SPELL_AURA_MOD_STEALTH and \
                         cast_spell and not cast_spell.cast_breaks_stealth():
                     continue  # Skip cast interrupt for stealth spells for flagged spells.

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -115,7 +115,7 @@ class AuraManager:
         return True
 
     def check_aura_interrupts(self, moved=False, turned=False, changed_stand_state=False, negative_aura_applied=False,
-                              received_damage=False, enter_combat=False, started_attack=False,
+                              received_damage=False, enter_combat=False, attacked=False,
                               cast_spell: Optional[CastingSpell] = None):
         # Add once movement information is passed to update.
         flag_cases = {
@@ -123,7 +123,7 @@ class AuraManager:
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NOT_MOUNTED: self.unit_mgr.unit_flags & UnitFlags.UNIT_MASK_MOUNTED,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_MOVE: moved,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_TURNING: turned,
-            SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_ACTION: cast_spell is not None or started_attack,
+            SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_ACTION: cast_spell is not None or attacked,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NEGATIVE_SPELL: negative_aura_applied,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_DAMAGE: received_damage,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NOT_ABOVEWATER: self.unit_mgr.is_over_water(),
@@ -143,7 +143,7 @@ class AuraManager:
                 continue
 
             # Some stealth auras don't have correct interrupt flags set (5916, 6408), but should be removed on attack.
-            if aura.spell_effect.aura_type == AuraTypes.SPELL_AURA_MOD_STEALTH and started_attack:
+            if aura.spell_effect.aura_type == AuraTypes.SPELL_AURA_MOD_STEALTH and attacked:
                 self.remove_aura(aura)
                 continue
 

--- a/game/world/managers/objects/units/MovementManager.py
+++ b/game/world/managers/objects/units/MovementManager.py
@@ -70,9 +70,10 @@ class MovementManager:
                     self.unit.taxi_manager.update_flight_state()
 
                 if not self.is_player:
-                    if self.unit.is_evading:
+                    if self.unit.is_evading or \
+                            self.unit.is_at_home() and \
+                            self.unit.movement_spline.is_type(SplineType.SPLINE_TYPE_NORMAL):
                         self.unit.is_evading = False
-                    if self.unit.is_at_home() and self.unit.movement_spline.is_type(SplineType.SPLINE_TYPE_NORMAL):
                         self.unit.on_at_home()
 
                 self.reset()

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -23,7 +23,7 @@ from utils.constants.DuelCodes import DuelState
 from utils.constants.MiscCodes import ObjectTypeFlags, ObjectTypeIds, AttackTypes, ProcFlags, \
     ProcFlagsExLegacy, HitInfo, AttackSwingError, MoveFlags, VictimStates, UnitDynamicTypes, HighGuid
 from utils.constants.SpellCodes import SpellMissReason, SpellHitFlags, SpellSchools, ShapeshiftForms, SpellImmunity, \
-    SpellSchoolMask
+    SpellSchoolMask, AuraTypes
 from utils.constants.UnitCodes import UnitFlags, StandState, WeaponMode, PowerTypes, UnitStates, RegenStatsFlags
 from utils.constants.UpdateFields import UnitFields
 
@@ -266,6 +266,10 @@ class UnitManager(ObjectManager):
 
         self.set_current_target(victim.guid)
         self.combat_target = victim
+        self.aura_manager.check_aura_interrupts(started_attack=True)
+
+        # Some stealth auras don't have correct interrupt flags set (5916, 6408), but should be removed on attack.
+        self.aura_manager.remove_auras_by_type(AuraTypes.SPELL_AURA_MOD_STEALTH)
 
         # Reset offhand weapon attack
         if self.has_offhand_weapon():

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -981,10 +981,6 @@ class UnitManager(ObjectManager):
         if not target.unit_flags & UnitFlags.UNIT_FLAG_SNEAK:
             return True, False
 
-        # Already attacked by the target.
-        if self.threat_manager.has_aggro_from(target):
-            return True, False
-
         # No distance provided, calculate here.
         if not distance:
             distance = self.location.distance(target.location)

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -266,7 +266,6 @@ class UnitManager(ObjectManager):
 
         self.set_current_target(victim.guid)
         self.combat_target = victim
-        self.aura_manager.check_aura_interrupts(started_attack=True)
 
         # Reset offhand weapon attack
         if self.has_offhand_weapon():
@@ -390,6 +389,7 @@ class UnitManager(ObjectManager):
         if not victim or not self.is_alive or not victim.is_alive or victim.unit_state & UnitStates.SANCTUARY:
             return
 
+        self.aura_manager.check_aura_interrupts(attacked=True)
         if attack_type == AttackTypes.BASE_ATTACK:
             # No recent extra attack only at any non-extra attack.
             if not extra and self.extra_attacks > 0:

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -268,9 +268,6 @@ class UnitManager(ObjectManager):
         self.combat_target = victim
         self.aura_manager.check_aura_interrupts(started_attack=True)
 
-        # Some stealth auras don't have correct interrupt flags set (5916, 6408), but should be removed on attack.
-        self.aura_manager.remove_auras_by_type(AuraTypes.SPELL_AURA_MOD_STEALTH)
-
         # Reset offhand weapon attack
         if self.has_offhand_weapon():
             self.set_attack_timer(AttackTypes.OFFHAND_ATTACK, self.offhand_attack_time)

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -486,6 +486,7 @@ class PlayerManager(UnitManager):
         # Handle visibility/stealth.
         if not self.can_detect_target(creature)[0]:
             self.known_stealth_units[creature.guid] = (creature, True)
+            creature.known_players[self.guid] = self
             return
         elif creature.guid in self.known_stealth_units:
             del self.known_stealth_units[creature.guid]

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -830,6 +830,9 @@ class StatManager(object):
         skill_value = -1
         if caster.get_type_id() == ObjectTypeIds.ID_PLAYER:
             _, skill, _ = caster.skill_manager.get_skill_info_for_spell_id(casting_spell.spell_entry.ID)
+            if not skill and casting_spell.triggered_by_spell:
+                # If this spell was triggered by another spell, use the triggering spell's skill.
+                _, skill, _ = caster.skill_manager.get_skill_info_for_spell_id(casting_spell.triggered_by_spell.spell_entry.ID)
             # Use skill level if one exists for the spell, otherwise fall back to max possible skill.
             skill_value = caster.skill_manager.get_total_skill_value(skill.ID) if skill else -1
 

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -777,6 +777,8 @@ class StatManager(object):
             return SpellMissReason.MISS_REASON_EVADED, hit_flags
 
         spell_school = casting_spell.spell_entry.School
+        # TODO Wands should get spell school from the item and use spell formulas.
+
         caster = casting_spell.spell_caster
 
         # Spells cast on friendly targets should always hit.

--- a/utils/constants/SpellCodes.py
+++ b/utils/constants/SpellCodes.py
@@ -376,14 +376,14 @@ class SpellChannelInterruptFlags(IntEnum):
 
 class SpellAuraInterruptFlags(IntEnum):
     AURA_INTERRUPT_FLAG_NEGATIVE_SPELL = 0x00000001  # 0 Stealth, sap etc.
-    AURA_INTERRUPT_FLAG_DAMAGE = 0x00000002  # 1    removed by any damage
-    AURA_INTERRUPT_FLAG_CAST = 0x00000004  # 2
-    AURA_INTERRUPT_FLAG_MOVE = 0x00000008  # 3    removed by any movement
-    AURA_INTERRUPT_FLAG_TURNING = 0x00000010  # 4    removed by any turning
-    AURA_INTERRUPT_FLAG_ENTER_COMBAT = 0x00000020  # 5    removed by entering combat
-    AURA_INTERRUPT_FLAG_NOT_MOUNTED = 0x00000040  # 6    removed by unmounting
-    AURA_INTERRUPT_FLAG_NOT_ABOVEWATER = 0x00000080  # 7    removed by entering water
-    AURA_INTERRUPT_FLAG_NOT_UNDERWATER = 0x00000100  # 8    removed by leaving water - aquatic form
+    AURA_INTERRUPT_FLAG_DAMAGE = 0x00000002  # 1  Removed by any damage.
+    AURA_INTERRUPT_FLAG_ACTION = 0x00000004  # 2  Removed by spell cast or attack start.
+    AURA_INTERRUPT_FLAG_MOVE = 0x00000008  # 3  Removed by any movement.
+    AURA_INTERRUPT_FLAG_TURNING = 0x00000010  # 4  Removed by any turning.
+    AURA_INTERRUPT_FLAG_ENTER_COMBAT = 0x00000020  # 5  Removed by entering combat.
+    AURA_INTERRUPT_FLAG_NOT_MOUNTED = 0x00000040  # 6  Removed by unmounting.
+    AURA_INTERRUPT_FLAG_NOT_ABOVEWATER = 0x00000080  # 7  Removed by entering water.
+    AURA_INTERRUPT_FLAG_NOT_UNDERWATER = 0x00000100  # 8  Removed by leaving water - aquatic form.
 
 
 class ShapeshiftForms(IntEnum):


### PR DESCRIPTION
* Correct aura interrupt flag for combat actions
* Fix resetting unit auras after evading (related to pathing/Namigator? @devw4r)
* Fix stealthed creatures not detecting players until they've been detected by a player
* Remove all stealth auras on combat actions (https://github.com/The-Alpha-Project/alpha-core/issues/613#issuecomment-1416877496)
    * some stealth auras lack proper interrupt flags
* Fix proc spell aura target resolving when changing targets (Arcane Missiles)
* Fix script effects being able to be resisted (Arcane Missiles)
* Fix spell skill check for proc spells
    * Triggered spells don't have a skill type (Arcane Missiles Effect, Chilled etc.), track and use source spell skill instead
* Remove unused methods in spell code, group logic in `validate_cast`
* Replace `CastingSpell` effect check methods with direct effect checks