### PR TITLE
Database fixes

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -320,6 +320,9 @@ begin not atomic
         -- Slightly move a Lost Barrens Kodo spawn as it spawns inside a house
         update spawns_creatures set position_x = 753.196, position_y = -2777.454, position_z = 92.003 where spawn_id = 15119;
 
+        -- Despawn unused object Tool Bucket from Barrens
+        update spawns_gameobjects set ignored = 1 where spawn_entry = 161752;
+
         insert into`applied_updates`values ('310320232');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -254,6 +254,15 @@ begin not atomic
         insert into`applied_updates`values ('300320231');
     end if;
 
+    -- 31/03/2023 2
+    if (select count(*) from `applied_updates` where id='310320232') = 0 then
+
+        -- Fix Ratchet/Tanaris faction templates by aligning all these goblins with Booty Bay
+        update creature_template set faction = 121 where faction in(474, 637);
+
+        insert into`applied_updates`values ('310320232');
+    end if;
+
 
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1,8 +1,8 @@
 delimiter $
 begin not atomic
 
-    -- 27/03/2023 1
-    if(select count(*) from applied_updates where id = '270320231') = 0 then
+    -- 27/03/2023 2
+    if(select count(*) from applied_updates where id = '270320232') = 0 then
         -- Set subname for Brock Stoneseeker
         update creature_template set subname = "Cartography Trainer" where entry = 1681;
         -- Set subname for Karm Ironquill
@@ -31,7 +31,7 @@ begin not atomic
         -- set proper faction and have him spawn his spider pet
         update creature_template set faction = 57, spell_id1 = 7912 where entry = 2872;
 
-        insert into applied_updates values ('270320231');
+        insert into applied_updates values ('270320232');
     end if;
 
     -- 29/03/2023 1

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -261,7 +261,7 @@ begin not atomic
         update creature_template set faction = 121 where faction in(474, 637);
 
         -- Despawn objects from Barrens affected by vanilla terrain changes
-        update spawns_gameobjects set ignored = 1 where spawn_id in(13241, 13505, 13320, 12935);
+        update spawns_gameobjects set ignored = 1 where spawn_id in(13241, 13505, 13320, 12935, 2183, 13202, 1814, 2066, 15688, 2725, 1901, 2160);
 
         -- Fix quest Verog the Dervish - he's not near any command tents since there is no command tent yet.
         update quest_template set Details = "The centaur Verog the Dervish wanders the Barrens, and will be difficult to find. But he is based at the camps near the Stagnant Oasis to the southeast. It may be possible to draw him to you.$B$BTravel to the centaur camps near the Stagnant Oasis and attack the centaurs there. It will be dangerous, but if you can kill enough centaurs at those camps then they should raise an alarm. And Verog will come.$B$BBring me his head and I will place it with Barak Kodobane's." where entry = 851;
@@ -284,6 +284,9 @@ begin not atomic
         update spawns_creatures set ignored = 1 where spawn_id in(19402, 19361, 19326, 19438, 19412);
         -- Despawn shane cubed benches from the same camp
         update spawns_gameobjects set ignored = 1 where spawn_id in(13407, 13403);
+
+        -- Fix quest text of Deepmoss Spider Eggs
+        update quest_template set Details = "Spider egg omelettes are a new fad in Booty Bay! The problem is... Booty Bay's got no supply of eggs.$B$BI smell an opportunity!$B$BIn Windshear Crag -- in the Stonetalon Mountains to the northwest -- lives the deepmoss spider. Bring me its eggs and I'll pay a bundle!$B$BThe spiders like to creep under the shade of trees... Too bad the Venture Company cut down most of their trees!$B$BBut go to Windshear Crag anyway and look for deepmoss spiders. Their eggs will be clustered under what trees remain." where entry = 1069;
 
         insert into`applied_updates`values ('310320232');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -260,6 +260,18 @@ begin not atomic
         -- Fix Ratchet/Tanaris faction templates by aligning all these goblins with Booty Bay
         update creature_template set faction = 121 where faction in(474, 637);
 
