### PR TITLE
Various fixes

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -211,6 +211,9 @@ begin not atomic
         -- Update Jade Ooze
         update creature_template set display_id1 = 1146 where entry = 2656;
 
+        -- Despawn a bunch of objects related to NYI quest "Counterattack!" from The Barrens
+        update spawns_gameobjects set ignored = 1 where spawn_id in(16771, 14777, 14779, 16770, 14776);
+
 
 
         insert into`applied_updates`values ('300320231');

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -219,13 +219,13 @@ begin not atomic
         -- Set correct quest objective for Regthar Deathgate's quests as he isn't west of Crossroads
         -- but in Crossroads proper in 0.5.3
         -- Kolkar Leaders, proof: https://web.archive.org/web/20040825094143/http://wow.allakhazam.com/db/quest.html?wquest=855
-        update quest_template set Objective = 'Bring 15 Centaur Bracers to Regthar Deathgate at the Crossroads.' where entry = 855;
+        update quest_template set Objectives = 'Bring 15 Centaur Bracers to Regthar Deathgate at the Crossroads.' where entry = 855;
         -- Same for quest Hezrul Bloodmark, proof: https://web.archive.org/web/20040903231152/http://www.goblinworkshop.com/quests/hezrul-bloodmark.html
-        update quest_template set Objective = "Bring Hezrul's Head to Regthar Deathgate at the Crossroads." where entry = 852;
+        update quest_template set Objectives = "Bring Hezrul's Head to Regthar Deathgate at the Crossroads." where entry = 852;
         -- Same for quest Verog the Dervish, proof: https://web.archive.org/web/20040918103729/http://www.goblinworkshop.com/quests/verog-the-dervish.html
-        update quest_template set Objective = "Bring Verog's Head to Regthar Deathgate at the Crossroads." where entry = 851;
+        update quest_template set Objectives = "Bring Verog's Head to Regthar Deathgate at the Crossroads." where entry = 851;
         -- Same for quest Kolkar Leaders, proof: https://web.archive.org/web/20040906103419/http://www.goblinworkshop.com/quests/kolkar-leaders.html
-        update quest_template set Objective = "Bring Barak's Head to Regthar Deathgate at the Crossroads." where entry = 850;
+        update quest_template set Objectives = "Bring Barak's Head to Regthar Deathgate at the Crossroads." where entry = 850;
 
         -- Set placeholder for Kreenig Snarlsnout
         update creature_template set display_id1 = 1420 where entry = 3438;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -236,6 +236,9 @@ begin not atomic
         -- Update Deathguard Lundmark with placeholder
         update creature_template set display_id1 = 1021 where entry = 5725;
 
