### PR TITLE
Various fixes and Zone cleanup

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -885,6 +885,12 @@ begin not atomic
         update spawns_gameobjects set spawn_positionX = -3716.220, spawn_positionY = -800.334, spawn_positionZ = 26.48 where spawn_id = 14567;
         -- Fix placement of book "The Battle of Grim Batol" in Menethil Harbor
         update spawns_gameobjects set spawn_positionX = -3823.855, spawn_positionY = -836.920, spawn_positionZ = 18.22 where spawn_id = 14569;
+        -- Fix Z placement of Hargin Mundar
+        update spawns_creatures set position_z = 9.592 where spawn_id = 9535;
+        -- Fix Z placement of Innkeeper Helbrek
+        update spawns_creatures set position_z = 10.215 where spawn_id = 9460;
+        -- Fix Z placement of Junder Brokk
+        update spawns_creatures set position_z = 10.219 where spawn_id = 9526;
 
         insert into applied_updates values ('160320231');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -876,6 +876,8 @@ begin not atomic
         -- Set one Dragonmaw Scout's spawn to idle instead of waypoints.
         -- The waypoints are from vanilla and don't work with the alpha terrain.
         update spawns_creatures set movement_type = 0 where spawn_id = 9793;
+        -- Set faction for Cave Stalker to 22 (Spider).
+        update creature_template set faction = 22 where entry = 4040;
 
         insert into applied_updates values ('160320231');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -891,6 +891,8 @@ begin not atomic
         update spawns_creatures set position_z = 10.215 where spawn_id = 9460;
         -- Fix Z placement of Junder Brokk
         update spawns_creatures set position_z = 10.219 where spawn_id = 9526;
+        -- Fix Innkeeper Helbrok's inventory
+        update creature_template set vendor_id = 0 where entry = 1464;
 
         insert into applied_updates values ('160320231');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -883,6 +883,8 @@ begin not atomic
         update creature_ai_scripts set datalong = 4061 where id = 107301; -- Throw Dynamite (replaced by Coarse Dynamite)
         -- Fix placement of book "Charge of the Dragonflights" in Menethil Harbor
         update spawns_gameobjects set spawn_positionX = -3716.220, spawn_positionY = -800.334, spawn_positionZ = 26.48 where spawn_id = 14567;
+        -- Fix placement of book "The Battle of Grim Batol" in Menethil Harbor
+        update spawns_gameobjects set spawn_positionX = -3823.855, spawn_positionY = -836.920, spawn_positionZ = 18.22 where spawn_id = 14569;
 
         insert into applied_updates values ('160320231');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -881,6 +881,8 @@ begin not atomic
         -- Fix spells/abilities for Dun Modr siege dwarves.
         update creature_ai_scripts set datalong = 1485 where id in(107201, 107401); -- Shoot
         update creature_ai_scripts set datalong = 4061 where id = 107301; -- Throw Dynamite (replaced by Coarse Dynamite)
+        -- Fix placement of book "Charge of the Dragonflights" in Menethil Harbor
+        update spawns_gameobjects set spawn_positionX = -3716.220, spawn_positionY = -800.334, spawn_positionZ = 26.48 where spawn_id = 14567;
 
         insert into applied_updates values ('160320231');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -878,6 +878,9 @@ begin not atomic
         update spawns_creatures set movement_type = 0 where spawn_id = 9793;
         -- Set faction for Cave Stalker to 22 (Spider).
         update creature_template set faction = 22 where entry = 4040;
+        -- Fix spells/abilities for Dun Modr siege dwarves.
+        update creature_ai_scripts set datalong = 1485 where id in(107201, 107401); -- Shoot
+        update creature_ai_scripts set datalong = 4061 where id = 107301; -- Throw Dynamite (replaced by Coarse Dynamite)
 
         insert into applied_updates values ('160320231');
     end if;

