### PR TITLE
Add support for master server for online user count

### DIFF
--- a/etc/config/config.yml.dist
+++ b/etc/config/config.yml.dist
@@ -1,5 +1,5 @@
 Version:
-    current: 10
+    current: 11
 
 Database:
     Connection:
@@ -11,6 +11,11 @@ Database:
         realm_db: alpha_realm
         world_db: alpha_world
         dbc_db: alpha_dbc
+
+MasterServer:
+        enabled: False # Enable to get and report player count from and to a master server.
+        master_server_uri: http://localhost # Change this to the URI of your master server.
+        master_server_port: 8000 # Change this to the port of your master server.
 
 Server:
     Connection:  # Change 0.0.0.0 for 127.0.0.1 if it doesn't work

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from game.world.managers.maps.MapTile import MapTile
 from utils.ConfigManager import config, ConfigManager
 from utils.Logger import Logger
 from utils.ChatLogManager import ChatLogManager
+from utils.MasterServerManager import MasterServerManager
 from utils.PathManager import PathManager
 from utils.constants import EnvVars
 
@@ -110,6 +111,7 @@ if __name__ == '__main__':
                 world_process.join()
         except:
             Logger.info('Shutting down the core...')
+            MasterServerManager.checkout()
 
         ChatLogManager.exit()
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
-bitarray
-PyYAML
-colorama
-SQLAlchemy
+bitarray~=2.7.3
+PyYAML~=6.0
+colorama~=0.4.6
+SQLAlchemy~=2.0.9
 pymysql
-apscheduler
+apscheduler~=3.10.1
+
+requests~=2.28.2

--- a/utils/ConfigManager.py
+++ b/utils/ConfigManager.py
@@ -5,7 +5,7 @@ from utils.PathManager import PathManager
 
 
 class ConfigManager:
-    EXPECTED_VERSION = 10
+    EXPECTED_VERSION = 11
 
     def __init__(self):
         self.config = None

--- a/utils/MasterServerManager.py
+++ b/utils/MasterServerManager.py
@@ -1,0 +1,61 @@
+from database.realm.RealmDatabaseManager import RealmDatabaseManager
+from utils.ConfigManager import config
+import requests
+
+from utils.Logger import Logger
+
+master_server_uri = f"{config.MasterServer.master_server_uri}:{config.MasterServer.master_server_port}"
+master_server_enabled = config.MasterServer.enabled
+server_id = config.Server.Connection.Realm.local_realm_id
+
+
+class MasterServerManager:
+
+    @staticmethod
+    def checkout():
+        if not master_server_enabled:
+            return
+        try:
+            requests.get(f"{master_server_uri}/checkout/{server_id}")
+        except requests.exceptions.Timeout:
+            Logger.warning('MasterServerManager: unable to connect to master server (request timeout)')
+        except requests.exceptions.HTTPError:
+            Logger.warning('MasterServerManager: unable to connect to master server (HTTP error)')
+        except requests.exceptions.ConnectionError:
+            Logger.warning('MasterServerManager: unable to connect to master server (connection error)')
+        except requests.exceptions.RequestException as e:
+            Logger.warning(f'MasterServerManager: unable to connect to master server ({e})')
+
+    @staticmethod
+    def update():
+        if not master_server_enabled:
+            return
+        try:
+            count = RealmDatabaseManager.character_get_online_count(server_id)
+            requests.get(f"{master_server_uri}/update/{server_id}/{count}")
+        except requests.exceptions.Timeout:
+            Logger.warning('MasterServerManager: unable to connect to master server (request timeout)')
+        except requests.exceptions.HTTPError:
+            Logger.warning('MasterServerManager: unable to connect to master server (HTTP error)')
+        except requests.exceptions.ConnectionError:
+            Logger.warning('MasterServerManager: unable to connect to master server (connection error)')
+        except requests.exceptions.RequestException as e:
+            Logger.warning(f'MasterServerManager: unable to connect to master server ({e})')
+
+    @staticmethod
+    def query():
+        if not master_server_enabled:
+            return None
+        data = None
+        try:
+            data = requests.get(f"{master_server_uri}/query").json()
+        except requests.exceptions.Timeout:
+            Logger.warning('MasterServerManager: unable to connect to master server (request timeout)')
+        except requests.exceptions.HTTPError:
+            Logger.warning('MasterServerManager: unable to connect to master server (HTTP error)')
+        except requests.exceptions.ConnectionError:
+            Logger.warning('MasterServerManager: unable to connect to master server (connection error)')
+        except requests.exceptions.RequestException as e:
+            Logger.warning(f'MasterServerManager: unable to connect to master server ({e})')
+
+        return data


### PR DESCRIPTION
Implements reporting to and fetching user count from a Master Server (implemented in https://github.com/mindphluxnet/AlphaCoreMasterServer). Reporting will occur every minute and once on server shutdown. Master server support is turned off by default and needs to be configured in the config.yaml before it can be used.