+        -- Despawn objects from Barrens affected by vanilla terrain changes
+        update spawns_gameobjects set ignored = 1 where spawn_id in(13241);
+
+        -- Fix quest Verog the Dervish - he's not near any command tents since there is no command tent yet.
+        update quest_template set Details = "The centaur Verog the Dervish wanders the Barrens, and will be difficult to find. But he is based at the camps near the Stagnant Oasis to the southeast. It may be possible to draw him to you.$B$BTravel to the centaur camps near the Stagnant Oasis and attack the centaurs there. It will be dangerous, but if you can kill enough centaurs at those camps then they should raise an alarm. And Verog will come.$B$BBring me his head and I will place it with Barak Kodobane's." where entry = 851;
+
+        -- Fix quest Echeyakee - he's not summoned by any horn, nor does the horn item even exist
+        update quest_template set Details = "Whitemist, Echeyakee in the Tauren tongue, is the king of the savannah cats.  He hunts with such stealth, they say he's like a thin, white mist on the earth.  And he kills so fast his prey have no time for fear, or pain.$B$BThe Tauren say he is both mercy and death.$B$BYou will learn this, for I set you on the path to hunt Echeyakee. He stalks with his lion brethren, northeast of The Crossroads...$B$BGo. He is waiting." where entry = 881;
+
+        -- Spawn Echeyakee at retail position of his lair - it's northeast of the Crossroads and with his "lion brethren"
+        insert into spawns_creatures (spawn_entry1, map, position_x, position_y, position_z, orientation, spawntimesecsmin, spawntimesecsmax, movement_type) values (3475, 1, 458.11, -3035.91, 91.6839, 0, 300, 300, 1);
+
         insert into`applied_updates`values ('310320232');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -267,10 +267,15 @@ begin not atomic
         update quest_template set Details = "The centaur Verog the Dervish wanders the Barrens, and will be difficult to find. But he is based at the camps near the Stagnant Oasis to the southeast. It may be possible to draw him to you.$B$BTravel to the centaur camps near the Stagnant Oasis and attack the centaurs there. It will be dangerous, but if you can kill enough centaurs at those camps then they should raise an alarm. And Verog will come.$B$BBring me his head and I will place it with Barak Kodobane's." where entry = 851;
 
         -- Fix quest Echeyakee - he's not summoned by any horn, nor does the horn item even exist
-        update quest_template set Details = "Whitemist, Echeyakee in the Tauren tongue, is the king of the savannah cats.  He hunts with such stealth, they say he's like a thin, white mist on the earth.  And he kills so fast his prey have no time for fear, or pain.$B$BThe Tauren say he is both mercy and death.$B$BYou will learn this, for I set you on the path to hunt Echeyakee. He stalks with his lion brethren, northeast of The Crossroads...$B$BGo. He is waiting." where entry = 881;
+        -- Also fix Objectives to mention the changed questgiver (see below)
+        update quest_template set Objectives = "Bring Echeyakee's Hide to Jorn Skyseer at Camp Taujaro.", Details = "Whitemist, Echeyakee in our tongue, is the king of the savannah cats. With such steath does he hunt, he is like a thin white mist on the earth. And with such speed does he kill, his prey have no time for fear, or pain.$B$BHe is mercy, and he is death.$B$BYou will learn this, for I set you on the path to hunt Echeyakee. He stalks with his lion brethren, northeast of The Crossroads...$B$BGo. He is waiting.", OfferRewardText = "You have beaten Echeyakee, and though he hunts no more... his spirit is with you. He will show you the strength found in subtlety, and the honor in mercy.$B$BYour path is long, young $c. Stride it well." where entry = 881;
 
         -- Spawn Echeyakee at retail position of his lair - it's northeast of the Crossroads and with his "lion brethren"
         insert into spawns_creatures (spawn_entry1, map, position_x, position_y, position_z, orientation, spawntimesecsmin, spawntimesecsmax, movement_type) values (3475, 1, 458.11, -3035.91, 91.6839, 0, 300, 300, 1);
+
+        -- Move quest Echeyakee to Jorn Skyseer in Camp Taujaro. Evidence suggests he was originally the quest starter, not Sergra Darkthorn.
+        update creature_quest_starter set entry = 3387 where quest = 881;
+        update creature_quest_finisher set entry = 3387 where quest = 881;
 
         insert into`applied_updates`values ('310320232');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -294,6 +294,9 @@ begin not atomic
         -- Fix Z for Barrel of Milk in Stonetalon Mountains
         update spawns_gameobjects set spawn_positionZ = 22.9 where spawn_id = 47559;
 