--- a/game/world/managers/objects/spell/ExtendedSpellData.py
+++ b/game/world/managers/objects/spell/ExtendedSpellData.py
@@ -253,7 +253,8 @@ class UnitSpellsValidator:
         3131,  # Frost Breath
         3129,  # Frost Breath
         3143,  # Glacial Roar
-        7395  # Deadmines Dynamite
+        7395,  # Deadmines Dynamite
+        3335   # Dark Sludge
     }
 
     @staticmethod


### PR DESCRIPTION
Closes #979
Closes #974 
Closes #985 
Closes #987 
Closes #988 
Closes #989 
Closes #994 

## Zone cleanup

### Herbs
- despawn Purple Lotus, this herb was clearly not yet implemented as it has no model, no loot, and isn't pickable
- despawns the herb Arthas's Tears, same as above
- despawns Icecap, same as above
- despawns Blindweed, same as above

### Ironforge

- fix Grumnus Steelshaper's trainer_id to blacksmithing

### Eastern Plaguelands
- removes a (floating) campfire from Light's Hope Chapel, EPL. Reasoning: despite its rather low ID its placement is clearly not matching the terrain. It's also not visible on https://archive.thealphaproject.eu/media/Alpha-Project-Archive/Images/Azeroth/Eastern%20Kingdoms/Eastern%20Plaguelands/fb9bf0fd401fcbb4.jpg
- sets the faction for the EPL flight master to Human, Alliance. Reasoning: he's hostile to Horde in the screenshot linked above. Also sets his level to 55+. Reasoning: [see screenshot](https://archive.thealphaproject.eu/media/Alpha-Project-Archive/Images/Azeroth/Eastern%20Kingdoms/Eastern%20Plaguelands/IMG_EasternPlaugelands.jpg).
- despawn all instances of Rancid Meat/Big Rancid meat. Reasoning: all shane cubes and since EPL isn't remotely done they make no sense here
- despawn Tirion Fordring's Grave/Loose Dirt Mount, reasoning: used by NYI quest "Of Forgotten Memories"
- despawn all parts of Pamela's Doll, reasoning: used by NYI quest "Pamela's Doll"
- despawn all parts of a roadsign north of Darrowshire. Reasoning: the roadsign's post is at a different location and the signs themselves are all shane cubes
- despawn all parts of another roadsign in Corin's Crossing. Reasoning: this time the entire roadsign post is missing and the signs are again all shane cubes
- despawn all gameobjects related to a NYI paladin-only quest called "Exorcising Terrordale". Reasoning: it's NYI, and Terrordale doesn't even exist yet
- despawn Augustus' Receipt Book related to a NYI quest of the same name, reasoning: as above
- despawn all Mark of Detonation gameobjects. Reasoning: NYI quest and the terrain was changed later on so they aren't at their proper location
- despawn Quel'Thalas Registry object. Reasoning: the bench it's supposed to be sitting on is missing, and the quest is NYI

### Winterspring
- despawns loads of gameobjects from Winterspring, including Moontouched Feather and several misc. objects. Reasoning: Winterspring wasn't even remotely done yet, most of it is not terraformed and untextured. These items have no place there yet and most of them are floating in the air or stuck in the ground.

