### PR TITLE
Pet

### DIFF
--- a/game/world/WorldManager.py
+++ b/game/world/WorldManager.py
@@ -235,7 +235,7 @@ class WorldServerSessionHandler:
         player_update_known_object_scheduler = BackgroundScheduler()
         player_update_known_object_scheduler._daemon = True
         player_update_known_object_scheduler.add_job(WorldSessionStateHandler.update_known_players_objects, 'interval',
-                                                     seconds=0.5, max_instances=1)
+                                                     seconds=0.5, max_instances=4)
         player_update_known_object_scheduler.start()
 
         # Creature updates.

--- a/game/world/WorldManager.py
+++ b/game/world/WorldManager.py
@@ -235,7 +235,7 @@ class WorldServerSessionHandler:
         player_update_known_object_scheduler = BackgroundScheduler()
         player_update_known_object_scheduler._daemon = True
         player_update_known_object_scheduler.add_job(WorldSessionStateHandler.update_known_players_objects, 'interval',
-                                                     seconds=0.5, max_instances=4)
+                                                     seconds=0.5, max_instances=1)
         player_update_known_object_scheduler.start()
 
         # Creature updates.

--- a/game/world/WorldSessionStateHandler.py
+++ b/game/world/WorldSessionStateHandler.py
@@ -92,17 +92,18 @@ class WorldSessionStateHandler(object):
     def update_players():
         now = time.time()
         for session in WORLD_SESSIONS:
-            if session.player_mgr and session.player_mgr.online:
-                if not session.player_mgr.update_lock:
-                    session.player_mgr.update(now)
+            if session.player_mgr and session.player_mgr.online and not session.player_mgr.update_lock:
+                session.player_mgr.update(now)
 
     @staticmethod
     def update_known_players_objects():
         for session in WORLD_SESSIONS:
-            if session.player_mgr and session.player_mgr.online:
-                if not session.player_mgr.update_lock and session.player_mgr.update_known_objects_on_tick:
-                    session.player_mgr.update_known_objects_on_tick = False
-                    session.player_mgr.update_known_world_objects()
+            if not session.player_mgr or not session.player_mgr.online:
+                continue
+            if session.player_mgr.update_lock or not session.player_mgr.update_known_objects_on_tick:
+                continue
+            session.player_mgr.update_known_objects_on_tick = False
+            session.player_mgr.update_known_world_objects()
 
     @staticmethod
     def save_characters():

--- a/game/world/managers/CommandManager.py
+++ b/game/world/managers/CommandManager.py
@@ -191,7 +191,8 @@ class CommandManager(object):
 
         if location:
             tel_location = Vector(location.x, location.y, location.z, location.o)
-            success = world_session.player_mgr.teleport(location.map, tel_location)
+            success = world_session.player_mgr.teleport(location.map, tel_location,
+                                                        is_instant=location.map == world_session.player_mgr.map_id)
 
             if success:
                 return 0, f'Teleported to "{location.name}".'

--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -26,18 +26,12 @@ class GridManager:
         if not world_object_spawn and not world_object_instance:
             Logger.warning(f'Spawn object called with None arguments.')
 
-    def update_object(self, world_object, old_map, has_changes=False, has_inventory_changes=False):
+    def update_object(self, world_object, has_changes=False, has_inventory_changes=False):
         source_cell_key = world_object.current_cell
         current_cell_key = CellUtils.get_cell_key_for_object(world_object)
 
-        # Handle teleport between different maps.
-        if old_map and old_map != self:
-            # Remove from old location.
-            old_map.remove_object(world_object)
-            # Add to new location.
-            self._add_world_object(world_object)
         # Handle cell change within the same map.
-        elif current_cell_key != source_cell_key:
+        if current_cell_key != source_cell_key:
             # Remove from old location and Add to new location.
             if source_cell_key:
                 self.remove_object(world_object, update_players=False)
@@ -59,7 +53,7 @@ class GridManager:
                 world_object.inventory.reset_fields_older_than(now)
 
         # Notify cell changed if needed.
-        if old_map and old_map != self or current_cell_key != source_cell_key:
+        if current_cell_key != source_cell_key:
             world_object.on_cell_change()
 
     # Remove a world_object from its cell and notify surrounding players if required.

--- a/game/world/managers/maps/Map.py
+++ b/game/world/managers/maps/Map.py
@@ -65,8 +65,8 @@ class Map:
     def spawn_object(self, world_object_spawn=None, world_object_instance=None):
         self.grid_manager.spawn_object(world_object_spawn, world_object_instance)
 
-    def update_object(self, world_object, old_map, has_changes=False, has_inventory_changes=False):
-        self.grid_manager.update_object(world_object, old_map, has_changes, has_inventory_changes)
+    def update_object(self, world_object, has_changes=False, has_inventory_changes=False):
+        self.grid_manager.update_object(world_object, has_changes, has_inventory_changes)
 
     def remove_object(self, world_object, update_players=True):
         self.grid_manager.remove_object(world_object, update_players)

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -601,18 +601,9 @@ class MapManager:
 
     @staticmethod
     def update_object(world_object, has_changes=False, has_inventory_changes=False):
