### PR TITLE
DB update Alterac/Hinterlands/WPL/Badlands/Stonetalon

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1073,6 +1073,9 @@ begin not atomic
         update creature_template set display_id1 = 2606 where entry = 1852;
         -- Despawn Musty Tome and Musty Tome Trap, quest NYI
         update spawns_gameobjects set ignored = 1 where spawn_entry in(176152, 176151, 176150);
+        -- Additional Hearthglen fixes by @Geo-tp
+        update creature_template set display_id1 = 1611, display_id2 = 1612, display_id3 = 0, display_id4 = 0 where entry = 1839; -- Scarlet High Clerist
+        update creature_template set display_id1 = 1611, display_id2 = 1612, display_id3 = 0, display_id4 = 0 where entry = 1833; -- Scarlet Knight
 
         -- Hinterlands
         -- Despawn Wildkin Feather, quest NYI
@@ -1121,10 +1124,7 @@ begin not atomic
         -- Set gnome placeholder for Lotwill and Lucien Tosselwrench
         update creature_template set display_id1 = 2581 where entry in(2921, 2920);
 
-        -- Additional Hearthglen fixes by @Geo-tp
-        update creature_template set display_id1 = 1611, display_id2 = 1612, display_id3 = 0, display_id4 = 0 where entry = 1839; -- Scarlet High Clerist
-        update creature_template set display_id1 = 1611, display_id2 = 1612, display_id3 = 0, display_id4 = 0 where entry = 1833; -- Scarlet Knight
-
+        -- Stonetalon Mountains
         -- Fix quest pre-requisites for "Covert Ops: Alpha"
         update quest_template set ExclusiveGroup = -1079 where entry in(1077, 1074);
         update quest_template set PrevQuestId = 1077 where entry = 1079;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1138,11 +1138,6 @@ begin not atomic
         -- Set gnome placeholder for Lotwill and Lucien Tosselwrench
         update creature_template set display_id1 = 2581 where entry in(2921, 2920);
 
-        -- Stonetalon Mountains
-        -- Fix quest pre-requisites for "Covert Ops: Alpha"
-        update quest_template set ExclusiveGroup = -1079 where entry in(1077, 1074);
-        update quest_template set PrevQuestId = 1077 where entry = 1079;
-
         -- Feralas
         -- Delete duplicate spawn for Tarhus <Binder>, his real position is in Barrens
         -- Closes #1029

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1040,5 +1040,14 @@ begin not atomic
 		insert into applied_updates values ('210320232');
 	end if;
 
+    -- 23/03/2023 1
+	if(select count(*) from applied_updates where id = '230320231') = 0 then
+        -- Set placeholder display_id for Glommus
+        update creature_template set display_id1 = 536 where entry = 2422;
+
+		insert into applied_updates values ('230320231');
+	end if;
+
+
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1135,6 +1135,7 @@ begin not atomic
         -- Feralas
         -- Delete duplicate spawn for Tarhus <Binder>, his real position is in Barrens
         -- Closes #1029
+        update spawns_creatures set position_x = -481.16, position_y = -2667.08, position_z = 99, orientation = 0.701327 where spawn_id = 50967;
         delete from spawns_creatures where spawn_id = 400049;
 
 		insert into applied_updates values ('230320231');

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1042,8 +1042,71 @@ begin not atomic
 
     -- 23/03/2023 1
 	if(select count(*) from applied_updates where id = '230320231') = 0 then
+        -- Herbalism nodes
+        update creature_template set display_id1 = 750 where entry = 2257;
+        -- Set placeholder display_id for Wintersbite
+        update gameobject_template set displayId = 28 where entry = 2044;
+        -- Set placeholder display_id for Khadgar's Whisker
+        update gameobject_template set displayId = 28 where entry = 2043;
+        -- Set placeholder display_id for Firebloom
+        update gameobject_template set displayId = 28 where entry = 2866;
+        -- Set size for Goldthorn and Firebloom to 0.5
+        update gameobject_template set size = 0.5 where entry in(2046, 2866);
+
+        -- Mining nodes
+        -- Enable Mithril Deposit to be mined at 155 skill
+        update gameobject_template set data0 = 42 where entry = 2040;
+
+	    -- Alterac Mountains
         -- Set placeholder display_id for Glommus
         update creature_template set display_id1 = 536 where entry = 2422;
