### PR TITLE
Despawn GameObjects clearly not present in 0.5.3

### DIFF
--- a/game/world/managers/objects/script/ScriptHandler.py
+++ b/game/world/managers/objects/script/ScriptHandler.py
@@ -175,14 +175,6 @@ class ScriptHandler:
         self.last_hp_event_id = -1
 
     def update(self):
-        for script in self.script_queue:
-            if time.time() - script.time_added >= script.delay:
-                ScriptHandler.handle_script(self, script)
-
-                # TODO: Removing item from list while iterating? Something doesn't look correct, please change.
-                if script in self.script_queue:
-                    self.script_queue.remove(script)
-
         if self.ooc_scripts:
             if self.ooc_next is not None and time.time() >= self.ooc_next and not self.ooc_running:
                 self.ooc_running = True
@@ -194,6 +186,12 @@ class ScriptHandler:
                     self.enqueue_ai_script(self.ooc_target, script)
 
                 self.ooc_running = False
+
+        for i, script in enumerate(self.script_queue):
+            if time.time() - script.time_added >= script.delay:
+                ScriptHandler.handle_script(self, script)
+                del self.script_queue[i]
+                break
 
     def handle_script_command_talk(self, script):
         # source = WorldObject

--- a/game/world/managers/objects/script/ScriptHandler.py
+++ b/game/world/managers/objects/script/ScriptHandler.py
@@ -175,6 +175,14 @@ class ScriptHandler:
         self.last_hp_event_id = -1
 
     def update(self):
+        for script in self.script_queue:
+            if time.time() - script.time_added >= script.delay:
+                ScriptHandler.handle_script(self, script)
+
+                # TODO: Removing item from list while iterating? Something doesn't look correct, please change.
+                if script in self.script_queue:
+                    self.script_queue.remove(script)
+
         if self.ooc_scripts:
             if self.ooc_next is not None and time.time() >= self.ooc_next and not self.ooc_running:
                 self.ooc_running = True
@@ -186,12 +194,6 @@ class ScriptHandler:
                     self.enqueue_ai_script(self.ooc_target, script)
 
                 self.ooc_running = False
-
-        for i, script in enumerate(self.script_queue):
-            if time.time() - script.time_added >= script.delay:
-                ScriptHandler.handle_script(self, script)
-                del self.script_queue[i]
-                break
 
     def handle_script_command_talk(self, script):
         # source = WorldObject

--- a/game/world/managers/objects/script/ScriptHandler.py
+++ b/game/world/managers/objects/script/ScriptHandler.py
@@ -152,19 +152,17 @@ class ScriptHandler:
             self.enqueue_ai_script(self.ooc_target, script)
 
     def enqueue_scripts(self, source, target, script_type, entry_id):
-        if script_type in SCRIPT_TYPES:
+        try:
             scripts = SCRIPT_TYPES[script_type](entry_id)
-        else:
+        except IndexError:
             Logger.warning(f'Unhandled script type {script_type}.')
             return
 
-        if scripts:
-            from game.world.managers.objects.script.ScriptManager import ScriptManager
-            for script in scripts:
-                if script.condition_id > 0:
-                    if not ConditionChecker.check_condition(script.condition_id, self.object, target):
-                        continue
-                self.enqueue_ai_script(source, script, target=target)
+        for script in scripts:
+            if script.condition_id > 0:
+                if not ConditionChecker.check_condition(script.condition_id, self.object, target):
+                    continue
+            self.enqueue_ai_script(source, script, target=target)
 
     def reset(self):
         self.script_queue.clear()
@@ -181,6 +179,7 @@ class ScriptHandler:
             if time.time() - script.time_added >= script.delay:
                 ScriptHandler.handle_script(self, script)
 
+                # TODO: Removing item from list while iterating? Something doesn't look correct, please change.
                 if script in self.script_queue:
                     self.script_queue.remove(script)
 


### PR DESCRIPTION
This database update despawns trade skill related game objects clearly not present in the alpha:

- Herbs: Dreamfoil, Black Lotus, Golden Sansam, Gromsblood, Plaguebloom, Sungrass and Mountain Silversage
- Ore Veins: Thorium, True Silver

Update: I'll leave the chests alone for now.