### PR TITLE
Fix Angry Programmer Tweedle Dee

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -980,5 +980,13 @@ begin not atomic
         insert into applied_updates values ('210320231');
     end if;
 
+    -- 21/03/2023 2
+	if(select count(*) from applied_updates where id = '210320232') = 0 then
+		--Fix Angry Programmer Tweedle Dee <Testing>'s DisplayID
+		update creature_template set display_id1 = 1415 where entry = 128;
+
+		insert into applied_updates values ('210320232');
+	end if;
+
 end $
 delimiter ;


### PR DESCRIPTION
For some reason this summonable dev only NPC has it's DisplayID set to 0.
The correct DisplayID exists in 0.5.3 and other databases have it corrected.

## Sources
https://www.wowhead.com/classic/npc=128/angry-programmer-tweedle-dee
https://www.youtube.com/watch?v=op4JHRWl-rk