+        -- Set placeholder display_id for Grel'Borg the Miser
+        update creature_template set display_id1 = 811 where entry = 2417;
+        -- Set placeholder display_id for Mug'thol
+
+        -- Western Plaguelands
+        -- Despawn Cauldron, Campfire and 2x Campfire Damage from future Argent Dawn camp in WPL
+        update spawns_gameobjects set ignored = 1 where spawn_id in(45306, 45307, 45322, 45323);
+        -- Despawn Andorhal Silo Temporal Rift objects, quest NYI
+        update spawns_gameobjects set ignored = 1 where spawn_entry = 175795;
+        -- Set placeholder display_id for Araj the Summoner
+        update creature_template set display_id1 = 2606 where entry = 1852;
+        -- Despawn Musty Tome and Musty Tome Trap, quest NYI
+        update spawns_gameobjects set ignored = 1 where spawn_entry in(176152, 176151, 176150);
+
+        -- Hinterlands
+        -- Despawn Wildkin Feather, quest NYI
+        update spawns_gameobjects set ignored = 1 where spawn_entry = 153239;
+        -- Set placeholder display_id for Mangy Silvermane, Silvermane Wolf and Silvermane Howler
+        update creature_template set display_id1 = 380 where entry in(2923, 2924, 2925);
+        -- Despawn Aerie Peak Town Center, quest NYI
+        update spawns_gameobjects set ignored = 1 where spawn_id = 21508;
+        -- Despawn Rin'ji's Cage, quest NYI
+        update spawns_gameobjects set ignored = 1 where spawn_id = 46065;
+        -- Set placeholder display_id for Jade Ooze
+        update creature_template set display_id1 = 1749 where entry = 2656;
+        -- Despawn Horde Supply Crate, quest NYI
+        update spawns_gameobjects set ignored = 1 where spawn_entry = 142191;
+        -- Fix Z of a floating Solid Chest
+        update spawns_gameobjects set spawn_positionZ = 117.825 where spawn_id = 46430;
+        -- Set proper (placeholder) faction for Vilebranch and Witherbark Trolls
+        update creature_template set faction = 16 where faction in(795, 654, 312);
+        -- Set placeholder display_id for Saltwater Snapjaw
+        update creature_template set display_id1 = 1244 where entry = 2505;
+        -- Despawn campfire from Hinterlands Beach
+        update spawns_gameobjects set ignored = 1 where spawn_id in(46038, 46037);
+
+        -- Badlands
+        -- Despawn two unused Wanted signs
+        update spawns_gameobjects set ignored = 1 where spawn_id in(10747, 10746);
+        -- Set placeholder display_id for Barnabus
+        update creature_template set display_id1 = 246 where entry = 2753;
+        -- Set placeholder display_id for Dustbelcher Warrior
+        update creature_template set display_id1 = 1120 where entry = 2906;
+        -- Despawn Short Wooden Seat from Uldaman exterior (was WMO in 0.5.3)
+        update spawns_gameobjects set ignored = 1 where spawn_id in(11272, 10927, 10922, 11245, 11246, 11279, 10923, 11273, 11264, 11259, 10936, 10921, 10920, 11278, 11260, 11261, 11274, 11243, 11254, 10917, 11242, 11250, 11249, 11267, 11244);
+        -- Despawn Magenta Cap Cluster and Magenta Cap Cluster Trap, quest NYI
+        update spawns_gameobjects set ignored = 1 where spawn_entry in(128293, 128196, 126049);
 
 		insert into applied_updates values ('230320231');
 	end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1043,7 +1043,6 @@ begin not atomic
     -- 23/03/2023 1
 	if(select count(*) from applied_updates where id = '230320231') = 0 then
         -- Herbalism nodes
-        update creature_template set display_id1 = 750 where entry = 2257;
         -- Set placeholder display_id for Wintersbite
         update gameobject_template set displayId = 28 where entry = 2044;
         -- Set placeholder display_id for Khadgar's Whisker
@@ -1063,6 +1062,7 @@ begin not atomic
         -- Set placeholder display_id for Grel'Borg the Miser
         update creature_template set display_id1 = 811 where entry = 2417;
         -- Set placeholder display_id for Mug'thol
+        update creature_template set display_id1 = 750 where entry = 2257;
 
         -- Western Plaguelands
         -- Despawn Cauldron, Campfire and 2x Campfire Damage from future Argent Dawn camp in WPL

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1129,6 +1129,9 @@ begin not atomic
         update quest_template set ExclusiveGroup = -1079 where entry in(1077, 1074);
         update quest_template set PrevQuestId = 1077 where entry = 1079;
 