+        -- Restore quest Goblin Invaders
+        update quest_template set Objectives = "Kill 12 Venture Co. Cutters, 10 Venture Co. Grinders and 6 Venture Co. Loggers, then return to Seereth Stonebreak on the border of Stonetalon and the Barrens.", ReqCreatureOrGOId3 = 3989, ReqCreatureOrGOCount3 = 6 where entry = 1062;
+
         insert into`applied_updates`values ('310320232');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -277,6 +277,9 @@ begin not atomic
         update creature_quest_starter set entry = 3387 where quest = 881;
         update creature_quest_finisher set entry = 3387 where quest = 881;
 
+        -- Fix quest text of The Angry Scytheclaws
+        update quest_template set Details = "The Sunscale Scytheclaws have gone berserk. Normally they fight with Savannah Prowlers for food, keeping both predators scarce.$B$BWithout their natural enemy, they have started stalking the roads, picking off unwary travelers. You must thin their numbers, $N.$B$BFind the Sunscale Scytheclaws to the south, slay them and cut out their bladders. Use the Scytheclaw Bladders to defile the Scytheclaw nests, southwest of the Stagnant Oasis. WIth their nests defiled they will abandon them and move elsewhere.", RequestItemsText = "Is your task finished? Ponder the life of the Scytheclaw as you do it. There are important lessons within every creature's lifespawn.", OfferRewardText = "Some of the others believe I have been too heavy handed in my lesson. I know that you are simply following my orders, but I want you to consider the life of the creatures you are slaughtering.$B$BThough they are at times a nuisance, they only become threatening when we seek their slaughter. This days defilement will cause us more trouble than it will solve problems...", Objectives = "Kill Sunscale raptors and collect their bladders. Use the bladders on the 3 Scytheclaw nests. Return to Sergra Darkthorn in the Crossroads." where entry = 905;
+
         insert into`applied_updates`values ('310320232');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -280,6 +280,11 @@ begin not atomic
         -- Fix quest text of The Angry Scytheclaws
         update quest_template set Details = "The Sunscale Scytheclaws have gone berserk. Normally they fight with Savannah Prowlers for food, keeping both predators scarce.$B$BWithout their natural enemy, they have started stalking the roads, picking off unwary travelers. You must thin their numbers, $N.$B$BFind the Sunscale Scytheclaws to the south, slay them and cut out their bladders. Use the Scytheclaw Bladders to defile the Scytheclaw nests, southwest of the Stagnant Oasis. WIth their nests defiled they will abandon them and move elsewhere.", RequestItemsText = "Is your task finished? Ponder the life of the Scytheclaw as you do it. There are important lessons within every creature's lifespawn.", OfferRewardText = "Some of the others believe I have been too heavy handed in my lesson. I know that you are simply following my orders, but I want you to consider the life of the creatures you are slaughtering.$B$BThough they are at times a nuisance, they only become threatening when we seek their slaughter. This days defilement will cause us more trouble than it will solve problems...", Objectives = "Kill Sunscale raptors and collect their bladders. Use the bladders on the 3 Scytheclaw nests. Return to Sergra Darkthorn in the Crossroads." where entry = 905;
 
+        -- Despawn Horde Guards from a non-existant camp
+        update spawns_creatures set ignored = 1 where spawn_id in(19402, 19361, 19326, 19438, 19412);
+        -- Despawn shane cubed benches from the same camp
+        update spawns_gameobjects set ignored = 1 where spawn_id in(13407, 13403);
+
         insert into`applied_updates`values ('310320232');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -310,6 +310,13 @@ begin not atomic
         -- Set proper faction for Theramore units in The Barrens - they need to be hostile to Horde
         update creature_template set faction = 150 where entry in(3454, 3455, 3393, 3385, 3386);
 
