### PR TITLE
Miscfixes2

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -696,6 +696,8 @@ begin not atomic
         -- Wetlands
         -- Fix Naela Trance, she's a vendor, not a trainer.
         update creature_template set npc_flags = 1 where entry = 1459;
+        -- Fix Fen Creeper's display_id according to sniffs.
+        update creature_template set display_id1 = 2023 where entry = 1040;
 
         insert into applied_updates values ('190320231');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -690,5 +690,15 @@ begin not atomic
 
         insert into applied_updates values ('150320232');
     end if;
+
+    -- 19/03/2023 1
+    if(select count(*) from applied_updates where id = '190320231') = 0 then
+        -- Wetlands
+        -- Fix Naela Trance, she's a vendor, not a trainer.
+        update creature_template set npc_flags = 1 where entry = 1459;
+
+        insert into applied_updates values ('190320231');
+    end if;
+
 end $
 delimiter ;

--- a/game/world/managers/objects/script/ScriptHandler.py
+++ b/game/world/managers/objects/script/ScriptHandler.py
@@ -72,9 +72,9 @@ class ScriptHandler:
             self.script_queue.remove(script)
 
         # Check if we need to initialize or remove ooc event.
-        self._check_occ_event(now)
+        self._check_ooc_event(now)
 
-    def _check_occ_event(self, now):
+    def _check_ooc_event(self, now):
         if not self.ooc_event or self.owner.in_combat or self.owner.is_evading:
             return
         # Check if we should remove the ongoing ooc event.

--- a/game/world/managers/objects/script/ScriptHandler.py
+++ b/game/world/managers/objects/script/ScriptHandler.py
@@ -64,19 +64,12 @@ class ScriptHandler:
     def update(self, now):
         # Update scripts, each one can contain multiple script actions.
         for script in list(self.script_queue):
-            # TODO: Fix modify flags command.
-            if not script.started and self.is_quest_giver:
-                self.owner.set_npc_flag(NpcFlags.NPC_FLAG_QUESTGIVER, state=False)
 
             script.update(now)
             if not script.is_complete():
                 continue
             # Finished all actions, remove.
             self.script_queue.remove(script)
-
-            # TODO: Fix modify flags command.
-            if self.is_quest_giver:
-                self.owner.set_npc_flag(NpcFlags.NPC_FLAG_QUESTGIVER, state=True)
 
         # Check if we need to initialize or remove ooc event.
         self._check_occ_event(now)

--- a/game/world/managers/objects/script/ScriptHandler.py
+++ b/game/world/managers/objects/script/ScriptHandler.py
@@ -1113,6 +1113,12 @@ class ScriptHandler:
         # dataint1-4 = chance (total cant be above 100)
         Logger.debug('ScriptHandler: handle_script_command_start_script_on_group not implemented yet')
 
+    @staticmethod
+    def handle_script_command_call_for_help(command):
+        # source = Creature
+        # x = radius
+        Logger.debug('ScriptHandler: handle_script_command_call_for_help not implemented yet')
+
     # Script types.
 
     @staticmethod
@@ -1233,12 +1239,12 @@ SCRIPT_COMMANDS = {
     ScriptCommands.SCRIPT_COMMAND_RESET_DOOR_OR_BUTTON: ScriptHandler.handle_script_command_reset_door_or_button,
     ScriptCommands.SCRIPT_COMMAND_SET_COMMAND_STATE: ScriptHandler.handle_script_command_set_command_state,
     ScriptCommands.SCRIPT_COMMAND_PLAY_CUSTOM_ANIM: ScriptHandler.handle_script_command_play_custom_anim,
-    ScriptCommands.SCRIPT_COMMAND_START_SCRIPT_ON_GROUP: ScriptHandler.handle_script_command_start_script_on_group
+    ScriptCommands.SCRIPT_COMMAND_START_SCRIPT_ON_GROUP: ScriptHandler.handle_script_command_start_script_on_group,
+    ScriptCommands.SCRIPT_COMMAND_CALL_FOR_HELP: ScriptHandler.handle_script_command_call_for_help,
     # Unused in 0.5.3.
     # ScriptCommands.SCRIPT_COMMAND_PLAY_SOUND: ScriptHandler.handle_script_command_play_sound
     # ScriptCommands.SCRIPT_COMMAND_SEND_TAXI_PATH: ScriptHandler.handle_script_command_send_taxi_path,
     # ScriptCommands.SCRIPT_COMMAND_ZONE_COMBAT_PULSE: ScriptHandler.handle_script_command_zone_combat_pulse,
-    # ScriptCommands.SCRIPT_COMMAND_CALL_FOR_HELP: ScriptHandler.handle_script_command_call_for_help,
     # ScriptCommands.SCRIPT_COMMAND_SET_FLY: ScriptHandler.handle_script_command_set_fly
     # ScriptCommands.SCRIPT_COMMAND_SET_GOSSIP_MENU: ScriptHandler.handle_script_command_set_gossip_menu,
     # ScriptCommands.SCRIPT_COMMAND_MEETINGSTONE: ScriptHandler.handle_script_command_meeting_stone,

--- a/game/world/managers/objects/units/player/quest/QuestManager.py
+++ b/game/world/managers/objects/units/player/quest/QuestManager.py
@@ -777,8 +777,11 @@ class QuestManager(object):
         if req_src_item != 0:
             # Check if the required source item is the item quest starter, else check if we can add it to the inventory.
             if not quest_item_starter or quest_item_starter.entry != req_src_item:
-                if not self.player_mgr.inventory.add_item(req_src_item, count=req_src_item_count):
-                    return
+                # Don't try to add the req_src_item if the player already has it (for example from the
+                # previous quest step).
+                if not self.player_mgr.inventory.get_item_count(req_src_item):
+                    if not self.player_mgr.inventory.add_item(req_src_item, count=req_src_item_count):
+                        return
                 # If the quest source item isn't required for the quest, remove it.
                 if quest_item_starter:
                     self.player_mgr.inventory.remove_item(quest_item_starter.item_instance.bag,


### PR DESCRIPTION
Closes #998 
Closes #995 

- Fixes Naela Trance to be a vendor instead of a trainer. Reasoning: she has a vendor list attached but NPC_FLAGS were set to trainer.
- Fixes Fen Creeper's display_id according to sniffs. He's not a zombie but an elemental and the display_id used in vanilla is available in alpha as well.
- Revert change to scripting system that disabled the quest giver flag while a script was running as this caused the quest giver flag to be almost permanently off while an OOC script was waiting for its repeat. Scripts should instead toggle the flag themselves if needed.