### PR TITLE
RFC: Unique creature spawns

### DIFF
--- a/database/world/WorldDatabaseManager.py
+++ b/database/world/WorldDatabaseManager.py
@@ -545,6 +545,13 @@ class WorldDatabaseManager(object):
         return res
 
     @staticmethod
+    def creature_spawn_get_by_map_id_and_entry(map_id, entry) -> [list[SpawnsCreatures], scoped_session]:
+        world_db_session = SessionHolder()
+        res = world_db_session.query(SpawnsCreatures).filter_by(ignored=0, map=map_id, spawn_entry1=entry).all()
+        world_db_session.close()
+        return res
+
+    @staticmethod
     def creature_spawn_get_by_spawn_id(spawn_id) -> [Optional[SpawnsCreatures], scoped_session]:
         world_db_session = SessionHolder()
         res = world_db_session.query(SpawnsCreatures).filter_by(spawn_id=spawn_id).first()
@@ -1164,6 +1171,23 @@ class WorldDatabaseManager(object):
         res = world_db_session.query(NpcText).all()
         world_db_session.close()
         return res
+
+    # Pool Creature Template.
+
+    class PoolCreatureTemplateHolder:
+        POOL_CREATURE_TEMPLATES: dict[int, PoolCreatureTemplate] = {}
+
+        @staticmethod
+        def load_pool_creature_template(pool_creature_template: PoolCreatureTemplate):
+            WorldDatabaseManager.PoolCreatureTemplateHolder.POOL_CREATURE_TEMPLATES[pool_creature_template.id] = pool_creature_template
+
+    @staticmethod
+    def pool_creature_template_get_all():
+        world_db_session: scoped_session = SessionHolder()
+        res = world_db_session.query(PoolCreatureTemplate).all()
+        world_db_session.close()
+        return res
+
 
     # Broadcast Text.
 

--- a/database/world/WorldModels.py
+++ b/database/world/WorldModels.py
@@ -1114,6 +1114,13 @@ class SpawnsGameobjects(Base):
     spawn_visibility_mod = Column(Float, nullable=True, server_default=text("'0'"))
     ignored = Column(TINYINT(1), nullable=False, server_default=text("'0'"))
 
+class PoolCreatureTemplate(Base):
+    __tablename__ = 'pool_creature_template'
+
+    id = Column(INTEGER(10), primary_key=True)
+    pool_entry = Column(MEDIUMINT(8), nullable=False, server_default=text("'0'"))
+    chance = Column(Float, nullable=False, server_default=text("'0'"))
+    description = Column(Text)
 
 class NpcGossip(Base):
     __tablename__ = 'npc_gossip'

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1040,5 +1040,76 @@ begin not atomic
 		insert into applied_updates values ('210320232');
 	end if;
 