+        -- Despawn a bunch of objects from not-yet-existant Northwatch Hold
+        update spawns_gameobjects set ignored = 1 where spawn_id in(13360, 12705, 13365, 13354);
+
+        -- Spawn Cannoneers Smythe & Wesson
+        update spawns_creatures set ignored = 0, position_x = -2088.116, position_y = -3683.056, position_z = 50.397, orientation = 4.450 where spawn_id = 12165;
+        update spawns_creatures set ignored = 0, position_x = -2097.684 , position_y = -3675.315, position_z = 50.254, orientation = 4.450 where spawn_id = 12166;
+
         insert into`applied_updates`values ('310320232');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -261,7 +261,7 @@ begin not atomic
         update creature_template set faction = 121 where faction in(474, 637);
 
         -- Despawn objects from Barrens affected by vanilla terrain changes
-        update spawns_gameobjects set ignored = 1 where spawn_id in(13241, 13505, 13320);
+        update spawns_gameobjects set ignored = 1 where spawn_id in(13241, 13505, 13320, 12935);
 
         -- Fix quest Verog the Dervish - he's not near any command tents since there is no command tent yet.
         update quest_template set Details = "The centaur Verog the Dervish wanders the Barrens, and will be difficult to find. But he is based at the camps near the Stagnant Oasis to the southeast. It may be possible to draw him to you.$B$BTravel to the centaur camps near the Stagnant Oasis and attack the centaurs there. It will be dangerous, but if you can kill enough centaurs at those camps then they should raise an alarm. And Verog will come.$B$BBring me his head and I will place it with Barak Kodobane's." where entry = 851;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -291,6 +291,9 @@ begin not atomic
         -- Fix Z of two NPCs in Sepulcher
         update spawns_creatures set position_z = 104.877 where spawn_id in(17622, 17625);
 
+        -- Fix Z for Barrel of Milk in Stonetalon Mountains
+        update spawns_gameobjects set spawn_positionZ = 22.9 where spawn_id = 47559;
+
         insert into`applied_updates`values ('310320232');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -297,6 +297,16 @@ begin not atomic
         -- Restore quest Goblin Invaders
         update quest_template set Objectives = "Kill 12 Venture Co. Cutters, 10 Venture Co. Grinders and 6 Venture Co. Loggers, then return to Seereth Stonebreak on the border of Stonetalon and the Barrens.", ReqCreatureOrGOId3 = 3989, ReqCreatureOrGOCount3 = 6 where entry = 1062;
 
+        -- Despawn a floating book in Ratchet, table is missing
+        update spawns_gameobjects set ignored = 1 where spawn_id = 13452;
+
+        -- Remove invalid display_id from Southsea Cannoneer
+        update creature_template set display_id2 = 3828, display_id3 = 0 where entry = 3382;
+        -- Same for Southsea Brigand
+        update creature_template set display_id4 = 0 where entry = 3381;
+        -- And for Southsea Cutthroat
+        update creature_template set display_id2 = 3836, display_id3 = 0, display_id4 = 0 where entry = 3383;
+
         insert into`applied_updates`values ('310320232');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -261,7 +261,7 @@ begin not atomic
         update creature_template set faction = 121 where faction in(474, 637);
 
         -- Despawn objects from Barrens affected by vanilla terrain changes
-        update spawns_gameobjects set ignored = 1 where spawn_id in(13241, 13505, 13320, 12935, 2183, 13202, 1814, 2066, 15688, 2725, 1901, 2160);
+        update spawns_gameobjects set ignored = 1 where spawn_id in(13241, 13505, 13320, 12935, 2183, 13202, 1814, 2066, 15688, 2725, 1901, 2160, 13314);
 
         -- Fix quest Verog the Dervish - he's not near any command tents since there is no command tent yet.
         update quest_template set Details = "The centaur Verog the Dervish wanders the Barrens, and will be difficult to find. But he is based at the camps near the Stagnant Oasis to the southeast. It may be possible to draw him to you.$B$BTravel to the centaur camps near the Stagnant Oasis and attack the centaurs there. It will be dangerous, but if you can kill enough centaurs at those camps then they should raise an alarm. And Verog will come.$B$BBring me his head and I will place it with Barak Kodobane's." where entry = 851;
@@ -322,6 +322,9 @@ begin not atomic
 
         -- Despawn unused object Tool Bucket from Barrens
         update spawns_gameobjects set ignored = 1 where spawn_entry = 161752;