-        if world_object.current_cell:
-            key_split = world_object.current_cell.split(':')
-            old_map_id = int(key_split[-2])
-            old_instance_id = int(key_split[-1])
-            old_map = MapManager.get_map(old_map_id, old_instance_id)
-        else:
-            old_map = None
-
         map_ = MapManager.get_map_by_object(world_object)
         try:
-            map_.update_object(world_object, old_map, has_changes=has_changes,
-                               has_inventory_changes=has_inventory_changes)
+            map_.update_object(world_object, has_changes=has_changes, has_inventory_changes=has_inventory_changes)
         except AttributeError:
             Logger.warning(f'Did not find Map {world_object.map_id}, update_object()')
 

--- a/game/world/managers/objects/ai/PetAI.py
+++ b/game/world/managers/objects/ai/PetAI.py
@@ -28,8 +28,7 @@ class PetAI(CreatureAI):
         if self.move_state == PetMoveState.AT_RANGE and self.pending_spell_cast:
             spell_id, target = self.pending_spell_cast
             self.pending_spell_cast = None
-            if self.creature.combat_target:
-                self.do_spell_cast(spell_id, target, validate_range=False)
+            self.do_spell_cast(spell_id, target, validate_range=False)
 
         if owner.get_type_id() == ObjectTypeIds.ID_PLAYER:
             if self.creature.combat_target and not self.creature.combat_target.is_alive:

--- a/game/world/managers/objects/units/movement/MovementManager.py
+++ b/game/world/managers/objects/units/movement/MovementManager.py
@@ -142,15 +142,8 @@ class MovementManager:
     def move_to_point(self, location, speed=config.Unit.Defaults.walk_speed):
         self.spline_callback(SplineBuilder.build_normal_spline(self.unit, points=[location], speed=speed))
 
-    def pet_move_in_range(self, target, range_: SpellRange, delay: int):
-        pet_movement = self.movement_behaviors.get(MoveType.PET, None)
-        if pet_movement:
-            pet_movement.move_in_range(target=target, range_=range_, delay=delay)
-
-    def pet_move_stay(self, state):
-        pet_movement = self.movement_behaviors.get(MoveType.PET, None)
-        if pet_movement:
-            pet_movement.stay(state=state)
+    def get_move_behavior_by_type(self, move_type) -> Optional[BaseMovement]:
+        return self.movement_behaviors.get(move_type, None)
 
     # Instant.
     def stop(self):

--- a/game/world/managers/objects/units/movement/behaviors/PetMovement.py
+++ b/game/world/managers/objects/units/movement/behaviors/PetMovement.py
@@ -37,6 +37,8 @@ class PetMovement(BaseMovement):
         self.unit.object_ai.movement_inform(data=self.follow_state)
         if self.follow_state == PetMoveState.AT_HOME and not self.stay_position:
             charmer_or_summoner = self.unit.get_charmer_or_summoner()
+            if self.unit.location.o == charmer_or_summoner.location.o:
+                return
             self.unit.movement_manager.face_angle(charmer_or_summoner.location.o)
 
     # override

--- a/game/world/managers/objects/units/movement/behaviors/PetMovement.py
+++ b/game/world/managers/objects/units/movement/behaviors/PetMovement.py
@@ -1,4 +1,6 @@
 import math
+
+from game.world.managers.maps.helpers import CellUtils
 from game.world.managers.objects.units.movement.helpers.PetRangeMove import PetRangeMove
 from game.world.managers.objects.units.movement.helpers.SplineBuilder import SplineBuilder
 from utils.constants.MiscCodes import MoveType
@@ -116,4 +118,10 @@ class PetMovement(BaseMovement):
 
         self.home_position = target_location.get_point_in_radius_and_angle(PetMovement.PET_FOLLOW_DISTANCE,
                                                                            PetMovement.PET_FOLLOW_ANGLE)
+
+        # Near teleport if lagging above cell size, this can probably be less or half cell.
+        if current_distance > CellUtils.CELL_SIZE:
+            self.unit.near_teleport(self.home_position)
+            return False, None
+
         return True, self.home_position

--- a/game/world/managers/objects/units/movement/behaviors/PetMovement.py
+++ b/game/world/managers/objects/units/movement/behaviors/PetMovement.py
@@ -90,6 +90,10 @@ class PetMovement(BaseMovement):
                 or (self.spline and self.spline.get_waypoint_location() == target_location):
             return False, None
 
+        # get_point_in_between can return None.
+        if not target_location:
+            return False, None
+
         self.pet_range_move.location = target_location
 
         return True, self.pet_range_move.location


### PR DESCRIPTION
- Move stay / move_in_range into PetMovement only.
- Remove pet active cast if commanded to stay / follow.
- Fix crash on PetMovement due None target location.
- Fix pet orientation fixation after killing a unit.
- Fix MapManager issue introduced at https://github.com/The-Alpha-Project/alpha-core/pull/869 when decoupling Map/Grid/Cell, objects should no longer be continuously removed and added from cells.
- PetMovement - Use a near teleport if lagging beyond cell size.