### PR TITLE
Fixes.

### DIFF
--- a/database/world/WorldDatabaseManager.py
+++ b/database/world/WorldDatabaseManager.py
@@ -854,14 +854,14 @@ class WorldDatabaseManager(object):
     @staticmethod
     def quest_start_script_get_by_quest_id(quest_id):
         world_db_session = SessionHolder()
-        res = world_db_session.query(QuestStartScript).filter_by(quest_id=quest_id).all()
+        res = world_db_session.query(t_quest_start_scripts).filter_by(id=quest_id).all()
         world_db_session.close()
         return res
 
     @staticmethod
     def quest_end_script_get_by_quest_id(quest_id):
         world_db_session = SessionHolder()
-        res = world_db_session.query(QuestEndScript).filter_by(quest_id=quest_id).all()
+        res = world_db_session.query(t_quest_end_scripts).filter_by(id=quest_id).all()
         world_db_session.close()
         return res
 

--- a/database/world/WorldModels.py
+++ b/database/world/WorldModels.py
@@ -1151,60 +1151,58 @@ class CreatureAddon(Base):
     auras = Column(Text)
 
 
-class QuestStartScript(Base):
-    __tablename__ = 'quest_start_scripts'
+t_quest_start_scripts = Table(
+    'quest_start_scripts', metadata,
+    Column('id', MEDIUMINT, nullable=False, server_default=text("'0'")),
+    Column('delay', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('priority', TINYINT, nullable=False, server_default=text("'0'")),
+    Column('command', MEDIUMINT, nullable=False, server_default=text("'0'")),
+    Column('datalong', MEDIUMINT, nullable=False, server_default=text("'0'")),
+    Column('datalong2', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('datalong3', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('datalong4', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('target_param1', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('target_param2', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('target_type', TINYINT, nullable=False, server_default=text("'0'")),
+    Column('data_flags', TINYINT, nullable=False, server_default=text("'0'")),
+    Column('dataint', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('dataint2', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('dataint3', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('dataint4', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('x', Float, nullable=False, server_default=text("'0'")),
+    Column('y', Float, nullable=False, server_default=text("'0'")),
+    Column('z', Float, nullable=False, server_default=text("'0'")),
+    Column('o', Float, nullable=False, server_default=text("'0'")),
+    Column('condition_id', MEDIUMINT, nullable=False, server_default=text("'0'")),
+    Column('comments', String(255), nullable=False)
+)
 
-    id = Column(MEDIUMINT, primary_key=True, server_default=text("'0'"))
-    quest_id = Column(MEDIUMINT, nullable=False, server_default=text("'0'"))
-    delay = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    priority = Column(TINYINT, nullable=False, server_default=text("'0'"))
-    command = Column(MEDIUMINT, nullable=False, server_default=text("'0'"))
-    datalong = Column(MEDIUMINT, nullable=False, server_default=text("'0'"))
-    datalong2 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    datalong3 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    datalong4 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    target_param1 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    target_param2 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    target_type = Column(TINYINT, nullable=False, server_default=text("'0'"))
-    data_flags = Column(TINYINT, nullable=False, server_default=text("'0'"))
-    dataint = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    dataint2 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    dataint3 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    dataint4 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    x = Column(Float, nullable=False, server_default=text("'0'"))
-    y = Column(Float, nullable=False, server_default=text("'0'"))
-    z = Column(Float, nullable=False, server_default=text("'0'"))
-    o = Column(Float, nullable=False, server_default=text("'0'"))
-    condition_id = Column(MEDIUMINT, nullable=False, server_default=text("'0'"))
-    comments = Column(String(255))
 
-
-class QuestEndScript(Base):
-    __tablename__ = 'quest_end_scripts'
-
-    id = Column(MEDIUMINT, primary_key=True, server_default=text("'0'"))
-    quest_id = Column(MEDIUMINT, nullable=False, server_default=text("'0'"))
-    delay = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    priority = Column(TINYINT, nullable=False, server_default=text("'0'"))
-    command = Column(MEDIUMINT, nullable=False, server_default=text("'0'"))
-    datalong = Column(MEDIUMINT, nullable=False, server_default=text("'0'"))
-    datalong2 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    datalong3 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    datalong4 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    target_param1 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    target_param2 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    target_type = Column(TINYINT, nullable=False, server_default=text("'0'"))
-    data_flags = Column(TINYINT, nullable=False, server_default=text("'0'"))
-    dataint = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    dataint2 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    dataint3 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    dataint4 = Column(INTEGER, nullable=False, server_default=text("'0'"))
-    x = Column(Float, nullable=False, server_default=text("'0'"))
-    y = Column(Float, nullable=False, server_default=text("'0'"))
-    z = Column(Float, nullable=False, server_default=text("'0'"))
-    o = Column(Float, nullable=False, server_default=text("'0'"))
-    condition_id = Column(MEDIUMINT, nullable=False, server_default=text("'0'"))
-    comments = Column(String(255))
+t_quest_end_scripts = Table(
+    'quest_end_scripts', metadata,
+    Column('id', MEDIUMINT, nullable=False, server_default=text("'0'")),
+    Column('delay', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('priority', TINYINT, nullable=False, server_default=text("'0'")),
+    Column('command', MEDIUMINT, nullable=False, server_default=text("'0'")),
+    Column('datalong', MEDIUMINT, nullable=False, server_default=text("'0'")),
+    Column('datalong2', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('datalong3', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('datalong4', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('target_param1', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('target_param2', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('target_type', TINYINT, nullable=False, server_default=text("'0'")),
+    Column('data_flags', TINYINT, nullable=False, server_default=text("'0'")),
+    Column('dataint', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('dataint2', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('dataint3', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('dataint4', INTEGER, nullable=False, server_default=text("'0'")),
+    Column('x', Float, nullable=False, server_default=text("'0'")),
+    Column('y', Float, nullable=False, server_default=text("'0'")),
+    Column('z', Float, nullable=False, server_default=text("'0'")),
+    Column('o', Float, nullable=False, server_default=text("'0'")),
+    Column('condition_id', MEDIUMINT, nullable=False, server_default=text("'0'")),
+    Column('comments', String(255), nullable=False)
+)
 
 
 t_creature_movement_scripts = Table(

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -655,6 +655,35 @@ begin not atomic
 
         insert into applied_updates values ('140320231');
     end if;
+	
+    -- 15/03/2023 1
+	if(select count(*) from applied_updates where id = '150320231') = 0 then
+		UPDATE `quest_template` SET `SpecialFlags` = '1' WHERE (`entry` = '308');
+
+        DELETE FROM `quest_end_scripts` WHERE `id`=308;
+        INSERT INTO `quest_end_scripts` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`, `target_param1`, `target_param2`, `target_type`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+        (308, 0, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5600.98, -540.38, 392.42, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 3, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5597.71, -543.117, 392.42, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 5, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5598.95, -549.48, 395.48, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 6, 0, 81, 1037, 60, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Distracting Jarven: Guarded Thunder Ale Barrel - Despawn'),
+        (308, 6, 0, 9, 35875, 60, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Distracting Jarven: Unguarded Thunder Ale Barrel - Respawn'),
+        (308, 8, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5605.31, -549.33, 399.09, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 11, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5607.55, -546.63, 399.09, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 13, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5597.52, -538.75, 399.09, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 19, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5597.62, -530.24, 399.65, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 23, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5603.67, -529.91, 399.65, 3.16, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 125, 0, 0, 0, 0, 0, 0, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Say Text'),
+        (308, 41, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5597.62, -530.24, 399.65, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 43, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5597.52, -539.75, 399.09, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 46, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5607.55, -545.63, 399.09, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 51, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5605.31, -549.33, 399.09, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 54, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5598, -549.326, 395.48, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 57, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5597.59, -543.05, 392.42, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 60, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5599.94, -540.04, 392.42, 0, 0, 'Distracting Jarven: Jarven Thunderbrew - Move'),
+        (308, 63, 0, 3, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, -5605.96, -544.45, 392.43, 0.9, 0, 'Distracting Jarven: Jarven Thunderbrew - Move');
+		
+        insert into applied_updates values ('150320231');
+    end if;
 
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -646,11 +646,5 @@ begin not atomic
         insert into applied_updates values ('130320231');
     end if;
 	
-    -- 14/03/2023 1
-    if(select count(*) from applied_updates where id = '140320232') = 0 then
-		-- Spanwed by quest_end_script 308.
-        UPDATE `alpha_world`.`spawns_gameobjects` SET `ignored` = '1' WHERE (`spawn_id` = '35875');       
-        insert into applied_updates values ('140320232');
-    end if;		
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -621,6 +621,31 @@ begin not atomic
         insert into applied_updates values ('130320232');
     end if;
 	
+	-- 13/03/2023 1
+    if(select count(*) from applied_updates where id = '130320231') = 0 then
+
+        -- Set guesstimated display_id for Timber.
+        update creature_template set display_id1 = 720 where entry = 1132;
+
+        -- Set display_id for Captured Leper Gnome. Since there are only 4
+        -- leper gnome display_ids available and he spawns as a random one
+        -- out of 4 we'll just take all of them.
+        update creature_template set display_id1 = 1101, display_id2 = 2490, display_id3 = 352, display_id4 = 836 where entry = 5568;
+
+        -- Also fix Captured Leper Gnome's Z as he's supposed to stand in the cage,
+        -- not below it.
+        update spawns_creatures set position_z = 397 where spawn_id = 186;
+
+        -- Fix faction for several NPCs in Ironforge (was 1217):
+        -- Bogus Thunderbrew <Food and Drink>
+        -- Lana Thunderbrew <Blacksmithing Supplies>
+        -- Jonivera Farmountain <Cartography Trainer>
+        -- Svalbrad Farmountain <Cartography Supplier>
+        update creature_template set faction = 57 where entry in(4255, 4257, 5134, 5135);
+
+        insert into applied_updates values ('130320231');
+    end if;
+	
     -- 14/03/2023 1
     if(select count(*) from applied_updates where id = '140320232') = 0 then
 		-- Spanwed by quest_end_script 308.

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -621,7 +621,7 @@ begin not atomic
         insert into applied_updates values ('130320232');
     end if;
 	
-	-- 13/03/2023 1
+    -- 13/03/2023 1
     if(select count(*) from applied_updates where id = '130320231') = 0 then
 
         -- Set guesstimated display_id for Timber.

--- a/game/world/managers/CommandManager.py
+++ b/game/world/managers/CommandManager.py
@@ -145,7 +145,7 @@ class CommandManager(object):
             unit = CommandManager._target_or_self(world_session)
             if unit == world_session.player_mgr:
                 return -1, f'invalid unit selection.'
-            unit.movement_manager.move_waypoints_from_script()
+            unit.movement_manager.move_automatic_waypoints_from_script()
             return 0, ''
         except:
             return -1, 'invalid unit selection.'

--- a/game/world/managers/CommandManager.py
+++ b/game/world/managers/CommandManager.py
@@ -735,6 +735,17 @@ class CommandManager(object):
         return 0, f'{len(quests)} quests found.'
 
     @staticmethod
+    def qdel(world_session, args):
+        try:
+            quest_id = int(args)
+            player_mgr = CommandManager._target_or_self(world_session, only_players=True)
+            player_mgr.quest_manager.remove_quest(quest_id)
+
+            return 0, ''
+        except ValueError:
+            return -1, 'please specify a valid quest entry.'
+
+    @staticmethod
     def qadd(world_session, args):
         try:
             quest_id = int(args)
@@ -918,7 +929,8 @@ GM_COMMAND_DEFINITIONS = {
     'guildcreate': [CommandManager.guildcreate, 'create and join a guild'],
     'alltaxis': [CommandManager.alltaxis, 'discover all flightpaths'],
     'squest': [CommandManager.squest, 'search quests'],
-    'qadd': [CommandManager.qadd, 'adds a quest to your log']
+    'qadd': [CommandManager.qadd, 'adds a quest to your log'],
+    'qdel': [CommandManager.qdel, 'delete active or completed quest']
 }
 
 DEV_COMMAND_DEFINITIONS = {

--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -255,6 +255,13 @@ class GridManager:
                 return spawn_found
         return None
 
+    def get_gameobject_spawn_by_id(self, spawn_id):
+        for cell in set(self.cells.values()):
+            spawn_found = cell.gameobject_spawns.get(spawn_id)
+            if spawn_found:
+                return spawn_found
+        return None
+
     def _get_surrounding_creature_spawns(self, world_object):
         spawns = {}
         location = world_object.location
@@ -332,7 +339,7 @@ class GridManager:
         except KeyError:
             return None
 
-    def get_surrounding_gameobject_by_spawn_id(self, world_object, spawn_id_):
+    def get_surrounding_gameobject_spawn_by_spawn_id(self, world_object, spawn_id_):
         surrounding_gameobjects_spawns = self._get_surrounding_gameobjects_spawns(world_object)
         try:
             return surrounding_gameobjects_spawns[spawn_id_]

--- a/game/world/managers/maps/Map.py
+++ b/game/world/managers/maps/Map.py
@@ -45,7 +45,7 @@ class Map:
         length = len(gobject_spawns)
         for gobject_spawn in gobject_spawns:
             gameobject_spawn = GameObjectSpawn(gobject_spawn, instance_id=self.instance_id)
-            gameobject_spawn.spawn_gameobject()
+            gameobject_spawn.spawn()
             count += 1
             Logger.progress(f'Loading gameobjects Map {self.name}, Instance {self.instance_id}...', count, length)
 

--- a/game/world/managers/maps/Map.py
+++ b/game/world/managers/maps/Map.py
@@ -92,6 +92,9 @@ class Map:
     def get_creature_spawn_by_id(self, spawn_id):
         return self.grid_manager.get_creature_spawn_by_id(spawn_id)
 
+    def get_gameobject_spawn_by_id(self, spawn_id):
+        return self.grid_manager.get_gameobject_spawn_by_id(spawn_id)
+
     def get_surrounding_units_by_location(self, vector, target_map, target_instance, range_, include_players=False):
         return self.grid_manager.get_surrounding_units_by_location(vector, target_map, target_instance, range_, include_players)
 
@@ -113,8 +116,8 @@ class Map:
     def get_surrounding_gameobject_by_guid(self, world_object, guid):
         return self.grid_manager.get_surrounding_gameobject_by_guid(world_object, guid)
 
-    def get_surrounding_gameobject_by_spawn_id(self, world_object, spawn_id):
-        return self.grid_manager.get_surrounding_gameobject_by_spawn_id(world_object, spawn_id)
+    def get_surrounding_gameobject_spawn_by_spawn_id(self, world_object, spawn_id):
+        return self.grid_manager.get_surrounding_gameobject_spawn_by_spawn_id(world_object, spawn_id)
 
     def update_creatures(self):
         self.grid_manager.update_creatures()

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -653,6 +653,10 @@ class MapManager:
         return MapManager.get_map(map_id, instance_id).get_creature_spawn_by_id(spawn_id)
 
     @staticmethod
+    def get_gameobject_spawn_by_id(map_id, instance_id, spawn_id):
+        return MapManager.get_map(map_id, instance_id).get_gameobject_spawn_by_id(spawn_id)
+
+    @staticmethod
     def get_surrounding_creature_spawn_by_spawn_id(world_object, spawn_id):
         return MapManager.get_map_by_object(world_object).get_surrounding_creature_spawn_by_spawn_id(
             world_object, spawn_id)
@@ -691,8 +695,8 @@ class MapManager:
         return MapManager.get_map_by_object(world_object).get_surrounding_gameobject_by_guid(world_object, guid)
 
     @staticmethod
-    def get_surrounding_gameobject_by_spawn_id(world_object, spawn_id):
-        return MapManager.get_map_by_object(world_object).get_surrounding_gameobject_by_spawn_id(world_object, spawn_id)
+    def get_surrounding_gameobject_spawn_by_spawn_id(world_object, spawn_id):
+        return MapManager.get_map_by_object(world_object).get_surrounding_gameobject_spawn_by_spawn_id(world_object, spawn_id)
 
     @staticmethod
     def update_creatures():

--- a/game/world/managers/objects/ObjectManager.py
+++ b/game/world/managers/objects/ObjectManager.py
@@ -64,6 +64,7 @@ class ObjectManager:
 
         self.initialized = False
         self.is_spawned = True
+        self.is_default = True
         self.summoner = None
         self.charmer = None
         self.current_cell = ''
@@ -369,15 +370,23 @@ class ObjectManager:
         pass
 
     # override
-    def destroy(self):
+    def despawn(self):
         self.is_spawned = False
+        if self.spell_manager:
+            self.spell_manager.remove_casts()
         if self.object_ai:
             self.object_ai.just_despawned()
-        MapManager.remove_object(self)
+        # Destroy completely.
+        if self.is_default:
+            MapManager.remove_object(self)
+            return
+        # Despawn (De-activate)
+        MapManager.update_object(self, has_changes=True)
 
     # override
     def respawn(self):
-        pass
+        self.is_spawned = True
+        MapManager.update_object(world_object=self, has_changes=True)
 
     # override
     def is_above_water(self):

--- a/game/world/managers/objects/ObjectManager.py
+++ b/game/world/managers/objects/ObjectManager.py
@@ -370,14 +370,14 @@ class ObjectManager:
         pass
 
     # override
-    def despawn(self):
+    def despawn(self, ttl=0):
         self.is_spawned = False
         if self.spell_manager:
             self.spell_manager.remove_casts()
         if self.object_ai:
             self.object_ai.just_despawned()
         # Destroy completely.
-        if self.is_default:
+        if self.is_default and not ttl:
             MapManager.remove_object(self)
             return
         # Despawn (De-activate)

--- a/game/world/managers/objects/corpse/CorpseManager.py
+++ b/game/world/managers/objects/corpse/CorpseManager.py
@@ -81,7 +81,7 @@ class CorpseManager(ObjectManager):
             elapsed = now - self.last_tick
             self.ttl -= elapsed
             if self.ttl <= 0:
-                self.destroy()
+                self.despawn()
         self.last_tick = now
 
     @staticmethod

--- a/game/world/managers/objects/dynamic/DynamicObjectManager.py
+++ b/game/world/managers/objects/dynamic/DynamicObjectManager.py
@@ -53,7 +53,7 @@ class DynamicObjectManager(ObjectManager):
             if self.ttl > 0:
                 self.ttl = max(0, self.ttl - elapsed)
                 if self.ttl == 0:
-                    self.destroy()
+                    self.despawn()
 
         self.last_tick = now
 

--- a/game/world/managers/objects/gameobjects/GameObjectBuilder.py
+++ b/game/world/managers/objects/gameobjects/GameObjectBuilder.py
@@ -10,13 +10,14 @@ class GameObjectBuilder:
 
     @staticmethod
     def create(entry_id, location, map_id, instance_id, state, summoner=None, rot0=0, rot1=0, rot2=0, rot3=0, faction=0,
-               spell_id=0, ttl=0, spawn_id=0):
+               spell_id=0, ttl=0, spawn_id=0, is_spawned=True):
 
         gobject_template = WorldDatabaseManager.GameobjectTemplateHolder.gameobject_get_by_entry(entry_id)
         if not gobject_template:
             return None
 
         gameobject_instance = GameObjectManager()
+        gameobject_instance.is_spawned = is_spawned
         gameobject_instance.spawn_id = spawn_id
         gameobject_instance.entry = gobject_template.entry
         gameobject_instance.guid = gameobject_instance.generate_object_guid(GameObjectBuilder.GUID_MANAGER.get_new_guid())
@@ -43,19 +44,4 @@ class GameObjectBuilder:
         if summoner:
             gameobject_instance.flags |= GameObjectFlags.TRIGGERED
 
-        return gameobject_instance
-
-    @staticmethod
-    def create_from_spawn_id(spawn_id, instance_id, ttl=0):
-        gameobject_spawn = WorldDatabaseManager.gameobject_spawn_get_by_spawn_id(spawn_id)
-        location = Vector(gameobject_spawn.spawn_positionX, gameobject_spawn.spawn_positionY,
-                          gameobject_spawn.spawn_positionZ, gameobject_spawn.spawn_orientation)
-        gameobject_instance = GameObjectBuilder.create(gameobject_spawn.spawn_entry, location,
-                                                       gameobject_spawn.spawn_map, instance_id,
-                                                       gameobject_spawn.spawn_state,
-                                                       rot0=gameobject_spawn.spawn_rotation0,
-                                                       rot1=gameobject_spawn.spawn_rotation1,
-                                                       rot2=gameobject_spawn.spawn_rotation2,
-                                                       rot3=gameobject_spawn.spawn_rotation3,
-                                                       ttl=ttl)
         return gameobject_instance

--- a/game/world/managers/objects/gameobjects/GameObjectBuilder.py
+++ b/game/world/managers/objects/gameobjects/GameObjectBuilder.py
@@ -1,5 +1,4 @@
 from database.world.WorldDatabaseManager import WorldDatabaseManager
-from game.world.managers.abstractions.Vector import Vector
 from game.world.managers.objects.gameobjects.GameObjectManager import GameObjectManager
 from game.world.managers.objects.guids.GuidManager import GuidManager
 from utils.constants.MiscFlags import GameObjectFlags
@@ -10,13 +9,14 @@ class GameObjectBuilder:
 
     @staticmethod
     def create(entry_id, location, map_id, instance_id, state, summoner=None, rot0=0, rot1=0, rot2=0, rot3=0, faction=0,
-               spell_id=0, ttl=0, spawn_id=0, is_spawned=True):
+               spell_id=0, ttl=0, spawn_id=0, is_spawned=True, is_default=False):
 
         gobject_template = WorldDatabaseManager.GameobjectTemplateHolder.gameobject_get_by_entry(entry_id)
         if not gobject_template:
             return None
 
         gameobject_instance = GameObjectManager()
+        gameobject_instance.is_default = is_default
         gameobject_instance.is_spawned = is_spawned
         gameobject_instance.spawn_id = spawn_id
         gameobject_instance.entry = gobject_template.entry

--- a/game/world/managers/objects/gameobjects/GameObjectBuilder.py
+++ b/game/world/managers/objects/gameobjects/GameObjectBuilder.py
@@ -1,7 +1,6 @@
 from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.managers.objects.gameobjects.GameObjectManager import GameObjectManager
 from game.world.managers.objects.guids.GuidManager import GuidManager
-from utils.constants.MiscFlags import GameObjectFlags
 
 
 class GameObjectBuilder:

--- a/game/world/managers/objects/gameobjects/GameObjectBuilder.py
+++ b/game/world/managers/objects/gameobjects/GameObjectBuilder.py
@@ -1,4 +1,5 @@
 from database.world.WorldDatabaseManager import WorldDatabaseManager
+from game.world.managers.abstractions.Vector import Vector
 from game.world.managers.objects.gameobjects.GameObjectManager import GameObjectManager
 from game.world.managers.objects.guids.GuidManager import GuidManager
 from utils.constants.MiscFlags import GameObjectFlags
@@ -42,4 +43,19 @@ class GameObjectBuilder:
         if summoner:
             gameobject_instance.flags |= GameObjectFlags.TRIGGERED
 
+        return gameobject_instance
+
+    @staticmethod
+    def create_from_spawn_id(spawn_id, instance_id, ttl=0):
+        gameobject_spawn = WorldDatabaseManager.gameobject_spawn_get_by_spawn_id(spawn_id)
+        location = Vector(gameobject_spawn.spawn_positionX, gameobject_spawn.spawn_positionY,
+                          gameobject_spawn.spawn_positionZ, gameobject_spawn.spawn_orientation)
+        gameobject_instance = GameObjectBuilder.create(gameobject_spawn.spawn_entry, location,
+                                                       gameobject_spawn.spawn_map, instance_id,
+                                                       gameobject_spawn.spawn_state,
+                                                       rot0=gameobject_spawn.spawn_rotation0,
+                                                       rot1=gameobject_spawn.spawn_rotation1,
+                                                       rot2=gameobject_spawn.spawn_rotation2,
+                                                       rot3=gameobject_spawn.spawn_rotation3,
+                                                       ttl=ttl)
         return gameobject_instance

--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -398,7 +398,7 @@ class GameObjectManager(ObjectManager):
         return True
 
     # override
-    def despawn(self):
+    def despawn(self, ttl=0):
         self.unlocked_by.clear()
         super().despawn()
 

--- a/game/world/managers/objects/gameobjects/GameObjectManager.py
+++ b/game/world/managers/objects/gameobjects/GameObjectManager.py
@@ -164,7 +164,7 @@ class GameObjectManager(ObjectManager):
     def handle_loot_release(self, player):
         # On loot release, always despawn the fishing bobber regardless of it still having loot or not.
         if self.gobject_template.type == GameObjectTypes.TYPE_FISHINGNODE:
-            self.destroy()
+            self.despawn()
             return
 
         if self.loot_manager:
@@ -174,7 +174,7 @@ class GameObjectManager(ObjectManager):
                 if self.loot_manager.has_loot():
                     self.set_ready()
                 else:  # Despawn or destroy.
-                    self.destroy()
+                    self.despawn()
             # Mining node.
             else:
                 self.mining_node_manager.handle_looted(player)
@@ -393,20 +393,14 @@ class GameObjectManager(ObjectManager):
             self.time_to_live_timer -= elapsed
             # Time to live expired, destroy.
             if self.time_to_live_timer <= 0:
-                self.destroy()
+                self.despawn()
                 return False
         return True
 
     # override
-    def destroy(self):
-        if self.spell_manager:
-            self.spell_manager.remove_casts()
+    def despawn(self):
         self.unlocked_by.clear()
-        super().destroy()
-
-    # override
-    def respawn(self):
-        pass
+        super().despawn()
 
     # override
     def update(self, now):

--- a/game/world/managers/objects/gameobjects/GameObjectSpawn.py
+++ b/game/world/managers/objects/gameobjects/GameObjectSpawn.py
@@ -24,9 +24,6 @@ class GameObjectSpawn:
 
     def update(self, now):
         if now > self.last_tick > 0:
-            if not self.is_default:
-                return
-
             elapsed = now - self.last_tick
             gameobject = self.gameobject_instance
             if gameobject:
@@ -52,10 +49,13 @@ class GameObjectSpawn:
 
         MapManager.spawn_object(world_object_spawn=self, world_object_instance=self.gameobject_instance)
 
-    def despawn(self):
+    def despawn(self, ttl=0):
         if not self.gameobject_instance or not self.gameobject_instance.is_spawned:
             return
-        self.gameobject_instance.despawn()
+        if ttl:
+            self.respawn_timer = 0
+            self.respawn_time = ttl
+        self.gameobject_instance.despawn(ttl=ttl)
 
     def _generate_gameobject_instance(self, ttl=0):
         gameobject_template_id = self._generate_gameobject_template()
@@ -80,6 +80,8 @@ class GameObjectSpawn:
         return gameobject_instance
 
     def _update_respawn(self, elapsed):
+        if self.respawn_time <= 0:
+            return
         self.respawn_timer += elapsed
         # Spawn a new gameobject instance when needed.
         if self.respawn_timer >= self.respawn_time:

--- a/game/world/managers/objects/gameobjects/managers/GooberManager.py
+++ b/game/world/managers/objects/gameobjects/managers/GooberManager.py
@@ -10,6 +10,6 @@ class GooberManager(object):
         if self.has_custom_animation:
             self.goober_object.send_custom_animation(0)
         if self.is_consumable:
-            self.goober_object.destroy()
+            self.goober_object.despawn()
         if self.quest_id:
             player.quest_manager.handle_goober_use(self.goober_object, self.quest_id)

--- a/game/world/managers/objects/gameobjects/managers/MiningNodeManager.py
+++ b/game/world/managers/objects/gameobjects/managers/MiningNodeManager.py
@@ -18,7 +18,7 @@ class MiningNodeManager(object):
 
         # Max attempts, despawn.
         if self.attempts >= max_amount:
-            self.mining_node.destroy()
+            self.mining_node.despawn()
             return
 
         # 100% chance until min uses.
@@ -36,7 +36,7 @@ class MiningNodeManager(object):
 
         # Failed chance roll, despawn.
         if not succeed_roll:
-            self.mining_node.destroy()
+            self.mining_node.despawn()
             return
 
         # Node still alive, regenerate loot.

--- a/game/world/managers/objects/gameobjects/managers/TrapManager.py
+++ b/game/world/managers/objects/gameobjects/managers/TrapManager.py
@@ -49,7 +49,7 @@ class TrapManager(object):
             # Valid target found, trigger the trap. In case charges = 1, despawn the trap.
             if self.trigger(unit) and self.charges == 1:
                 self.trap_object.set_active()
-                self.trap_object.destroy()
+                self.trap_object.despawn()
             break
 
     def trigger(self, who):

--- a/game/world/managers/objects/script/Script.py
+++ b/game/world/managers/objects/script/Script.py
@@ -12,11 +12,13 @@ class Script:
         self.script_handler = script_handler
         self.delay: float = delay
         self.time_added: float = time.time()
+        self.started = False
 
     def update(self, now):
         # Check initial delay for command sequence.
         if now - self.time_added < self.delay:
             return
+        self.started = True
 
         for script_command in list(self.commands):
             # Check if it's time to execute the command action.
@@ -35,7 +37,6 @@ class Script:
 
             # Execute action.
             self.script_handler.handle_script_command_execution(script_command)
-            break
 
     def abort(self):
         self.commands.clear()

--- a/game/world/managers/objects/script/ScriptHandler.py
+++ b/game/world/managers/objects/script/ScriptHandler.py
@@ -294,7 +294,7 @@ class ScriptHandler:
         if not go_spawn:
             Logger.warning(f'ScriptHandler: No gameobject {command.datalong} found, aborting {command.get_info()}.')
             return
-        go_spawn.spawn()
+        go_spawn.spawn(ttl=command.datalong2)
 
     @staticmethod
     def handle_script_command_temp_summon_creature(command):

--- a/game/world/managers/objects/script/ScriptHandler.py
+++ b/game/world/managers/objects/script/ScriptHandler.py
@@ -290,11 +290,11 @@ class ScriptHandler:
         # target = GameObject (from datalong, provided source or target)
         # datalong = db_guid
         # datalong2 = despawn_delay
-        from game.world.managers.objects.gameobjects.GameObjectBuilder import GameObjectBuilder
-        gameobject = GameObjectBuilder.create_from_spawn_id(spawn_id=command.datalong,
-                                                            instance_id=command.source.instance_id,
-                                                            ttl=command.datalong2)
-        MapManager.spawn_object(world_object_instance=gameobject)
+        go_spawn = MapManager.get_surrounding_gameobject_by_spawn_id(command.source, command.datalong)
+        if not go_spawn:
+            Logger.warning(f'ScriptHandler: No gameobject {command.datalong} found, aborting {command.get_info()}.')
+            return
+        go_spawn.spawn()
 
     @staticmethod
     def handle_script_command_temp_summon_creature(command):

--- a/game/world/managers/objects/script/ScriptHandler.py
+++ b/game/world/managers/objects/script/ScriptHandler.py
@@ -239,7 +239,6 @@ class ScriptHandler:
         if angle:
             command.source.movement_manager.set_face_angle(angle)
         if location:
-
             command.source.movement_manager.move_to_point(location, speed)
 
     # TODO: This is not compatible with 0.5.3.

--- a/game/world/managers/objects/script/ScriptManager.py
+++ b/game/world/managers/objects/script/ScriptManager.py
@@ -125,7 +125,7 @@ class ScriptManager:
     @staticmethod
     def handle_gameobject_with_guid(caster, target=None, param1=None, param2=None, spell_template=None):
         spawn_id: Optional[int] = param1
-        spawn = MapManager.get_surrounding_gameobject_by_spawn_id(caster, spawn_id)
+        spawn = MapManager.get_surrounding_gameobject_spawn_by_spawn_id(caster, spawn_id)
         if not spawn or not spawn.gameobject_instance or not spawn.gameobject_instance.is_spawned:
             return None
         return spawn.gameobject_instance

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -590,7 +590,7 @@ class SpellManager:
         casting_spell.cast_state = SpellState.SPELL_STATE_FINISHED
 
         if casting_spell.dynamic_object:
-            casting_spell.dynamic_object.destroy()
+            casting_spell.dynamic_object.despawn()
         [effect.area_aura_holder.destroy() for effect in casting_spell.get_effects() if effect.area_aura_holder]
 
         # Cancel auras applied by an active spell if the spell was interrupted.

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -308,13 +308,18 @@ class UnitManager(ObjectManager):
     def attack_update(self, elapsed):
         # Don't update melee swing timers while casting, stunned, pacified or fleeing..
         if not self.can_perform_melee_attack():
+            # Timers must be updated when out of combat.
+            if not self.in_combat:
+                self.update_attack_timers(elapsed)
             return False
 
+        self.update_attack_timers(elapsed)
+        return self.update_melee_attacking_state()
+
+    def update_attack_timers(self, elapsed):
         self.update_attack_time(AttackTypes.BASE_ATTACK, elapsed * 1000.0)
         if self.has_offhand_weapon():
             self.update_attack_time(AttackTypes.OFFHAND_ATTACK, elapsed * 1000.0)
-
-        return self.update_melee_attacking_state()
 
     def update_melee_attacking_state(self):
         # Don't update melee swing timers while casting, stunned, pacified or fleeing..

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -1609,7 +1609,7 @@ class UnitManager(ObjectManager):
         return True
 
     # override
-    def destroy(self):
+    def despawn(self):
         # Make sure to remove casts from units that are destroyed but not necessarily killed. e.g. Totems.
         if self.spell_manager:
             self.spell_manager.remove_casts()
@@ -1626,7 +1626,7 @@ class UnitManager(ObjectManager):
                 charmer.spell_manager.unlock_spell_cooldown(summon_spell)
 
         self.is_alive = False
-        super().destroy()
+        super().despawn()
 
         charmer_or_summoner = self.get_charmer_or_summoner()
         # Detach from controller if this unit is an active pet and the summoner is a unit

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -700,6 +700,14 @@ class CreatureManager(UnitManager):
             self.on_at_home()
         return True
 
+    def set_npc_flag(self, flag, state):
+        if not state:
+            self.npc_flags &= ~flag
+        else:
+            self.npc_flags |= flag
+        self.bytes_1 = self.get_bytes_1()
+        self.set_uint32(UnitFields.UNIT_FIELD_BYTES_1, self.bytes_1)
+
     # override
     def get_name(self):
         return self.creature_template.name

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -546,7 +546,7 @@ class CreatureManager(UnitManager):
         if self.summoner and not self.is_alive and self.is_spawned and self.initialized:
             self.destroy_timer += elapsed
             if self.destroy_timer >= self.destroy_time:
-                self.destroy()
+                self.despawn()
                 return False
         return True
 
@@ -555,7 +555,7 @@ class CreatureManager(UnitManager):
             self.time_to_live_timer -= elapsed
             # Time to live expired, destroy.
             if self.time_to_live_timer <= 0:
-                self.destroy()
+                self.despawn()
                 return False
         return True
 

--- a/game/world/managers/objects/units/creature/CreatureSpawn.py
+++ b/game/world/managers/objects/units/creature/CreatureSpawn.py
@@ -92,7 +92,7 @@ class CreatureSpawn:
         # Destroy the current creature instance body when respawn timer is about to expire.
         if self.creature_instance and self.creature_instance.is_spawned:
             if self.respawn_timer >= self.respawn_time * 0.8:
-                self.creature_instance.destroy()
+                self.creature_instance.despawn()
                 self.creature_instance = None
 
         # Spawn a new creature instance when needed.

--- a/game/world/managers/objects/units/creature/groups/CreatureGroupManager.py
+++ b/game/world/managers/objects/units/creature/groups/CreatureGroupManager.py
@@ -79,7 +79,7 @@ class CreatureGroupManager:
         if self.group_flags & CreatureGroupFlags.OPTION_RESPAWN_ALL_ON_ANY_EVADE or \
                 (self.group_flags & CreatureGroupFlags.OPTION_RESPAWN_ALL_ON_MASTER_EVADE and leader_evade):
             for guid, member in self.members.items():
-                member.creature.destroy()
+                member.creature.despawn()
             self.disband()
         elif self.group_flags & CreatureGroupFlags.OPTION_EVADE_TOGETHER:
             for guid, member in self.members.items():

--- a/game/world/managers/objects/units/creature/groups/CreatureGroupManager.py
+++ b/game/world/managers/objects/units/creature/groups/CreatureGroupManager.py
@@ -97,8 +97,9 @@ class CreatureGroupManager:
         return self.group_flags & CreatureGroupFlags.OPTION_FORMATION_MOVE
 
     def _get_sorted_waypoints_by_distance(self, movement_waypoints) -> list[MovementWaypoint]:
-        points = [MovementWaypoint(wp) for wp in movement_waypoints]  # Wrap them.
-        closest = min(points, key=lambda wp: self.leader.spawn_position.distance(wp.location()))
+        points = [MovementWaypoint(wp.point, wp.position_x, wp.position_y, wp.position_z, wp.orientation,
+                                   wp.waittime / 1000, wp.script_id) for wp in movement_waypoints]  # Wrap them.
+        closest = min(points, key=lambda wp: self.leader.spawn_position.distance(wp.location))
         index = points.index(closest)
         if index:
             points = points[index:] + points[0:index]

--- a/game/world/managers/objects/units/movement/MovementManager.py
+++ b/game/world/managers/objects/units/movement/MovementManager.py
@@ -67,18 +67,16 @@ class MovementManager:
             MapManager.send_surrounding(movement_packet, self.unit, include_self=self.is_player)
 
     def flush(self):
-        self._remove_invalid_expired_behaviors()
+        self.reset(clean_behaviors=True)
         for move_type in self.movement_behaviors.keys():
             self.movement_behaviors[move_type] = None
-        self.stop()
 
     def reset(self, clean_behaviors=False):
         self.pause_ooc_timer = 0
         # If currently moving, update the current spline in order to have latest guessed position before flushing.
         spline = self._get_current_spline()
         if spline:
-            spline.update_to_now()
-            self.stop()
+            self.stop(force=True)
         self.unit.movement_spline = None
         if clean_behaviors:
             self._remove_invalid_expired_behaviors()
@@ -148,8 +146,8 @@ class MovementManager:
         return self.movement_behaviors.get(move_type, None)
 
     # Instant.
-    def stop(self):
-        if not self.unit.is_moving():
+    def stop(self, force=False):
+        if not force and not self.unit.is_moving():
             return
         current_behavior = self._get_current_behavior()
         # Make sure the current behavior spline does not update an extra tick.

--- a/game/world/managers/objects/units/movement/MovementManager.py
+++ b/game/world/managers/objects/units/movement/MovementManager.py
@@ -1,3 +1,4 @@
+import time
 from typing import Optional
 
 from game.world.managers.maps.MapManager import MapManager
@@ -137,11 +138,11 @@ class MovementManager:
             return
         self.set_behavior(FearMovement(duration_seconds, spline_callback=self.spline_callback))
 
-    def move_waypoints_from_script(self):
+    def move_automatic_waypoints_from_script(self):
         self.set_behavior(WaypointMovement(spline_callback=self.spline_callback))
 
     def move_to_point(self, location, speed=config.Unit.Defaults.walk_speed):
-        self.spline_callback(SplineBuilder.build_normal_spline(self.unit, points=[location], speed=speed))
+        self.set_behavior(WaypointMovement(spline_callback=self.spline_callback, waypoints=[location], speed=speed))
 
     def get_move_behavior_by_type(self, move_type) -> Optional[BaseMovement]:
         return self.movement_behaviors.get(move_type, None)

--- a/game/world/managers/objects/units/movement/behaviors/GroupMovement.py
+++ b/game/world/managers/objects/units/movement/behaviors/GroupMovement.py
@@ -1,6 +1,5 @@
 from game.world.managers.maps.helpers import CellUtils
 from utils.ConfigManager import config
-from utils.Logger import Logger
 from utils.constants.MiscCodes import MoveType, ScriptTypes
 
 from game.world.managers.objects.units.movement.helpers.SplineBuilder import SplineBuilder
@@ -41,9 +40,9 @@ class GroupMovement(BaseMovement):
             return
         current_wp = self._get_waypoint()
         self._waypoint_push_back()
-        if current_wp.script_id():
+        if current_wp.script_id:
             self.unit.script_handler.enqueue_script(self.unit, self.unit, ScriptTypes.SCRIPT_TYPE_CREATURE_MOVEMENT,
-                                                    current_wp.script_id())
+                                                    current_wp.script_id)
 
     # override
     def reset(self):
@@ -62,8 +61,8 @@ class GroupMovement(BaseMovement):
     def _perform_waypoint(self):
         waypoint = self._get_waypoint()
         speed = config.Unit.Defaults.walk_speed
-        spline = SplineBuilder.build_normal_spline(self.unit, points=[waypoint.location()], speed=speed,
-                                                   extra_time_seconds=waypoint.wait_time_seconds())
+        spline = SplineBuilder.build_normal_spline(self.unit, points=[waypoint.location], speed=speed,
+                                                   extra_time_seconds=waypoint.wait_time_seconds)
         self.spline_callback(spline, movement_behavior=self)
 
     def _perform_follow_movement(self, elapsed):

--- a/game/world/managers/objects/units/movement/behaviors/WaypointMovement.py
+++ b/game/world/managers/objects/units/movement/behaviors/WaypointMovement.py
@@ -47,7 +47,7 @@ class WaypointMovement(BaseMovement):
         self.unit.spawn_position = new_position.copy()
         if waypoint_completed:
             current_wp = self._get_waypoint()
-            if current_wp.orientation and current_wp.wait_time_seconds:
+            if current_wp.orientation and (current_wp.wait_time_seconds or not self.is_default):
                 self.unit.movement_manager.face_angle(current_wp.orientation)
             if current_wp.script_id:
                 self.unit.script_handler.enqueue_script(self.unit, self.unit, ScriptTypes.SCRIPT_TYPE_CREATURE_MOVEMENT,

--- a/game/world/managers/objects/units/movement/behaviors/WaypointMovement.py
+++ b/game/world/managers/objects/units/movement/behaviors/WaypointMovement.py
@@ -1,5 +1,4 @@
 from utils.ConfigManager import config
-from utils.Logger import Logger
 from utils.constants.MiscCodes import MoveType, ScriptTypes
 
 from database.world.WorldDatabaseManager import WorldDatabaseManager
@@ -9,9 +8,11 @@ from game.world.managers.objects.units.movement.behaviors.BaseMovement import Ba
 
 
 class WaypointMovement(BaseMovement):
-    def __init__(self, spline_callback, is_default=False):
+    def __init__(self, spline_callback, is_default=False, waypoints=None, speed=0):
         super().__init__(move_type=MoveType.WAYPOINTS, spline_callback=spline_callback, is_default=is_default)
         self.creature_movement = None
+        self.speed = speed
+        self.points = waypoints
         self.waypoints: list[MovementWaypoint] = []
         self.last_waypoint_movement = 0
         self.wait_time_seconds = 0
@@ -19,6 +20,9 @@ class WaypointMovement(BaseMovement):
     # override
     def initialize(self, unit):
         super().initialize(unit)
+        if self.points:
+            self.waypoints = self._movement_waypoints_from_vectors(self.points)
+            return True
         self.creature_movement = WorldDatabaseManager.CreatureMovementHolder.get_waypoints_for_creature(unit)
         if self.creature_movement:
             self.creature_movement.sort(key=lambda wp: wp.point)
@@ -43,11 +47,11 @@ class WaypointMovement(BaseMovement):
         self.unit.spawn_position = new_position.copy()
         if waypoint_completed:
             current_wp = self._get_waypoint()
-            if current_wp.orientation() and current_wp.wait_time_seconds() != 0:
-                self.unit.movement_manager.face_angle(current_wp.orientation())
-            if current_wp.script_id():
+            if current_wp.orientation and current_wp.wait_time_seconds:
+                self.unit.movement_manager.face_angle(current_wp.orientation)
+            if current_wp.script_id:
                 self.unit.script_handler.enqueue_script(self.unit, self.unit, ScriptTypes.SCRIPT_TYPE_CREATURE_MOVEMENT,
-                                                        current_wp.script_id())
+                                                        current_wp.script_id)
             # If this is a default behavior, make it cyclic.
             if self.is_default:
                 self._waypoint_push_back()
@@ -61,19 +65,32 @@ class WaypointMovement(BaseMovement):
         self.wait_time_seconds = 0
         self.last_waypoint_movement = 0
 
+    # override
+    def can_remove(self):
+        return not self.unit.is_alive or (not self.waypoints and not self.spline)
+
     def _can_perform_waypoint(self, now):
         return self.waypoints and not self.spline and now > self.last_waypoint_movement + self.wait_time_seconds
 
     def _perform_waypoint(self):
         waypoint = self._get_waypoint()
-        speed = config.Unit.Defaults.walk_speed
-        spline = SplineBuilder.build_normal_spline(self.unit, points=[waypoint.location()], speed=speed,
-                                                   extra_time_seconds=waypoint.wait_time_seconds())
+        speed = config.Unit.Defaults.walk_speed if not self.speed else self.speed
+        spline = SplineBuilder.build_normal_spline(self.unit, points=[waypoint.location], speed=speed,
+                                                   extra_time_seconds=waypoint.wait_time_seconds)
         self.spline_callback(spline, movement_behavior=self)
 
+    # noinspection PyMethodMayBeStatic
+    def _movement_waypoints_from_vectors(self, points):
+        movement_waypoints = []
+        for index, point in enumerate(points):
+            wp = MovementWaypoint(index, point.x, point.y, point.z, point.o, wait_time_seconds=0)
+            movement_waypoints.append(wp)
+        return movement_waypoints
+
     def _get_sorted_waypoints_by_distance(self, movement_waypoints) -> list[MovementWaypoint]:
-        points = [MovementWaypoint(wp) for wp in movement_waypoints]  # Wrap them.
-        closest = min(points, key=lambda wp: self.unit.spawn_position.distance(wp.location()))
+        points = [MovementWaypoint(wp.point, wp.position_x, wp.position_y, wp.position_z, wp.orientation,
+                                   wp.waittime / 1000, wp.script_id) for wp in movement_waypoints]  # Wrap them.
+        closest = min(points, key=lambda wp: self.unit.spawn_position.distance(wp.location))
         index = points.index(closest)
         if index:
             points = points[index:] + points[0:index]
@@ -86,7 +103,4 @@ class WaypointMovement(BaseMovement):
         waypoint = self.waypoints[0]
         self.waypoints.remove(waypoint)
         self.waypoints.append(waypoint)
-
-    def can_remove(self):
-        return not self.unit.is_alive or not self.waypoints
 

--- a/game/world/managers/objects/units/movement/helpers/MovementWaypoint.py
+++ b/game/world/managers/objects/units/movement/helpers/MovementWaypoint.py
@@ -1,27 +1,10 @@
-from database.world.WorldModels import CreatureMovement
 from game.world.managers.abstractions.Vector import Vector
 
 
 class MovementWaypoint:
-    def __init__(self, creature_movement):
-        self.creature_movement: CreatureMovement = creature_movement
-        self._location = self._get_location()
-
-    def _get_location(self):
-        movement = self.creature_movement
-        return Vector(movement.position_x, movement.position_y, movement.position_z)
-
-    def id(self):
-        return self.creature_movement.point
-
-    def orientation(self):
-        return self.creature_movement.orientation
-
-    def location(self):
-        return self._location
-
-    def wait_time_seconds(self):
-        return self.creature_movement.waittime / 1000
-
-    def script_id(self):
-        return self.creature_movement.script_id
+    def __init__(self, id, x, y, z, orientation, wait_time_seconds, script_id=0):
+        self.id = id
+        self.script_id = script_id
+        self.location = Vector(x,y,z)
+        self.orientation = orientation
+        self.wait_time_seconds = wait_time_seconds

--- a/game/world/managers/objects/units/pet/ActivePet.py
+++ b/game/world/managers/objects/units/pet/ActivePet.py
@@ -154,7 +154,7 @@ class ActivePet:
 
         # Orphan creature. In some cases, the creature may already be destroyed.
         if self.creature.is_spawned and not self.creature.spawn_id:
-            self.creature.destroy()
+            self.creature.despawn()
 
         # Releasing a pet. Restore state.
         if self.is_permanent() or not self.is_controlled():

--- a/game/world/managers/objects/units/player/quest/ActiveQuest.py
+++ b/game/world/managers/objects/units/player/quest/ActiveQuest.py
@@ -282,10 +282,6 @@ class ActiveQuest:
         else:
             self.update_quest_state(QuestState.QUEST_ACCEPTED)
 
-    def requires_items(self):
-        req_items = list(filter((0).__ne__, QuestHelpers.generate_req_item_list(self.quest)))
-        return len(req_items) > 0
-
     def requires_item(self, item_entry):
         req_items = QuestHelpers.generate_req_item_list(self.quest)
         req_src_items = QuestHelpers.generate_req_source_list(self.quest)

--- a/game/world/managers/objects/units/player/quest/QuestHelpers.py
+++ b/game/world/managers/objects/units/player/quest/QuestHelpers.py
@@ -13,6 +13,11 @@ class QuestHelpers:
                not QuestHelpers.requires_items_or_gos(quest_template)
 
     @staticmethod
+    def requires_items(quest_template):
+        req_items = list(filter((0).__ne__, QuestHelpers.generate_req_item_list(quest_template)))
+        return len(req_items) > 0
+
+    @staticmethod
     def is_quest_repeatable(quest_template):
         return quest_template.SpecialFlags & QuestSpecialFlags.QUEST_SPECIAL_FLAG_REPEATABLE
 

--- a/game/world/managers/objects/units/player/quest/QuestManager.py
+++ b/game/world/managers/objects/units/player/quest/QuestManager.py
@@ -106,6 +106,20 @@ class QuestManager(object):
 
         return False
 
+    def remove_quest(self, quest_id):
+        if quest_id in self.active_quests:
+            self.remove_from_quest_log(quest_id)
+            return
+        if quest_id in self.completed_quests:
+            quest_db_states = RealmDatabaseManager.character_get_quests(self.player_mgr.guid)
+            for quest_db_state in quest_db_states:
+                if quest_db_state.quest != quest_id:
+                    continue
+                self.completed_quests.remove(quest_id)
+                RealmDatabaseManager.character_delete_quest(quest_db_state.guid, quest_id)
+                self.update_surrounding_quest_status()
+                break
+
     def get_dialog_status(self, quest_giver):
         dialog_status = QuestGiverStatus.QUEST_GIVER_NONE
         new_dialog_status = QuestGiverStatus.QUEST_GIVER_NONE

--- a/game/world/managers/objects/units/player/quest/QuestManager.py
+++ b/game/world/managers/objects/units/player/quest/QuestManager.py
@@ -842,7 +842,7 @@ class QuestManager(object):
                 self.send_quest_giver_request_items(quest, quest_giver_guid, close_on_cancel=False)
                 return
 
-        if quest_id in self.active_quests and self.active_quests[quest_id].requires_items():
+        if QuestHelpers.requires_items(quest):
             self.send_quest_giver_request_items(quest, quest_giver_guid, close_on_cancel=False)
         else:
             self.send_quest_giver_offer_reward(quest, quest_giver_guid, True)


### PR DESCRIPTION
- Closes #962.
- Use latest vmangos tables and fix db models. @mindphluxnet This will break your ScriptEditor changes (no PK for quest scripts).
- Fix out of order script commands.
- Fix move_to_point, it should not be an instant (spline only) action.
- Implement handle_script_command_respawn_gameobject.
- Fix quests dialog not displaying required items when the request comes from a non active quest.
- Fix movement splines ticking after dead.
- Fix combat timers always lingering at max value while out of combat.