+
+        -- Despawn unused object Gallywix' Lockbox and trap object
+        update spawns_gameobjects set ignored = 1 where spawn_entry in(129127, 130126);
 
         insert into`applied_updates`values ('310320232');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -317,6 +317,9 @@ begin not atomic
         update spawns_creatures set ignored = 0, position_x = -2088.116, position_y = -3683.056, position_z = 50.397, orientation = 4.450 where spawn_id = 12165;
         update spawns_creatures set ignored = 0, position_x = -2097.684 , position_y = -3675.315, position_z = 50.254, orientation = 4.450 where spawn_id = 12166;
 
+        -- Slightly move a Lost Barrens Kodo spawn as it spawns inside a house
+        update spawns_creatures set position_x = 753.196, position_y = -2777.454, position_z = 92.003 where spawn_id = 15119;
+
         insert into`applied_updates`values ('310320232');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -307,6 +307,9 @@ begin not atomic
         -- And for Southsea Cutthroat
         update creature_template set display_id2 = 3836, display_id3 = 0, display_id4 = 0 where entry = 3383;
 
+        -- Set proper faction for Theramore units in The Barrens - they need to be hostile to Horde
+        update creature_template set faction = 150 where entry in(3454, 3455, 3393, 3385, 3386);
+
         insert into`applied_updates`values ('310320232');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -261,7 +261,7 @@ begin not atomic
         update creature_template set faction = 121 where faction in(474, 637);
 
         -- Despawn objects from Barrens affected by vanilla terrain changes
-        update spawns_gameobjects set ignored = 1 where spawn_id in(13241);
+        update spawns_gameobjects set ignored = 1 where spawn_id in(13241, 13505, 13320);
 
         -- Fix quest Verog the Dervish - he's not near any command tents since there is no command tent yet.
         update quest_template set Details = "The centaur Verog the Dervish wanders the Barrens, and will be difficult to find. But he is based at the camps near the Stagnant Oasis to the southeast. It may be possible to draw him to you.$B$BTravel to the centaur camps near the Stagnant Oasis and attack the centaurs there. It will be dangerous, but if you can kill enough centaurs at those camps then they should raise an alarm. And Verog will come.$B$BBring me his head and I will place it with Barak Kodobane's." where entry = 851;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -288,6 +288,9 @@ begin not atomic
         -- Fix quest text of Deepmoss Spider Eggs
         update quest_template set Details = "Spider egg omelettes are a new fad in Booty Bay! The problem is... Booty Bay's got no supply of eggs.$B$BI smell an opportunity!$B$BIn Windshear Crag -- in the Stonetalon Mountains to the northwest -- lives the deepmoss spider. Bring me its eggs and I'll pay a bundle!$B$BThe spiders like to creep under the shade of trees... Too bad the Venture Company cut down most of their trees!$B$BBut go to Windshear Crag anyway and look for deepmoss spiders. Their eggs will be clustered under what trees remain." where entry = 1069;
 
+        -- Fix Z of two NPCs in Sepulcher
+        update spawns_creatures set position_z = 104.877 where spawn_id in(17622, 17625);
+
         insert into`applied_updates`values ('310320232');
     end if;
 