+        -- Fix broken SFK cell doors (they spawn too low so you can't ever pass even when opened)
+        update spawns_gameobjects set spawn_positionZ = 83.5 where spawn_id in(33219, 32445, 32446);
+
         insert into`applied_updates`values ('300320231');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -186,8 +186,6 @@ begin not atomic
         update creature_template set display_id1 = 2136 where entry = 3048;
         -- Update Bretta Goldfury
         update creature_template set display_id1 = 3058 where entry = 5123;
-        -- Update Ultar Threx
-        update creature_template set display_id1 = 3090 where entry = 1703;
         -- Update Witherbark Shadow Hunter
         update creature_template set display_id2 = 4000 where entry = 2557;
         -- Updathe Rhinag
@@ -196,6 +194,8 @@ begin not atomic
         update creature_template set display_id1 = 1498 where entry = 1350;
         -- Update Defias Pirate
         update creature_template set display_id2 = 2348 where entry = 657;
+        -- Update Belstaff Stormeye
+        update creature_template set display_id2 = 3090 where entry = 2489;
 
         -- Update Dark Strand creatures
         update creature_template set display_id1 = 1642, display_id2 = 1643, display_id3 = 0, display_id4 = 0 where entry in(2336, 2337, 3879);

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -233,6 +233,9 @@ begin not atomic
         -- Add trainer id to Kil'hala
         update creature_template set trainer_id = 507 where entry = 3484;
 
+        -- Update Deathguard Lundmark with placeholder
+        update creature_template set display_id1 = 1021 where entry = 5725;
+
         insert into`applied_updates`values ('300320231');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -231,7 +231,7 @@ begin not atomic
         update creature_template set display_id1 = 1420 where entry = 3438;
 
         -- Add trainer id to Kil'hala
-        update creature_template set trainer_id = 503 where entry = 3484;
+        update creature_template set trainer_id = 507 where entry = 3484;
 
         insert into`applied_updates`values ('300320231');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -227,6 +227,9 @@ begin not atomic
         -- Same for quest Kolkar Leaders, proof: https://web.archive.org/web/20040906103419/http://www.goblinworkshop.com/quests/kolkar-leaders.html
         update quest_template set Objective = "Bring Barak's Head to Regthar Deathgate at the Crossroads." where entry = 850;
 
+        -- Set placeholder for Kreenig Snarlsnout
+        update creature_template set display_id1 = 1420 where entry = 3438;
+
         insert into`applied_updates`values ('300320231');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -201,7 +201,7 @@ begin not atomic
         update creature_template set display_id1 = 1642, display_id2 = 1643, display_id3 = 0, display_id4 = 0 where entry in(2336, 2337, 3879);
 
         -- Fix Tursk <Crawler Trainer>
-        update creature_template set level_min = 50, level_max = 50, faction = 29, name = "Tursk", health_min = 1938, health_max = 1938, armor = 1341 where entry = 3623;
+        update creature_template set level_min = 50, level_max = 50, faction = 29, name = "Tursk", health_min = 1938, health_max = 1938, armor = 1341, spell_id1 = 7907 where entry = 3623;
 
         -- Update Charity Mipsy
         update creature_template set display_id1 = 213 where entry = 4896;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -213,8 +213,8 @@ begin not atomic
 
         -- Despawn a bunch of objects related to NYI quest "Counterattack!" from The Barrens
         update spawns_gameobjects set ignored = 1 where spawn_id in(16771, 14777, 14779, 16770, 14776);
-
-
+        -- Despawn a Fierce Blaze, the camp is NYI
+        update spawns_gameobjects set ignored = 1 where spawn_id = 13512;
 
         insert into`applied_updates`values ('300320231');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -240,10 +240,16 @@ begin not atomic
         update spawns_gameobjects set spawn_positionZ = 83.5 where spawn_id in(33219, 32445, 32446);
 
         -- Despawn objects affected by vanilla terrain change in Forgotten Pools/Barrens
-        update spawns_gameobjects set ignored = 1 where spawn_id in(1814, 13202, 15688, 2725);
+        update spawns_gameobjects set ignored = 1 where spawn_id in(1814, 13202, 15688, 2725, 2611);
 
         -- Set placeholder for Barak Kodobane, Verog and Hezrul
         update creature_template set display_id1 = 1257 where entry in(3394, 3395, 3396);
+
+        -- Despawn object from Camp Taujaro (shane cube with no use)
+        update spawns_gameobjects set ignored = 1 where spawn_id = 14708;
+
+        -- Have Harb Clawhoof spawn his pet cat
+        update creature_template set spell_id1 = 7906 where entry = 3685;
 
         insert into`applied_updates`values ('300320231');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -239,6 +239,12 @@ begin not atomic
         -- Fix broken SFK cell doors (they spawn too low so you can't ever pass even when opened)
         update spawns_gameobjects set spawn_positionZ = 83.5 where spawn_id in(33219, 32445, 32446);
 
+        -- Despawn objects affected by vanilla terrain change in Forgotten Pools/Barrens
+        update spawns_gameobjects set ignored = 1 where spawn_id in(1814, 13202, 15688, 2725);
+
+        -- Set placeholder for Barak Kodobane, Verog and Hezrul
+        update creature_template set display_id1 = 1257 where entry in(3394, 3395, 3396);
+
         insert into`applied_updates`values ('300320231');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -200,6 +200,9 @@ begin not atomic
         -- Update Dark Strand creatures
         update creature_template set display_id1 = 1642, display_id2 = 1643, display_id3 = 0, display_id4 = 0 where entry in(2336, 2337, 3879);
 
+        -- Fix Tursk <Crawler Trainer>
+        update creature_template set level_min = 50, level_max = 50, faction = 29, name = "Tursk", health_min = 1938, health_max = 1938, armor = 1341 where entry = 3623;
+
         insert into`applied_updates`values ('300320231');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -203,6 +203,9 @@ begin not atomic
         -- Fix Tursk <Crawler Trainer>
         update creature_template set level_min = 50, level_max = 50, faction = 29, name = "Tursk", health_min = 1938, health_max = 1938, armor = 1341 where entry = 3623;
 
+        -- Update Charity Mipsy
+        update creature_template set display_id1 = 213 where entry = 4896;
+
         insert into`applied_updates`values ('300320231');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -169,5 +169,37 @@ begin not atomic
         insert into`applied_updates`values ('290320234');
     end if;
 
+    -- 30/03/2023 1
+    if (select count(*) from `applied_updates` where id='300320231') = 0 then
+
+        -- Update Juli Stormbraid
+        update creature_template set display_id1 = 3067, faction = 57 where entry = 5145;
+        -- Update Alyssa Griffith
+        update creature_template set display_id1 = 1520 where entry = 1321;
+        -- Update Jorgen
+        update creature_template set display_id1 = 2960 where entry = 4959;
+        -- Update Elyssia <Portal Trainer>
+        update creature_template set display_id1 = 2204 where entry = 4165;
+        -- Update Ainethil <Herbalism Trainer>
+        update creature_template set display_id1 = 2215 where entry = 4160;
+        -- Update Ursyn Ghull
+        update creature_template set display_id1 = 2136 where entry = 3048;
+        -- Update Bretta Goldfury
+        update creature_template set display_id1 = 3058 where entry = 5123;
+        -- Update Ultar Threx
+        update creature_template set display_id1 = 3090 where entry = 1703;
+        -- Update Witherbark Shadow Hunter
+        update creature_template set display_id2 = 4000 where entry = 2557;
+        -- Updathe Rhinag
+        update creature_template set display_id1 = 4075 where entry = 3190;
+        -- Update Theresa Moulaine
+        update creature_template set display_id1 = 1498 where entry = 1350;
+        -- Update Defias Pirate
+        update creature_template set display_id2 = 2348 where entry = 657;
+
+        insert into`applied_updates`values ('300320231');
+    end if;
+
+
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -216,6 +216,17 @@ begin not atomic
         -- Despawn a Fierce Blaze, the camp is NYI
         update spawns_gameobjects set ignored = 1 where spawn_id = 13512;
 
+        -- Set correct quest objective for Regthar Deathgate's quests as he isn't west of Crossroads
+        -- but in Crossroads proper in 0.5.3
+        -- Kolkar Leaders, proof: https://web.archive.org/web/20040825094143/http://wow.allakhazam.com/db/quest.html?wquest=855
+        update quest_template set Objective = 'Bring 15 Centaur Bracers to Regthar Deathgate at the Crossroads.' where entry = 855;
+        -- Same for quest Hezrul Bloodmark, proof: https://web.archive.org/web/20040903231152/http://www.goblinworkshop.com/quests/hezrul-bloodmark.html
+        update quest_template set Objective = "Bring Hezrul's Head to Regthar Deathgate at the Crossroads." where entry = 852;
+        -- Same for quest Verog the Dervish, proof: https://web.archive.org/web/20040918103729/http://www.goblinworkshop.com/quests/verog-the-dervish.html
+        update quest_template set Objective = "Bring Verog's Head to Regthar Deathgate at the Crossroads." where entry = 851;
+        -- Same for quest Kolkar Leaders, proof: https://web.archive.org/web/20040906103419/http://www.goblinworkshop.com/quests/kolkar-leaders.html
+        update quest_template set Objective = "Bring Barak's Head to Regthar Deathgate at the Crossroads." where entry = 850;
+
         insert into`applied_updates`values ('300320231');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -206,6 +206,13 @@ begin not atomic
         -- Update Charity Mipsy
         update creature_template set display_id1 = 213 where entry = 4896;
 
+        -- Update Witherbark Zealot
+        update creature_template set display_id1 = 337 where entry = 2650;
+        -- Update Jade Ooze
+        update creature_template set display_id1 = 1146 where entry = 2656;
+
+
+
         insert into`applied_updates`values ('300320231');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -197,6 +197,9 @@ begin not atomic
         -- Update Defias Pirate
         update creature_template set display_id2 = 2348 where entry = 657;
 
+        -- Update Dark Strand creatures
+        update creature_template set display_id1 = 1642, display_id2 = 1643, display_id3 = 0, display_id4 = 0 where entry in(2336, 2337, 3879);
+
         insert into`applied_updates`values ('300320231');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -230,6 +230,9 @@ begin not atomic
         -- Set placeholder for Kreenig Snarlsnout
         update creature_template set display_id1 = 1420 where entry = 3438;
 
+        -- Add trainer id to Kil'hala
+        update creature_template set trainer_id = 503 where entry = 3484;
+
         insert into`applied_updates`values ('300320231');
     end if;
 


### PR DESCRIPTION
Closes #1085 
Closes #1089 
Closes #1092 
Closes #1093 
Closes #392 

- fix Tursk, Crawler Trainer's name, faction, level and stats. Also have him spawn his pet.
- quest objective text fixes for all quests from Regthar Deathgate because they referred to him as being "west of Crossroads" which he wasn't located at in 0.5.3 (he's in Crossroads at the watchtower). Quest texts from Allakhazam and Goblin Workshop, proof links in the SQL file.
- set placeholder display Id for Kreenig Snarlsnout
- tailoring vendor id to Kil'hala.
- fixes the broken Shadowfang Keep cell doors. They spawn at too low Z so even after opening them you can't pass. Random, I know.
- despawn several objects in the Barrens which are affected by terrain changes - either they float or they make no sense at that position
- have Harb Clawhoof spawn his pet
- despawn a shane cube from Camp Taujaro; likely this was supposed to be a cage but the model is missing (and so is the name) and there's no apparent use for it 