+    -- 23/03/2023 2
+	if(select count(*) from applied_updates where id = '230320232') = 0 then
+
+        CREATE TABLE IF NOT EXISTS `pool_creature_template` (
+          `id` int(10) unsigned NOT NULL DEFAULT 0,
+          `pool_entry` mediumint(8) unsigned NOT NULL DEFAULT 0,
+          `chance` float unsigned NOT NULL DEFAULT 0,
+          `description` varchar(255) NOT NULL,
+          `flags` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'FLAG_SPAWN_ENABLE_IF_WORLD_POP_OVER_BLIZZLIKE = 1',
+          `patch_min` tinyint(3) unsigned NOT NULL DEFAULT 0 COMMENT 'Minimum content patch to load this entry',
+          `patch_max` tinyint(3) unsigned NOT NULL DEFAULT 10 COMMENT 'Maximum content patch to load this entry',
+          PRIMARY KEY (`id`),
+          KEY `pool_idx` (`pool_entry`)
+        ) ENGINE=InnoDb DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+
+        INSERT INTO `pool_creature_template` (`id`, `pool_entry`, `chance`, `description`, `flags`, `patch_min`, `patch_max`) VALUES
+            (15466, 14006, 0, 'Minion of Omen', 0, 7, 10),
+            (9956, 25610, 0, 'BRD - Shadowforge Flame Keeper', 0, 0, 10),
+            (462, 462, 0, 'Vultros (462)', 0, 0, 10),
+            (3735, 3735, 0, 'Apothecary Falthis (3735)', 0, 0, 10),
+            (448, 1270, 0, 'Elwynn Forest - Forests Edge - Hogger (448)', 0, 0, 10),
+            (730, 125, 0, 'Tethis (730)', 0, 0, 10),
+            (2038, 108, 0, 'Lord Melenas', 0, 0, 10),
+            (7319, 109, 0, 'Lady Sathra', 0, 0, 10),
+            (3467, 110, 0, 'Baron Longshore', 0, 0, 10),
+            (3204, 111, 0, 'Gazz\'uz', 0, 0, 10),
+            (2304, 112, 0, 'Captain Ironhill', 0, 0, 10),
+            (5822, 113, 0, 'Felweaver Scornn', 0, 0, 10),
+            (5808, 114, 0, 'Warlord Kolkanis', 0, 0, 10),
+            (5824, 115, 0, 'Captain Flat Tusk', 0, 0, 10),
+            (5826, 116, 0, 'Geolord Mottle', 0, 0, 10),
+            (5809, 117, 0, 'Watch Commander Zalaphil', 0, 0, 10),
+            (3392, 118, 0, 'Prospector Khazgorm', 0, 0, 10),
+            (5847, 119, 0, 'Heggin Stonewhisker', 0, 0, 10),
+            (5859, 120, 0, 'Hagg Taurenbane', 0, 0, 10),
+            (3472, 121, 0, 'Washte Pawne', 0, 0, 10),
+            (3473, 122, 0, 'Owatanka', 0, 0, 10),
+            (3474, 123, 0, 'Lakota\'mani', 0, 0, 10),
+            (14275, 124, 0, 'Tamra Stormpike', 0, 0, 10),
+            (521, 521, 0, 'Lupos', 0, 0, 10),
+            (2598, 2598, 0, 'Darbel Montrose', 0, 0, 10),
+            (2605, 2605, 0, 'Zalas Witherbark', 0, 0, 10),
+            (2606, 2606, 0, 'Nimar the Slayer', 0, 0, 10),
+            (2779, 2779, 0, 'Prince Nazjak', 0, 0, 10),
+            (2850, 2850, 0, 'Broken Tooth', 0, 0, 10),
+            (61, 3200, 0, 'Thuros Lightfingers', 0, 0, 10),
+            (7850, 9002, 0, 'Kernobee', 0, 0, 10),
+            (832, 10003, 0, 'Dust Devil', 0, 0, 10),
+            (3671, 10004, 0, 'Lady Anacondra', 0, 0, 10),
+            (12902, 12902, 0, 'Lorgus Jett', 0, 0, 10),
+            (14222, 14222, 0, 'Araga', 0, 0, 10),
+            (14281, 14281, 0, 'Jimmy the Bleeder', 0, 0, 10),
+            (10558, 25468, 25, 'Hearthsinger Forresten', 0, 0, 10),
+            (14231, 42939, 0, 'Drogoth the Roamer', 0, 0, 10),
+            (14233, 43157, 0, 'Ripscale', 0, 0, 10),
+            (14230, 43517, 0, 'Burgle Eye', 0, 0, 10),
+            (13602, 43525, 0, 'The Abominable Greench', 0, 0, 10),
+            (1112, 1608, 0, 'Wetlands - Leech Widow', 0, 0, 10),
+            (3736, 1609, 0, 'Ashenvale - Darkslayer Mordenthal', 0, 0, 10),
+            (4202, 1610, 0, 'Stonetalon Mountains - Gerenzo Wrenchwhistle', 0, 0, 10),
+            (5350, 1604, 0, 'Feralas - Qirot', 0, 0, 10),
+            (5863, 1611, 0, 'Barrens - Geopriest Gukk\'rok', 0, 0, 10),
+            (7057, 1605, 0, 'Uldaman (Outside) - Digmaster Shovelphlange', 0, 0, 10),
+            (7895, 1606, 0, 'Barrens - Ambassador Bloodrage', 0, 0, 10),
+            (8212, 1607, 0, 'Hinterlands - The Reak', 0, 0, 10),
+            (10077, 1602, 0, 'Burning Steppes - Deathmaw', 0, 0, 10),
+            (3581, 279, 0, 'Stormwind City - Sewer Beast', 0, 0, 10);
+
+		insert into applied_updates values ('230320232');
+	end if;
+
 end $
 delimiter ;

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -63,6 +63,7 @@ class WorldLoader:
             WorldLoader.load_npc_gossip()
             WorldLoader.load_npc_text()
             WorldLoader.load_broadcast_text()
+            WorldLoader.load_pool_creature_templates()
         else:
             Logger.info('Skipped creature loading.')
 
@@ -697,6 +698,17 @@ class WorldLoader:
             Logger.progress('Loading creature families...', count, length)
 
         return length
+
+    @staticmethod
+    def load_pool_creature_templates():
+        pool_creature_templates = WorldDatabaseManager.pool_creature_template_get_all()
+        length = len(pool_creature_templates)
+        count = 0
+
+        for pool_creature_template in pool_creature_templates:
+            WorldDatabaseManager.PoolCreatureTemplateHolder.load_pool_creature_template(pool_creature_template)
+            count += 1
+            Logger.progress('Loading pool creature templates...', count, length)
 
     @staticmethod
     def load_npc_gossip():

