### PR TITLE
Spell bug fixes

### DIFF
--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -576,6 +576,7 @@ FRIENDLY_IMPLICIT_TARGETS = {
 }
 
 NEUTRAL_IMPLICIT_TARGETS = {
+    SpellImplicitTargets.TARGET_INITIAL,
     SpellImplicitTargets.TARGET_EFFECT_SELECT,
     SpellImplicitTargets.TARGET_UNIT,
     SpellImplicitTargets.TARGET_SCRIPT

--- a/game/world/managers/objects/spell/SpellEffect.py
+++ b/game/world/managers/objects/spell/SpellEffect.py
@@ -160,7 +160,7 @@ class SpellEffect:
                 return not can_target_friendly and \
                        self.casting_spell.spell_caster.can_attack_target(self.casting_spell.initial_target)
 
-        return not can_target_friendly  # TODO this may not cover all cases.
+        return not can_target_friendly
 
     def is_target_immune(self, target):
         # Validate target and check harmfulness.

--- a/game/world/managers/objects/spell/aura/AppliedAura.py
+++ b/game/world/managers/objects/spell/aura/AppliedAura.py
@@ -26,11 +26,13 @@ class AppliedAura:
         for effect in casting_spell.get_effects():
             if effect.effect_index >= spell_effect.effect_index:
                 break
-            if effect.effect_type == SpellEffects.SPELL_EFFECT_APPLY_AURA and \
-                    effect.implicit_target_a == self.spell_effect.implicit_target_a:
-                # Some buffs/debuffs have multiple effects in one aura, in which case they're merged in the UI
-                # If this spell has an effect with a lower index already applies an aura,
-                # this aura is set to passive to not display twice in client.
+            if effect.effect_type != SpellEffects.SPELL_EFFECT_APPLY_AURA:
+                continue
+
+            # Some buffs/debuffs have multiple effects in one aura, in which case they're merged in the UI
+            # If this spell has an effect with a lower index that already applies an aura,
+            # this aura is set to passive to not display twice in client.
+            if self.target in effect.targets.get_resolved_effect_targets_by_type(type(self.target)):
                 self.passive = True
                 break
 

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -411,12 +411,9 @@ class UnitManager(ObjectManager):
         if damage_info.total_damage > 0:
             victim.spell_manager.check_spell_interrupts(received_auto_attack=True, hit_info=damage_info.hit_info)
 
-        # Victim will not die with this hit.
-        if not damage_info.hit_info & HitInfo.UNIT_DEAD:
-            # The hit was successful, check melee attack procs.
-            if damage_info.hit_info & HitInfo.SUCCESS:
-                self.handle_melee_attack_procs(damage_info)
-        else:  # Victim will die after this hit, reset extra attacks.
+        self.handle_melee_attack_procs(damage_info)
+
+        if damage_info.hit_info & HitInfo.UNIT_DEAD:
             self.extra_attacks = 0
 
         self.send_attack_state_update(damage_info)


### PR DESCRIPTION
* Fix resolving harmfulness for some creature spells (closes #948)
* Fix resolving passiveness for auras with differing spell target types but same targets (#948)
* Fix spell channel start being sent on a full miss (closes #951)
* Fix melee attack procs only being checked on successful hits (partially addresses #952)