### Searing Gorge
- despawns a few campfires from Searing Gorge. Reasoning: they are clearly from vanilla data. Searing Gorge was opened fairly late and there's nothing there that warrants these campfires to exist. I left in one at a camp site as that one seems plausible.
- move Grisha ```<Binder>``` to Durotar. The "original" was floating in the air in Searing Gorge and the copy was at the correct spot in Durotar so I flipped their location and despawned the Searing Gorge version.
- despawn any gameobject related to the vanilla quests "Trinkets ..." and "The Torch of Retribution". Reasoning: as above, Searing Gorge wasn't open for players in 0.5.3. Even though the IDs are pretty low it makes absolutely no sense for Blizzard to put them there that early, especially since all of them are Shane Cubes. Any screenshots we've got are from way later than 0.5.3. Also, the Torch of Retribution/Light of Retribution objects aren't static spawns either, they get summoned by a script and shouldn't be there.
- despawn two floating objects (Stone Anvil and Forge) from Searing Gorge. Reasoning: due to Searing Gorge not yet complete the terrain doesn't match the object Z so they have no reason to exist yet.
- despawn "Singed Letter" object floating in the air. Reasoning: related to a not yet implemented quest. Also, it's floating in the air so the terrain wasn't done yet.
- despawn "Goodsteel Ledger" object. Reasoning: it's spawned by a quest from the outhouse so it's not a static spawn. The outhouse should probably be removed as well but I wasn't sure about that. The quest doesn't yet exist though so the click handling script effect is missing.

### Azshara
- despawns a Solid Chest standing out in the open. Reasoning: Azshara was unfinished and this chest must have bled in from vanilla where it stood in a camp
- despawn all gameobjects related to the quests "Stealing Knowledge" and "Fragments of the Past". Reasoning: not yet implemented
- despawn Ani, a Shane Cube floating in the ruins. Not even Wowhead knows what this should have been.

### Western Plaguelands
- despawn Redpath's Shield and associated visual effect: Reasoning: vanilla bleed-in, the quest isn't implemented yet

### Silithus
- despawn all gameobjects related to some kind of door between Silithus and the later Ahn'Quiraj. Reasoning: I'm pretty sure this was the door broken down when the gong was rang during the opening event but considering the terrain wasn't even in its final state yet it's more than unlikely these GO's were already there in 0.5.3

### Un'goro Crater
- despawn all Power Crystals, including decorative ones at Marshall's Refuge. Reasoning: they had various uses in vanilla but none of them are already implemented. Un'goro is completely unfinished so it makes no sense to have them spawned already. They also don't have a model yet.

### Felwood
- despawn Corrupted Songflower, Whipper Root, Night  Dragon and Windblossom. Reasoning: all of these corrupted plants could be cleansed using 2x Cenarion Salve for a small XP gain. Each of them have individual quests attached but except for two Windblossoms none of these quests are actually in our database. Not that it would matter as Cenarion Salve is NYI either. All plants have no model.

### Feralas
- despawn several objects (campfire, cauldron) from the area that houses Dire Maul in the future. Reasoning: until Dire Maul was released during vanilla this area was empty except for some animals
- fix Jardenvis Seawatcher to actually be a Crawler Trainer instead of a reagent vendor. Reasoning: he got repurposed as a vendor in vanilla.

### Loch Modan
- fix position of object "Suspicious Barrel" at Stonewrough Dam. Reasoning: terrain changes made this float in the air, it was also not close to the dam's wall any more.

### Wetlands
- set proper placeholder display_id for Dragonmaw Scout. Reasoning: while we don't have any pictures of them they'd likely use the same placeholder display_id as Dragonmaw Grunts (which is used for all other Dragonmaw orcs).
- set movement type for one Dragonmaw Scout's spawn to idle. Reasoning: he uses waypoint movement but due to terrain changes the waypoints don't work and the unit is either running into walls or falling from the sky.
- set faction for Cave Stalker to 22 (spider)
- added spell "Dark Sludge" to precast blacklist. Reasoning: client crash.
- fix spells/abilities of Dun Modr siege dwarves. Reasoning: their scripts were using NYI spells, I've replaced them with identical ones that are implemented
- fix placement of two books in Menethil Harbor. Reasoning: environment changes in vanilla made them float.
- fix Z placement for Hargin Mundar, Innkeeper Helbrek and Junder Brokk. Reasoning: all of them are in the inn of Menethil Harbor; seems the Inn model was changed in vanilla.
- fix Innkeeper Helbrok's inventory. Reasoning: he was assigned a non-existing inventory but his real inventory was fortunately preserved.