--- a/game/world/managers/objects/units/UniqueSpawnManager.py
+++ b/game/world/managers/objects/units/UniqueSpawnManager.py
@@ -1,0 +1,41 @@
+import random
+from database.world.WorldDatabaseManager import WorldDatabaseManager
+from utils.Logger import Logger
+
+class UniqueSpawnManager:
+    UNIQUE_CREATURE_SPAWNS = []
+    UNIQUE_CREATURE_ENTRIES = []
+    def __init__(self, map):
+        self.map = map
+        self.UNIQUE_CREATURE_SPAWNS = []
+        self.UNIQUE_CREATURE_ENTRIES = []
+
+    def add_unique_creature_entry(self, entry):
+        if entry not in self.UNIQUE_CREATURE_ENTRIES:
+            self.UNIQUE_CREATURE_ENTRIES.append(entry)
+
+    def respawn_unique_creature(self, entry):
+        if entry not in self.UNIQUE_CREATURE_SPAWNS:
+            from game.world.managers.objects.units.creature.CreatureSpawn import CreatureSpawn
+
+            spawns = WorldDatabaseManager.creature_spawn_get_by_map_id_and_entry(self.map.dbc_map.ID, entry)
+            spawn = random.choice(spawns)
+
+            creature_spawn = CreatureSpawn(spawn, instance_id=self.map.instance_id, is_unique=True)
+            creature_spawn.spawn_creature()
+
+            self.UNIQUE_CREATURE_SPAWNS.append(entry)
+
+    def on_unique_creature_despawn(self, entry):
+        self.UNIQUE_CREATURE_SPAWNS.remove(entry)
+
+    def spawn_all_unique_creatures(self):
+        from game.world.managers.objects.units.creature.CreatureSpawn import CreatureSpawn
+        for entry in self.UNIQUE_CREATURE_ENTRIES:
+            spawns = WorldDatabaseManager.creature_spawn_get_by_map_id_and_entry(self.map.dbc_map.ID, entry)
+            spawn = random.choice(spawns)
+
+            creature_spawn = CreatureSpawn(spawn, instance_id=self.map.instance_id, is_unique=True)
+            creature_spawn.spawn_creature()
+
+            self.UNIQUE_CREATURE_SPAWNS.append(entry)

--- a/game/world/managers/objects/units/creature/CreatureSpawn.py
+++ b/game/world/managers/objects/units/creature/CreatureSpawn.py
@@ -10,7 +10,7 @@ from utils.Logger import Logger
 
 
 class CreatureSpawn:
-    def __init__(self, creature_spawn, instance_id):
+    def __init__(self, creature_spawn, instance_id, is_unique = False):
         self.creature_spawn: SpawnsCreatures = creature_spawn
         self.spawn_id = creature_spawn.spawn_id
         self.movement_type = creature_spawn.movement_type
@@ -26,6 +26,7 @@ class CreatureSpawn:
         self.respawn_time = 0
         self.last_tick = 0
         self.borrowed = False
+        self.is_unique = is_unique
 
     def update(self, now):
         if now > self.last_tick > 0:
@@ -94,10 +95,17 @@ class CreatureSpawn:
             if self.respawn_timer >= self.respawn_time * 0.8:
                 self.creature_instance.despawn()
                 self.creature_instance = None
+                if self.is_unique:
+                    map = MapManager.get_map(self.map_id, self.instance_id)
+                    map.unique_spawn_manager.on_unique_creature_despawn(self.creature_spawn.spawn_entry1)
 
         # Spawn a new creature instance when needed.
         if self.respawn_timer >= self.respawn_time:
-            self.spawn_creature()
+            if self.is_unique:
+                map = MapManager.get_map(self.map_id, self.instance_id)
+                map.unique_spawn_manager.respawn_unique_creature(self.creature_spawn.spawn_entry1)
+            else:
+                self.spawn_creature()
 
     def get_default_location(self):
         return Vector(self.creature_spawn.position_x, self.creature_spawn.position_y,


### PR DESCRIPTION
Currently, creatures that have multiple spawn points but are supposed to spawn at only one of them spawn at all positions. Vultros in Westfall comes to mind who has so many possible spawn points this certainly defeats the idea of a "rare spawn". However, this isn't restricted to "rare spawns" as even some quest targets have randomly chosen spawn points. 

I'm not sure if my implementation is any good - it's probably waaaaay to hacky - but I still wanted to give it a try. Since it works I thought I make a PR so everyone can pick it apart. Even if it's crap maybe it'll inspire someone else to make a proper version?

I took the pool_creature_template table from Mangos and used it to suit our needs which is rather simple:

- spawn unique creatures only once at a randomly chosen spawn point
- respawn them at a new random position

The "chance" column doesn't matter to us because there's exactly *one* creature with a spawn chance and that one is not in 0.5.3. Since we don't really need the "pool" concept from Mangos either I didn't bother with implementing it, instead I just make sure an unique creature can't spawn more than once.

Of course this doesn't bother with objects because they are way more complex. Unique creatures are just that - unique. Objects however can have multiple active spawn points at the same time, but only up to a defined limit, which definitely requires pooling. Since I had no idea how to implement that I'd rather see someone else doing it.