### PR TITLE
Unit PetManager support, pet AI improvements

### DIFF
--- a/game/world/managers/objects/ai/CreatureAI.py
+++ b/game/world/managers/objects/ai/CreatureAI.py
@@ -14,7 +14,7 @@ from network.packet.PacketWriter import PacketWriter
 from utils.constants.MiscCodes import ObjectTypeFlags, ObjectTypeIds
 from utils.constants.OpCodes import OpCode
 from utils.constants.ScriptCodes import CastFlags
-from utils.constants.SpellCodes import SpellCheckCastResult, SpellTargetMask, SpellInterruptFlags, SpellAttributes, \
+from utils.constants.SpellCodes import SpellCheckCastResult, SpellTargetMask, SpellInterruptFlags, \
     SpellEffects
 from utils.constants.UnitCodes import UnitFlags, UnitStates, AIReactionStates
 
@@ -163,7 +163,6 @@ class CreatureAI:
                 self.creature.spell_manager.apply_passive_spell_effects(spell)
             elif spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_SUMMON_PET):
                 self.creature.spell_manager.start_spell_cast(initialized_spell=spell)
-
 
     # Called when a creature is despawned by natural means (TTL).
     def just_despawned(self):

--- a/game/world/managers/objects/ai/CreatureAI.py
+++ b/game/world/managers/objects/ai/CreatureAI.py
@@ -32,7 +32,7 @@ class CreatureAI:
         if creature:
             self.creature = creature
             self.use_ai_at_control = False
-            self.melee_attack = True  # If we allow melee auto attack.
+            self.has_melee = self.creature.has_melee()  # If we allow melee auto attack.
             self.combat_movement = True  # If we allow targeted movement gen (chasing target).
             self.casting_delay = 0  # Cooldown before updating spell list again.
             self.last_alert_time = 0
@@ -199,7 +199,7 @@ class CreatureAI:
     # Called when creature attack is expected (if creature can and doesn't have current victim).
     # Note: for reaction at hostile action must be called AttackedBy function.
     def attack_start(self, victim, chase=True):
-        if chase:
+        if chase and self.has_melee:
             self.creature.movement_manager.move_chase()
         # Notify creature group.
         if self.creature.creature_group:
@@ -392,7 +392,7 @@ class CreatureAI:
         return self.combat_movement
 
     def is_melee_attack_enabled(self):
-        return self.melee_attack
+        return self.has_melee
 
     def set_melee_attack(self, enabled):
         pass

--- a/game/world/managers/objects/ai/PetAI.py
+++ b/game/world/managers/objects/ai/PetAI.py
@@ -1,5 +1,3 @@
-import math
-
 from game.world.managers.objects.ai.CreatureAI import CreatureAI
 from utils.constants.CustomCodes import Permits
 from utils.constants.MiscCodes import ObjectTypeIds
@@ -146,6 +144,9 @@ class PetAI(CreatureAI):
 
     def command_state_update(self):
         self.creature.movement_manager.reset(clean_behaviors=True)
+
+        # TODO Stay shouldn't cause pet to stop attacking, only stop chasing.
+        self.creature.attack_stop()
 
         if self._get_command_state() == PetCommandState.COMMAND_STAY:
             self.creature.movement_manager.move_stay(state=True)

--- a/game/world/managers/objects/ai/PetAI.py
+++ b/game/world/managers/objects/ai/PetAI.py
@@ -4,6 +4,7 @@ from game.world.managers.objects.ai.CreatureAI import CreatureAI
 from utils.constants.CustomCodes import Permits
 from utils.constants.MiscCodes import ObjectTypeIds
 from utils.constants.PetCodes import PetCommandState, PetReactState, PetFollowState
+from utils.constants.SpellCodes import SpellTargetMask
 from utils.constants.UnitCodes import UnitStates
 
 
@@ -135,6 +136,13 @@ class PetAI(CreatureAI):
 
     def stop_attack(self):
         pass
+
+    def do_spell_cast(self, spell_id, target):
+        if self.creature.spell_manager.is_casting():
+            return
+
+        target_mask = SpellTargetMask.SELF if target.guid == self.creature.guid else SpellTargetMask.UNIT
+        self.creature.spell_manager.handle_cast_attempt(spell_id, target, target_mask)
 
     def command_state_update(self):
         self.creature.movement_manager.reset(clean_behaviors=True)

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -590,7 +590,7 @@ class SpellEffectHandler:
 
     @staticmethod
     def handle_summon_pet(casting_spell, effect, caster, target):
