### PR TITLE
Pet active state persistency, summon cast validation fix

### DIFF
--- a/database/realm/RealmModels.py
+++ b/database/realm/RealmModels.py
@@ -242,6 +242,7 @@ class CharacterPet(Base):
 
     name = Column(String(255), nullable=False, server_default=text("''"))
     rename_time = Column(INTEGER(11), nullable=False, server_default=text("'0'"))
+    is_active = Column(TINYINT(1), nullable=False, server_default=text("'0'"))
 
     health = Column(INTEGER(11), nullable=False, server_default=text("'0'"))
     mana = Column(INTEGER(11), nullable=False, server_default=text("'0'"))

--- a/etc/databases/realm/updates/updates.sql
+++ b/etc/databases/realm/updates/updates.sql
@@ -171,5 +171,12 @@ begin not atomic
 
         insert into applied_updates values ('221220221');
     end if;
+
+    -- 12/02/2023 1
+	if (select count(*) from applied_updates where id='120220231') = 0 then
+        ALTER TABLE `character_pets` ADD COLUMN `is_active` TINYINT(1) unsigned NOT NULL DEFAULT 0;
+        insert into applied_updates values ('120220231');
+    end if;
+
 end $
 delimiter ;

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -1252,9 +1252,14 @@ class SpellManager:
 
         # Permanent pet summon check.
         summon_pet_effect = casting_spell.get_effect_by_type(SpellEffects.SPELL_EFFECT_SUMMON_PET)
-        if summon_pet_effect and not summon_pet_effect.misc_value and not len(self.caster.pet_manager.permanent_pets):
-            self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_NO_PET)
-            return False
+        if summon_pet_effect:
+            if not summon_pet_effect.misc_value and not len(self.caster.pet_manager.permanent_pets):
+                self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_NO_PET)
+                return False
+
+            if self.caster.pet_manager.get_active_controlled_pet():
+                self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_ALREADY_HAVE_SUMMON)
+                return False
 
         # Pickpocketing target validity check.
         if casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_PICKPOCKET):

--- a/game/world/managers/objects/units/pet/ActivePet.py
+++ b/game/world/managers/objects/units/pet/ActivePet.py
@@ -108,6 +108,8 @@ class ActivePet:
             self.creature.replenish_powers()
 
     def attach(self):
+        self.get_pet_data().set_active(True)
+
         if self.is_permanent() or not self.is_controlled():
             # Permanent pet/totem.
             self.creature.set_summoned_by(self._pet_manager.owner, spell_id=self.get_created_by_spell(),

--- a/game/world/managers/objects/units/pet/PetData.py
+++ b/game/world/managers/objects/units/pet/PetData.py
@@ -16,7 +16,7 @@ class PetData:
 
     def __init__(self, pet_id: int, name: str, rename_time: int, template: CreatureTemplate, owner_guid,
                  level: int, experience: int, summon_spell_id: int, permanent: bool,
-                 spells=None, action_bar=None):
+                 spells=None, action_bar=None, is_active: bool = False):
         self.pet_id = pet_id
 
         self.name = name
@@ -25,6 +25,7 @@ class PetData:
         self.permanent = permanent
         self.summon_spell_id = summon_spell_id
         self.rename_time = rename_time
+        self.is_active = is_active  # Used for tracking pet state between logins. Only set for permanent pets.
 
         self._level = level
         self._experience = experience
@@ -80,6 +81,7 @@ class PetData:
             command_state=int(self.command_state),
             name=self.name,
             rename_time=self.rename_time,
+            is_active=self.is_active,
             health=health,
             mana=mana,
             action_bar=pack('10I', *self.action_bar)
@@ -132,6 +134,13 @@ class PetData:
     def set_name(self, name: str):
         self.name = name
         self.rename_time = int(time.time())
+        self.set_dirty()
+
+    def set_active(self, active: bool):
+        if not self.permanent:
+            return
+
+        self.is_active = active
         self.set_dirty()
 
     def add_spell(self, spell_id) -> bool:

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -293,6 +293,7 @@ class PlayerManager(UnitManager):
             self.group_manager.send_update()
 
         self.spell_manager.send_login_effect()
+        self.pet_manager.handle_login()
 
     def logout(self):
         self.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_LOGOUT_COMPLETE))
@@ -307,7 +308,7 @@ class PlayerManager(UnitManager):
 
         self.spell_manager.remove_casts()
         self.aura_manager.remove_all_auras()
-        self.pet_manager.detach_active_pets()
+        self.pet_manager.detach_active_pets(is_logout=True)
         self.leave_combat()
 
         # Channels weren't saved on logout until Patch 0.5.5

--- a/game/world/opcode_handling/handlers/interface/CharEnumHandler.py
+++ b/game/world/opcode_handling/handlers/interface/CharEnumHandler.py
@@ -63,14 +63,16 @@ class CharEnumHandler(object):
     @staticmethod
     def _get_pet_info(character_guid):
         pets = RealmDatabaseManager.character_get_pets(character_guid)
-        pet = pets[0] if pets and len(pets) else None  # TODO Get active pet, not first.
-        if not pet:
-            return [0, 0, 0]
+        for pet in pets:
+            if not pet.is_active:
+                continue
 
-        pet_creature_template = WorldDatabaseManager.CreatureTemplateHolder.creature_get_by_entry(pet.creature_id)
-        # TODO tamed variant display id? Affects two tamable creatures (8933, 9696).
-        pet_display_id = pet_creature_template.display_id1
-        pet_level = pet.level
-        pet_family = pet_creature_template.beast_family
+            pet_creature_template = WorldDatabaseManager.CreatureTemplateHolder.creature_get_by_entry(
+                pet.creature_id)
+            # TODO tamed variant display id? Affects two tamable creatures (8933, 9696).
+            pet_display_id = pet_creature_template.display_id1
+            pet_level = pet.level
+            pet_family = pet_creature_template.beast_family
+            return [pet_display_id, pet_level, pet_family]
 
-        return [pet_display_id, pet_level, pet_family]
+        return [0, 0, 0]

--- a/game/world/opcode_handling/handlers/interface/CharEnumHandler.py
+++ b/game/world/opcode_handling/handlers/interface/CharEnumHandler.py
@@ -67,8 +67,7 @@ class CharEnumHandler(object):
             if not pet.is_active:
                 continue
 
-            pet_creature_template = WorldDatabaseManager.CreatureTemplateHolder.creature_get_by_entry(
-                pet.creature_id)
+            pet_creature_template = WorldDatabaseManager.CreatureTemplateHolder.creature_get_by_entry(pet.creature_id)
             # TODO tamed variant display id? Affects two tamable creatures (8933, 9696).
             pet_display_id = pet_creature_template.display_id1
             pet_level = pet.level


### PR DESCRIPTION
* Track pet activity state in database
    * If a permanent pet is active on logout, display it in character selection and summon it on login.
    * Partially addresses #281 
* Don't allow casting a permanent pet summon if a controlled pet is already active