### PR TITLE
The Night Watch part 1 quest restoration

### DIFF
--- a/game/world/managers/objects/script/ScriptHandler.py
+++ b/game/world/managers/objects/script/ScriptHandler.py
@@ -175,14 +175,6 @@ class ScriptHandler:
         self.last_hp_event_id = -1
 
     def update(self):
-        for script in self.script_queue:
-            if time.time() - script.time_added >= script.delay:
-                ScriptHandler.handle_script(self, script)
-
-                # TODO: Removing item from list while iterating? Something doesn't look correct, please change.
-                if script in self.script_queue:
-                    self.script_queue.remove(script)
-
         if self.ooc_scripts:
             if self.ooc_next is not None and time.time() >= self.ooc_next and not self.ooc_running:
                 self.ooc_running = True
@@ -194,6 +186,12 @@ class ScriptHandler:
                     self.enqueue_ai_script(self.ooc_target, script)
 
                 self.ooc_running = False
+
+        for i, script in enumerate(self.script_queue):
+            if time.time() - script.time_added >= script.delay:
+                ScriptHandler.handle_script(self, script)
+                del self.script_queue[i]
+                break
 
     def handle_script_command_talk(self, script):
         # source = WorldObject

--- a/game/world/managers/objects/script/ScriptHandler.py
+++ b/game/world/managers/objects/script/ScriptHandler.py
@@ -175,6 +175,14 @@ class ScriptHandler:
         self.last_hp_event_id = -1
 
     def update(self):
+        for script in self.script_queue:
+            if time.time() - script.time_added >= script.delay:
+                ScriptHandler.handle_script(self, script)
+
+                # TODO: Removing item from list while iterating? Something doesn't look correct, please change.
+                if script in self.script_queue:
+                    self.script_queue.remove(script)
+
         if self.ooc_scripts:
             if self.ooc_next is not None and time.time() >= self.ooc_next and not self.ooc_running:
                 self.ooc_running = True
@@ -186,12 +194,6 @@ class ScriptHandler:
                     self.enqueue_ai_script(self.ooc_target, script)
 
                 self.ooc_running = False
-
-        for i, script in enumerate(self.script_queue):
-            if time.time() - script.time_added >= script.delay:
-                ScriptHandler.handle_script(self, script)
-                del self.script_queue[i]
-                break
 
     def handle_script_command_talk(self, script):
         # source = WorldObject


### PR DESCRIPTION
Closes #838 

- Restores "Shambling Skeleton" (entry 200) as a basic warrior mob without special abilities (as none are known).
- Changed spawn points for Skeletal Warriors and Mages to shared and also mix in Shambling Skeleton.
- Changes quest "The Night Watch (56) to match the original where it targeted three different enemies - Skeletal Warriors, Mages and Shambling Skeletons - but only 6 of each. Also changed monetary reward to 18s 78c (was 17s).