-        if caster.get_type_id() != ObjectTypeIds.ID_PLAYER:
+        if not caster.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
             return
 
         caster.pet_manager.summon_permanent_pet(casting_spell.spell_entry.ID, effect.misc_value)

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -271,7 +271,7 @@ class SpellManager:
             return spell
         return spell if self.validate_cast(spell) else None
 
-    def start_spell_cast(self, spell: Optional[Spell]=None, spell_target=None, target_mask=SpellTargetMask.SELF,
+    def start_spell_cast(self, spell: Optional[Spell] = None, spell_target=None, target_mask=SpellTargetMask.SELF,
                          source_item=None, triggered=False, initialized_spell: Optional[CastingSpell]=None):
         casting_spell = self.try_initialize_spell(spell, spell_target, target_mask, source_item, triggered=triggered) \
             if not initialized_spell else initialized_spell

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -271,6 +271,10 @@ class UnitManager(ObjectManager):
         self.set_current_target(victim.guid)
         self.combat_target = victim
 
+        active_pet = self.pet_manager.get_active_controlled_pet()
+        if active_pet:
+            active_pet.creature.object_ai.owner_attacked(victim)
+
         # Reset offhand weapon attack
         if self.has_offhand_weapon():
             self.set_attack_timer(AttackTypes.OFFHAND_ATTACK, self.offhand_attack_time)

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -205,7 +205,6 @@ class UnitManager(ObjectManager):
         self.stat_manager = StatManager(self)
         self.aura_manager = AuraManager(self)
         self.movement_manager = MovementManager(self)
-        # TODO: Support for CreatureManager is not added yet.
         from game.world.managers.objects.units.pet.PetManager import PetManager
         self.pet_manager = PetManager(self)
         # Players/Creatures.

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -1564,6 +1564,8 @@ class UnitManager(ObjectManager):
         # Reset threat manager.
         self.threat_manager.reset()
 
+        self.pet_manager.detach_active_pets()
+
         self.set_health(0)
 
         self.unit_flags |= UnitFlags.UNIT_MASK_DEAD

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -1554,7 +1554,7 @@ class UnitManager(ObjectManager):
             self.object_ai.just_died()
 
         # Notify killer's pet AI about this kill.
-        if killer.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
+        if killer and killer.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
             killer_pet = killer.pet_manager.get_active_controlled_pet()
             if killer_pet:
                 killer_pet.creature.object_ai.killed_unit(self)

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -528,7 +528,7 @@ class CreatureManager(UnitManager):
 
     # override
     def attack(self, victim: UnitManager):
-        had_target = self.combat_target
+        had_target = self.combat_target and self.combat_target.is_alive
         super().attack(victim)
         if not had_target:
             self.object_ai.attack_start(victim)

--- a/game/world/managers/objects/units/creature/ThreatManager.py
+++ b/game/world/managers/objects/units/creature/ThreatManager.py
@@ -95,12 +95,10 @@ class ThreatManager:
         # If the threat comes from a pet, owner should be added to this unit threat list.
         charmer_or_summoner = source.get_charmer_or_summoner()
         if charmer_or_summoner and not self.has_aggro_from(charmer_or_summoner):
-            # If the charmer/summoner is a player, set him in combat as well.
-            if charmer_or_summoner.get_type_id() == ObjectTypeIds.ID_PLAYER:
-                charmer_or_summoner.attack(self.owner)
+            # Set pet owner in combat as well.
             self.add_threat(charmer_or_summoner)
 
-        # Notify pet pet that owner has been attacked.
+        # Notify pet that owner has been attacked.
         active_pet = self.owner.pet_manager.get_active_controlled_pet()
         if active_pet:
             active_pet.creature.object_ai.owner_attacked_by(source)

--- a/game/world/managers/objects/units/creature/ThreatManager.py
+++ b/game/world/managers/objects/units/creature/ThreatManager.py
@@ -100,6 +100,11 @@ class ThreatManager:
                 charmer_or_summoner.attack(self.owner)
             self.add_threat(charmer_or_summoner)
 
+        # Notify pet pet that owner has been attacked.
+        active_pet = self.owner.pet_manager.get_active_controlled_pet()
+        if active_pet:
+            active_pet.creature.object_ai.owner_attacked_by(source)
+
         if threat < 0.0:
             Logger.warning(f'Passed non positive threat {threat} from {source.get_low_guid()}')
 

--- a/game/world/managers/objects/units/pet/PetData.py
+++ b/game/world/managers/objects/units/pet/PetData.py
@@ -179,7 +179,8 @@ class PetData:
             # TODO Make these pets untamable?
             return []
 
-        skill_lines = [family_entry.SkillLine_1, family_entry.SkillLine_2]  # Include talents for this check (if any).
+        skill_lines = [family_entry.SkillLine_1,
+                       family_entry.SkillLine_2 if self.is_hunter_pet() else 0]  # Include talents for this check (if any).
 
         skill_line_abilities = DbcDatabaseManager.skill_line_ability_get_by_skill_lines(skill_lines)
         if not skill_line_abilities:

--- a/game/world/managers/objects/units/pet/PetData.py
+++ b/game/world/managers/objects/units/pet/PetData.py
@@ -7,6 +7,8 @@ from database.realm.RealmDatabaseManager import RealmDatabaseManager
 from database.realm.RealmModels import CharacterPet, CharacterPetSpell
 from database.world.WorldModels import CreatureTemplate
 from utils import Formulas
+from utils.GuidUtils import GuidUtils
+from utils.constants.MiscCodes import HighGuid
 from utils.constants.PetCodes import PetReactState, PetCommandState, PetActionBarIndex
 from utils.constants.SpellCodes import SpellAttributes
 
@@ -41,7 +43,7 @@ class PetData:
         self._dirty = pet_id == -1
 
     def save(self, creature_instance=None):
-        if not self.permanent or not self._dirty:
+        if not self.permanent or not self._dirty or not self._is_player_owned():
             return
 
         health = -1 if not creature_instance else creature_instance.health
@@ -58,7 +60,7 @@ class PetData:
         self._dirty = False
 
     def delete(self):
-        if not self.permanent:
+        if not self.permanent or not self._is_player_owned():
             return
         RealmDatabaseManager.character_delete_pet(self.pet_id)
 
@@ -149,6 +151,9 @@ class PetData:
 
         self.spells.append(spell_id)
 
+        if not self._is_player_owned():
+            return True
+
         button = CharacterPetSpell(guid=self.owner_guid, pet_id=self.pet_id, spell_id=spell_id)
         RealmDatabaseManager.character_add_pet_spell(button)
         return True
@@ -221,6 +226,9 @@ class PetData:
 
     def is_hunter_pet(self):
         return self.permanent and self.summon_spell_id == PetData.SUMMON_PET_SPELL_ID
+
+    def _is_player_owned(self):
+        return GuidUtils.extract_high_guid(self.owner_guid) == HighGuid.HIGHGUID_PLAYER
 
     @staticmethod
     def get_action_button_for(spell_id: int, auto_cast: bool = False, castable: bool = True):

--- a/game/world/managers/objects/units/pet/PetManager.py
+++ b/game/world/managers/objects/units/pet/PetManager.py
@@ -119,7 +119,8 @@ class PetManager:
             return
 
         # If a creature ID isn't provided, the pet to summon is the player's only pet (hunters).
-        is_warlock_pet = creature_id != 0
+        # Otherwise, the pet is owned by a warlock or a creature.
+        is_creature_summon = creature_id != 0
 
         pet_index = -1
         if not creature_id:
@@ -146,13 +147,13 @@ class PetManager:
                                                   spell_id=spell_id,
                                                   subtype=CustomCodes.CreatureSubtype.SUBTYPE_PET)
 