+        -- Set "<Needs Reward>" to quest "Reception from Tyrande"
+        update quest_template set Title = "Reception from Tyrande <Needs Reward>" where entry = 1081;
+
 		insert into applied_updates values ('230320231');
 	end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1077,7 +1077,7 @@ begin not atomic
         -- Hinterlands
         -- Despawn Wildkin Feather, quest NYI
         update spawns_gameobjects set ignored = 1 where spawn_entry = 153239;
-        -- Set placeholder display_id for Mangy Silvermane, Silvermane Wolf and Silvermane Howler
+        -- Set placeholder display_id for Silvermane wolves
         update creature_template set display_id1 = 380 where entry in(2923, 2924, 2925, 2926);
         -- Despawn Aerie Peak Town Center, quest NYI
         update spawns_gameobjects set ignored = 1 where spawn_id = 21508;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1125,6 +1125,10 @@ begin not atomic
         update creature_template set display_id1 = 1611, display_id2 = 1612, display_id3 = 0, display_id4 = 0 where entry = 1839; -- Scarlet High Clerist
         update creature_template set display_id1 = 1611, display_id2 = 1612, display_id3 = 0, display_id4 = 0 where entry = 1833; -- Scarlet Knight
 
+        -- Fix quest pre-requisites for "Covert Ops: Alpha"
+        update quest_template set ExclusiveGroup = -1079 where entry in(1077, 1074);
+        update quest_template set PrevQuestId = 1077 where entry = 1079;
+
 		insert into applied_updates values ('230320231');
 	end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1132,6 +1132,11 @@ begin not atomic
         -- Set "<Needs Reward>" to quest "Reception from Tyrande"
         update quest_template set Title = "Reception from Tyrande <Needs Reward>" where entry = 1081;
 
+        -- Feralas
+        -- Delete duplicate spawn for Tarhus <Binder>, his real position is in Barrens
+        -- Closes #1029
+        delete from spawns_creatures where spawn_id = 400049;
+
 		insert into applied_updates values ('230320231');
 	end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1078,7 +1078,7 @@ begin not atomic
         -- Despawn Wildkin Feather, quest NYI
         update spawns_gameobjects set ignored = 1 where spawn_entry = 153239;
         -- Set placeholder display_id for Mangy Silvermane, Silvermane Wolf and Silvermane Howler
-        update creature_template set display_id1 = 380 where entry in(2923, 2924, 2925);
+        update creature_template set display_id1 = 380 where entry in(2923, 2924, 2925, 2926);
         -- Despawn Aerie Peak Town Center, quest NYI
         update spawns_gameobjects set ignored = 1 where spawn_id = 21508;
         -- Despawn Rin'ji's Cage, quest NYI
@@ -1095,6 +1095,12 @@ begin not atomic
         update creature_template set display_id1 = 1244 where entry = 2505;
         -- Despawn campfire from Hinterlands Beach
         update spawns_gameobjects set ignored = 1 where spawn_id in(46038, 46037);
+        -- Set dwarf placeholder for Falstad Wildhammer, Truk Wildbeard, Gryphon Master Talonaxe
+        update creature_template set display_id1 = 2584 where entry in(5635, 4782, 5636);
+        -- Set high-elf placeholder for Highvale elves
+        update creature_template set display_id1 = 1642, display_id2 = 1643, display_id3 = 0, display_id4 = 0 where entry in(2691, 2692, 2693, 2694);
+        -- Set placeholder for Rothos
+        update creature_template set display_id1 = 2930 where entry = 5718;
 
         -- Badlands
         -- Despawn two unused Wanted signs
@@ -1107,6 +1113,13 @@ begin not atomic
         update spawns_gameobjects set ignored = 1 where spawn_id in(11272, 10927, 10922, 11245, 11246, 11279, 10923, 11273, 11264, 11259, 10936, 10921, 10920, 11278, 11260, 11261, 11274, 11243, 11254, 10917, 11242, 11250, 11249, 11267, 11244);
         -- Despawn Magenta Cap Cluster and Magenta Cap Cluster Trap, quest NYI
         update spawns_gameobjects set ignored = 1 where spawn_entry in(128293, 128196, 126049);
+        -- Set dwarf placeholder for Theldurin the Lost and Prospector Ryedol
+        update creature_template set display_id1 = 2584 where entry in(2785, 2910);
+        -- Set orc placeholder for Grawl, Sranda and Neeka Bloodscar
+        update creature_template set display_id1 = 2576 where entry = 2908;
+        update creature_template set display_id1 = 2577 where entry in(1407, 5394);
+        -- Set gnome placeholder for Lotwill and Lucien Tosselwrench
+        update creature_template set display_id1 = 2581 where entry in(2921, 2920);
 
 		insert into applied_updates values ('230320231');
 	end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1143,9 +1143,6 @@ begin not atomic
         update quest_template set ExclusiveGroup = -1079 where entry in(1077, 1074);
         update quest_template set PrevQuestId = 1077 where entry = 1079;
 