### PR DESCRIPTION
- since there are no separate factions for Steamwheedle Cartel or Ratchet yet but they aren't at odds with Booty Bay (they are allied under their goblin leader anyway) it's more than just likely they all had Booty Bay faction in 0.5.3 so I'm setting their faction to Booty Bay. Closes #1010 
- despawns objects and guards affected by vanilla terrain changes (floating, misplaced, non-existant camps)
- fixes Z position of two NPCs in Sepulcher who are stuck in the terrain
- fixes Z for a Barrel of Milk in Stonetalon Mountains
- fixes duplicate applied_update id for the dang squirrel update, it never got applied that way :(
- removes invalid display_ids from Southsea pirates in The Barrens
- fixes faction of Theramore creatures in the Barrens, they need to be hostile towards Horde
- despawns a bunch of shane cubed Tool Bucket objects from northern Barrens as the quest for them is NYI
- slightly moved a Lost Barrens Kodo which wasn't only lost but stuck in a building ... poor thing

### The Great Shane Cube Cleanup
Using the following SQL query I've identified many objects around the world which have no valid displayId and also no purpose in context of 0.5.3. Most of them are in dungeons (Uldaman, Razorfen Kraul, Sunken Temple) or areas that are not yet finished, others are affected by vanilla terrain changes and should not be there in 0.5.3, and some are related to NYI quests. I've visited most of them in-game to see if they could be of any relevance *and* looked them up on our database. I've left in anything that's involved in existant quests even if it's a shane cube because they could be changed to a placeholder. Also untouched is anything invisible.
```
SELECT * FROM alpha_world.gameobject_template WHERE displayId NOT IN(SELECT id FROM alpha_dbc.gameobjectdisplayinfo) AND entry IN(SELECT spawn_entry FROM alpha_world.spawns_gameobjects WHERE ignored = 0) and displayId > 0 ORDER BY entry
```

### Quest: Verog the Dervish
Our quest text is from vanilla when the zone was already done, in 0.5.3 the text wasn't referring to any "command tent" since there isn't one. [Proof](https://web.archive.org/web/20040918103729/http://www.goblinworkshop.com/quests/verog-the-dervish.html)

Verog gets summoned at release position after the player has killed lots of other centaurs. Unfortunately due to terrain changes he appears far from the oasis where it's not too likely the player will even notice him before he despawns again. He should probably be relocated closer to the oasis but I don't know where so I left it alone.

### Quest: Echeyakee
Several changes were needed here. 

According to the [archived quest text on Goblin Workshop](https://web.archive.org/web/20040903230823/http://www.goblinworkshop.com/quests/echeyakee.html), the original quest giver wasn't Sergra Darkthorn but Jorn Skyseer in Camp Taujaro. Even though the archived text is a mixture of old and new it makes sense as Jorn offers several named hunts and also sends players to his sister for one more hunt. In vanilla this was changed, possibly because Camp Taujaro is quite some way from Crossroads and Echeyakee is closer to Crossroads. The change greatly reduces backtracking as the *next* quest would be found in Crossroads once more. In vanilla the player would be sent to Jorn Skyseer after finishing the next quest. This breadcrumb quest (3261) is what's missing in 0.5.3 and this makes perfect sense as the high entry suggests it was added much later.

The quest text also tells us that originally Echeyakee was a normal spawn and not summoned by an item. In the archived text the horn isn't mentioned at all.

Further proof: [archived screenshot](https://archive.thealphaproject.eu/media/Alpha-Project-Archive/Images/Azeroth/Kalimdor/Barrens/images_6682.jpg)

Applied changes:
- spawned Echeyakee where he can be summoned in retail as the location matches the quest text regardless of version
- rewrote the quest text according to the archived version (shown in the screenshot)
- moved the quest start/end to Jorn Skyseer in Camp Taujaro

### Quest: The Angry Scytheclaws

This quest used the vanilla quest text asking the player to gather raptor feathers while still requiring the 0.5.3 items (raptor bladders). The real quest text - except for Objectives - can be found [on Goblin Workshop](https://web.archive.org/web/20040901124831/http://www.goblinworkshop.com/quests/angry-scytheclaws.html). I have adapted our quest template to match the old quest text.

### Quest: Deepmoss Spider Eggs
The vanilla quest text we used talks of looking for the eggs in Sishir Canyon but that area doesn't exist in 0.5.3. [Allakhazam](https://web.archive.org/web/20040822141326/http://wow.allakhazam.com/db/quest.html?wquest=1069) has the old quest text which I've used to revise our version.

### Quest: Goblin Invaders
As explained in #1110 this quest originally asked to kill three different mobs, not two. I've updated the quest text and requirements accordingly. However the mobs still need to be spawned which is a much greater task.

### Quest: The Guns of Northwatch
As the quest area isn't finished yet Cannoneers Smythe & Wesson weren't spawned. We did have spawns for them but they were ignored because they would have spawned high in the air. According [to a comment on Allakhazam](https://web.archive.org/web/20040825093750/http://wow.allakhazam.com/db/quest.html?wquest=891),
```
You will need to enter the fort and fight your way to the top deck to complete this, so a group is almost essential.
```
This is valid for either version of the Northwatch Keep - there's a top deck even in 0.5.3, so I put them there. 