-        # Match summoner level for warlock pets. Otherwise, set to the level in PetData.
-        pet_level = self.owner.level if is_warlock_pet else -1
+        # Match summoner level for creature summons. Otherwise, set to the level in PetData.
+        pet_level = self.owner.level if is_creature_summon else -1
         active_pet = self.set_creature_as_pet(creature_manager, spell_id, PetSlot.PET_SLOT_PERMANENT,
                                               pet_level=pet_level, pet_index=pet_index, is_permanent=True)
 
-        # On initial warlock pet summon, teach available spells according to the summon spell's level.
-        if is_warlock_pet and pet_index == -1:
+        # On initial creature summon, teach available spells according to the summon spell's level.
+        if is_creature_summon and pet_index == -1:
             spell_level = DbcDatabaseManager.SpellHolder.spell_get_by_id(spell_id).SpellLevel
             active_pet.initialize_spells(level_override=spell_level)
 

--- a/game/world/managers/objects/units/pet/PetManager.py
+++ b/game/world/managers/objects/units/pet/PetManager.py
@@ -236,15 +236,20 @@ class PetManager:
 
         elif action & (0x01 << 24):
             # Command state action.
-            active_pet.get_pet_data().command_state = action_id
-            active_pet.creature.object_ai.command_state_update()
+            if action_id in {PetCommandState.COMMAND_FOLLOW, PetCommandState.COMMAND_STAY} and \
+                    active_pet.get_pet_data().command_state != action_id:
+                active_pet.get_pet_data().command_state = action_id
+                active_pet.creature.object_ai.command_state_update()
+
             if action_id == PetCommandState.COMMAND_ATTACK and target_unit:
                 active_pet.creature.attack(target_unit)
             if action_id == PetCommandState.COMMAND_DISMISS:
                 self.detach_pet_by_slot(active_pet.pet_slot)
 
         else:
+            # Always trigger react state update for stopping pet attack even when already passive.
             active_pet.get_pet_data().react_state = action_id
+            active_pet.creature.object_ai.react_state_update()
 
     def handle_set_action(self, pet_guid, slot, action):
         active_pet = self.get_active_controlled_pet()

--- a/game/world/managers/objects/units/pet/PetManager.py
+++ b/game/world/managers/objects/units/pet/PetManager.py
@@ -231,8 +231,7 @@ class PetManager:
             return
 
         if action_id > PetCommandState.COMMAND_DISMISS:  # Highest action ID.
-            target_mask = SpellTargetMask.SELF if target_unit.guid == active_pet_unit.guid else SpellTargetMask.UNIT
-            active_pet_unit.spell_manager.handle_cast_attempt(action_id, target_unit, target_mask)
+            active_pet_unit.object_ai.do_spell_cast(action_id, target_unit)
 
         elif action & (0x01 << 24):
             # Command state action.

--- a/game/world/managers/objects/units/pet/PetManager.py
+++ b/game/world/managers/objects/units/pet/PetManager.py
@@ -235,8 +235,7 @@ class PetManager:
 
         elif action & (0x01 << 24):
             # Command state action.
-            if action_id in {PetCommandState.COMMAND_FOLLOW, PetCommandState.COMMAND_STAY} and \
-                    active_pet.get_pet_data().command_state != action_id:
+            if action_id in {PetCommandState.COMMAND_FOLLOW, PetCommandState.COMMAND_STAY}:
                 active_pet.get_pet_data().command_state = action_id
                 active_pet.creature.object_ai.command_state_update()
 

--- a/game/world/managers/objects/units/pet/PetManager.py
+++ b/game/world/managers/objects/units/pet/PetManager.py
@@ -30,6 +30,9 @@ class PetManager:
         self.active_pets: dict[PetSlot, ActivePet] = {}
 
     def load_pets(self):
+        if self.owner.get_type_id() != ObjectTypeIds.ID_PLAYER:
+            return
+
         character_pets = RealmDatabaseManager.character_get_pets(self.owner.guid)
         for character_pet in character_pets:
             spells = RealmDatabaseManager.character_get_pet_spells(self.owner.guid, character_pet.pet_id)
@@ -312,6 +315,9 @@ class PetManager:
         active_pet.set_level(self.owner.level, replenish=True)
 
     def handle_cast_result(self, spell_id, result):
+        if self.owner.get_type_id() != ObjectTypeIds.ID_PLAYER:
+            return
+
         if result == SpellCheckCastResult.SPELL_NO_ERROR:
             return
 
@@ -337,6 +343,9 @@ class PetManager:
         return SpellCheckCastResult.SPELL_NO_ERROR
 
     def _send_tame_result(self, result):
+        if self.owner.get_type_id() != ObjectTypeIds.ID_PLAYER:
+            return
+
         if result == PetTameResult.TAME_SUCCESS:
             return
 
@@ -370,6 +379,9 @@ class PetManager:
                 return
 
     def send_pet_spell_info(self, reset=False):
+        if self.owner.get_type_id() != ObjectTypeIds.ID_PLAYER:
+            return
+
         if not reset:
             active_pet = self.get_active_controlled_pet()
             if not active_pet:

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1736,8 +1736,6 @@ class PlayerManager(UnitManager):
                 death_notify_packet = PacketWriter.get_packet(OpCode.SMSG_DEATH_NOTIFY, pack('<Q', killer.guid))
                 self.enqueue_packet(death_notify_packet)
 
-        self.pet_manager.detach_active_pets()
-
         TradeManager.cancel_trade(self)
         self.spirit_release_timer = 0
         self.mirror_timers_manager.stop_all()


### PR DESCRIPTION
* Add support for creatures having pets
    * Cast creature pet summon spells on respawn
* Disable chase for creatures with no melee (Imp)
* Fix bug with units not chasing after changing targets
* Modify target selection logic in `PetAI`
    * Ignore the pet's own `ThreatManager` 
    * Only track pet stay/follow state in `PetAI`, infer attack state from the presence of a combat target
    * Always match owner combat target for creature-controlled pets
* Implement pet react and assist behavior when not passive
* Fix interrupt issue with manual pet spell casts