-        -- Set "<Needs Reward>" to quest "Reception from Tyrande"
-        update quest_template set Title = "Reception from Tyrande <Needs Reward>" where entry = 1081;
-
         -- Feralas
         -- Delete duplicate spawn for Tarhus <Binder>, his real position is in Barrens
         -- Closes #1029

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1121,6 +1121,10 @@ begin not atomic
         -- Set gnome placeholder for Lotwill and Lucien Tosselwrench
         update creature_template set display_id1 = 2581 where entry in(2921, 2920);
 
+        -- Additional Hearthglen fixes by @Geo-tp
+        update creature_template set display_id1 = 1611, display_id2 = 1612, display_id3 = 0, display_id4 = 0 where entry = 1839; -- Scarlet High Clerist
+        update creature_template set display_id1 = 1611, display_id2 = 1612, display_id3 = 0, display_id4 = 0 where entry = 1833; -- Scarlet Knight
+
 		insert into applied_updates values ('230320231');
 	end if;
 


### PR DESCRIPTION
## Herbalism
- Set placeholder display_id for Wintersbite, Khadgar's Whisker, Firebloom
- Change size for Goldthorn and Firebloom to 0.5

## Mining
- enable Mithril Deposit to be mined at 155 skill level, reasoning: [here](https://crawler.thealphaproject.eu/mnt/crawler/media/Text/WoWVault/WoWVault-Guidebook.txt), search for "mithril"

## Alterac Mountains
- set placeholder display_ids for ogres Glommus, Grel'borg the Miser, Mug'thol. All best guesses as there are very few models to choose from and they all look pretty similar except for the clothing. Have used two-headed ogre for casters as usual.

## Western Plaguelands
- Despawn Cauldron, Campfire and 2x Campfire Damage from future Argent Dawn camp in WPL
- Despawn Andorhal Silo Temporal Rift objects, quest NYI
- Set placeholder display_id for Araj the Summoner. There is exactly one "male caster" scourge model (1245) so I have used that.
- Despawn Musty Tome and Musty Tome Trap, quest NYI
- additional Hearthglen fixes by @geo-tp Closes #1026 

## Hinterlands
- Despawn Wildkin Feather, quest NYI
- Set placeholder display_id for Silvermane wolves. They are all greyish wolves so I've used the same PH for all of them (380)
- Despawn Aerie Peak Town Center, quest NYI
- Despawn Rin'ji's Cage, quest NYI
- Set placeholder display_id for Jade Ooze. Only one green ooze model unused so I've used that (1749)
- Despawn Horde Supply Crate, quest NYI
- Fix Z of a floating Solid Chest
- Set proper (placeholder) faction for Vilebranch and Witherbark Trolls. They have their own faction in vanilla but that doesn't exist yet and without changing the faction to generic monster they would be non-aggressive.
- Set placeholder display_id for Saltwater Snapjaw. Only three turtle models exist and they all look pretty much the same.
- Despawn campfire from Hinterlands Beach
- Set dwarf placeholder for Falstad Wildhammer, Truk Wildbeard, Gryphon Master Talonaxe
- Set high-elf placeholder for Highvale elves
- Set placeholder for Rothos

## Badlands
- Despawn two unused Wanted signs from Kargath, quests NYI
- Set placeholder display_id for Barnabus. It's a reddish, worg-like wolf in classic but we don't have that exact model yet so I've replaced it with a reddish wolf model.
- Set placeholder display_id for Dustbelcher Warrior. They now use the same PH as all other melee Dustbelchers.
- Despawn Short Wooden Seat from Uldaman exterior. They are baked into WMO in alpha so the doodad spawns were duplicates. There are likely many, many more ...
- Despawn Magenta Cap Cluster and Magenta Cap Cluster Trap, quest NYI
- Set dwarf placeholder for Theldurin the Lost and Prospector Ryedol
- Set orc placeholder for Grawl, Sranda and Neeka Bloodscar
- Set gnome placeholder for Lotwill and Lucien Tosselwrench

## Thousand Needles
- Fix quest pre-requisites for "Covert Ops: Alpha" (closes #1007)

## Feralas
- delete duplicate spawn for ```Tarhus <Binder>```, he's supposed to be in Crossroads/Barrens only. Closes #1029 