### PR TITLE
Barrens/Thousand Needles fixes

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -972,7 +972,7 @@ begin not atomic
         update spawns_gameobjects set ignored = 1 where spawn_id = 47693;
 
         -- Despawn several Horde Guards from the Barrens; the small camp they guard doesn't yet exist
-        update spawns_gameobjects set ignored = 1 where spawn_id in(19428, 19403, 19411, 19464);
+        update spawns_creatures set ignored = 1 where spawn_id in(19428, 19403, 19411, 19464);
         -- Despawn three floating Crude Brazier in the same nonexistant camp
         update spawns_gameobjects set ignored = 1 where spawn_id in(13443, 13491, 13470);
         -- Despawn a Barrel of Milk, same issue
@@ -1039,6 +1039,14 @@ begin not atomic
 
 		insert into applied_updates values ('210320232');
 	end if;
+
+    -- 22/03/2023 1
+    if(select count(*) from applied_updates where id = '220320231') = 0 then
+        -- Despawn unnamed object from Ratchets
+        update spawns_gameobjects set ignored = 1 where spawn_id = 12672;
+
+        insert into applied_updates values ('220320231');
+    end if;
 
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1046,6 +1046,8 @@ begin not atomic
         update spawns_gameobjects set ignored = 1 where spawn_id = 12672;
         -- Despawn duplicate Fire Totem from Barrens Lift
         update spawns_gameobjects set ignored = 1 where spawn_id = 17080;
+        -- Despawn Highperch Wyvern Egg from Thousand Needles, quest NYI
+        update spawns_gameobjects set ignored = 1 where spawn_entry = 175384;
 
         insert into applied_updates values ('220320232');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1040,12 +1040,12 @@ begin not atomic
 		insert into applied_updates values ('210320232');
 	end if;
 
-    -- 22/03/2023 1
-    if(select count(*) from applied_updates where id = '220320231') = 0 then
+    -- 22/03/2023 2
+    if(select count(*) from applied_updates where id = '220320232') = 0 then
         -- Despawn unnamed object from Ratchets
         update spawns_gameobjects set ignored = 1 where spawn_id = 12672;
 
-        insert into applied_updates values ('220320231');
+        insert into applied_updates values ('220320232');
     end if;
 
 end $

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1048,6 +1048,8 @@ begin not atomic
         update spawns_gameobjects set ignored = 1 where spawn_id = 17080;
         -- Despawn Highperch Wyvern Egg from Thousand Needles, quest NYI
         update spawns_gameobjects set ignored = 1 where spawn_entry = 175384;
+        -- Despawn Sunscorched Shell from Thousand Needles, quest NYI
+        update spawns_gameobjects set ignored = 1 where spawn_entry = 89635;
 
         insert into applied_updates values ('220320232');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1042,8 +1042,10 @@ begin not atomic
 
     -- 22/03/2023 2
     if(select count(*) from applied_updates where id = '220320232') = 0 then
-        -- Despawn unnamed object from Ratchets
+        -- Despawn unnamed object from Ratchet
         update spawns_gameobjects set ignored = 1 where spawn_id = 12672;
+        -- Despawn duplicate Fire Totem from Barrens Lift
+        update spawns_gameobjects set ignored = 1 where spawn_id = 17080;
 
         insert into applied_updates values ('220320232');
     end if;


### PR DESCRIPTION
- Despawn unnamed object from Ratchet. Reasoning: no idea what this would have been, didn't even have a name
- Despawn duplicate Fire Totem from Barrens Lift. Reasoning: is a WMO in 0.5.3
- Despawn Highperch Wyvern Egg from Thousand Needles, quest NYI
- Despawn Sunscorched Shell from Thousand Needles, quest NYI