### PR TITLE
Added spell effect "summon object wild" on death

### DIFF
--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -38,9 +38,10 @@ class SpellEffectHandler:
             return
 
         allowed_effects_on_death = {
-            SpellEffects.SPELL_EFFECT_RESURRECT,
+            SpellEffects.SPELL_EFFECT_RESURRECT, # Resurrection requires a dead target.
             SpellEffects.SPELL_EFFECT_SUMMON_OBJECT_WILD,  # Allow spells to summon an object on creature death.
-            SpellEffects.SPELL_EFFECT_SUMMON_WILD # Allow spells to summon another creature on creature death.
+            SpellEffects.SPELL_EFFECT_SUMMON_WILD, # Allow spells to summon another creature on creature death.
+            SPELL_EFFECT_SCHOOL_DAMAGE # Allow spells to deal damage after a creature's death.
         }
 
         from game.world.managers.objects.units.UnitManager import UnitManager

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -39,7 +39,8 @@ class SpellEffectHandler:
 
         allowed_effects_on_death = {
             SpellEffects.SPELL_EFFECT_RESURRECT,
-            SpellEffects.SPELL_EFFECT_SUMMON_OBJECT_WILD  # Allow spells to summon an object on creature death.
+            SpellEffects.SPELL_EFFECT_SUMMON_OBJECT_WILD,  # Allow spells to summon an object on creature death.
+            SpellEffects.SPELL_EFFECT_SUMMON_WILD # Allow spells to summon another creature on creature death.
         }
 
         from game.world.managers.objects.units.UnitManager import UnitManager
@@ -922,7 +923,6 @@ class SpellEffectHandler:
             return
 
         target.quest_manager.complete_quest_by_id(quest_id=quest.entry)
-
 
 SPELL_EFFECTS = {
     SpellEffects.SPELL_EFFECT_SCHOOL_DAMAGE: SpellEffectHandler.handle_school_damage,

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -41,7 +41,8 @@ class SpellEffectHandler:
             SpellEffects.SPELL_EFFECT_RESURRECT, # Resurrection requires a dead target.
             SpellEffects.SPELL_EFFECT_SUMMON_OBJECT_WILD,  # Allow spells to summon an object on creature death.
             SpellEffects.SPELL_EFFECT_SUMMON_WILD, # Allow spells to summon another creature on creature death.
-            SPELL_EFFECT_SCHOOL_DAMAGE # Allow spells to deal damage after a creature's death.
+            SPELL_EFFECT_SCHOOL_DAMAGE, # Allow spells to deal damage after a creature's death.
+            SPELL_EFFECT_APPLY_AURA # Allow spells to apply an aura to the corpse (poison cloud for example).
         }
 
         from game.world.managers.objects.units.UnitManager import UnitManager


### PR DESCRIPTION
Closes #391

https://www.youtube.com/watch?v=u40MvjTpZZQ

- Adds spell effect handler for effect "Summon object wild"
- Allow SPELL_EFFECT_SUMMON_OBJECT_WILD to run on dead targets via an effect whitelist
- Sets faction of summoned object to the one set in the GO's template instead of caster if it's a chest (otherwise it can't be interacted with)