### PR TITLE
Skill logic and crash fixes

### DIFF
--- a/game/world/managers/CommandManager.py
+++ b/game/world/managers/CommandManager.py
@@ -445,17 +445,18 @@ class CommandManager(object):
             skill_value = int(skill_value)
             skill = DbcDatabaseManager.SkillHolder.skill_get_by_id(skill_id)
             if not skill:
-                return -1, 'invalid skill.'
-            if skill_value <= 0:
-                return -1, 'skill value must be greater than 0.'
+                return -1, 'Invalid skill.'
+
+            if skill_value <= 0 or skill_value >= pow(2, 16):
+                return -1, 'Invalid skill value.'
 
             if not world_session.player_mgr.skill_manager.set_skill(skill_id, skill_value):
-                return -1, 'you haven\'t learned that skill.'
+                return -1, 'You haven\'t learned that skill.'
 
             world_session.player_mgr.skill_manager.build_update()
             return 0, 'Skill set.'
         except ValueError:
-            return -1, 'please specify the skill ID and new value.'
+            return -1, 'Please specify the skill ID and new value.'
 
     @staticmethod
     def port(world_session, args):

--- a/game/world/managers/CommandManager.py
+++ b/game/world/managers/CommandManager.py
@@ -445,18 +445,18 @@ class CommandManager(object):
             skill_value = int(skill_value)
             skill = DbcDatabaseManager.SkillHolder.skill_get_by_id(skill_id)
             if not skill:
-                return -1, 'Invalid skill.'
+                return -1, 'invalid skill.'
 
             if skill_value <= 0 or skill_value >= pow(2, 16):
-                return -1, 'Invalid skill value.'
+                return -1, 'invalid skill value.'
 
             if not world_session.player_mgr.skill_manager.set_skill(skill_id, skill_value):
-                return -1, 'You haven\'t learned that skill.'
+                return -1, 'you haven\'t learned that skill.'
 
             world_session.player_mgr.skill_manager.build_update()
             return 0, 'Skill set.'
         except ValueError:
-            return -1, 'Please specify the skill ID and new value.'
+            return -1, 'please specify the skill ID and new value.'
 
     @staticmethod
     def port(world_session, args):

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -765,7 +765,8 @@ class SpellEffectHandler:
         if not target.skill_manager.has_skill(skill_id):
             target.skill_manager.add_skill(skill_id)
 
-        target.skill_manager.set_skill(skill_id, max(1, target.skill_manager.get_total_skill_value(skill_id)), skill_max)
+        current_skill = target.skill_manager.get_total_skill_value(skill_id, no_bonus=True)
+        target.skill_manager.set_skill(skill_id, max(1, current_skill), skill_max)
         target.skill_manager.build_update()
 
     @staticmethod

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -359,7 +359,7 @@ class SpellEffectHandler:
 
         # Pet teaching.
         summoner = target.get_charmer_or_summoner()
-        if summoner.get_type_id() != ObjectTypeIds.ID_PLAYER:
+        if not summoner or summoner.get_type_id() != ObjectTypeIds.ID_PLAYER:
             return
 
         active_pet = summoner.pet_manager.get_active_permanent_pet()

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -76,12 +76,13 @@ class SpellManager:
 
         # If a profession spell is learned, grant the required skill.
         related_profession_skill = ExtendedSpellData.ProfessionInfo.get_profession_skill_id_for_spell(spell_id)
+        update_skill_max_values = False
         if related_profession_skill and not self.caster.skill_manager.has_skill(related_profession_skill):
             if not self.caster.skill_manager.add_skill(related_profession_skill):
                 return False
         # If the player already knows the skill, update max skill level.
         elif related_profession_skill:
-            self.caster.skill_manager.update_skills_max_value()
+            update_skill_max_values = True
 
         character_skill, skill, skill_line_ability = self.caster.skill_manager.get_skill_info_for_spell_id(spell_id)
         # Character does not have the skill, but it is a valid skill.
@@ -104,6 +105,9 @@ class SpellManager:
         db_spell.spell = spell_id
         RealmDatabaseManager.character_add_spell(db_spell)
         self.spells[spell_id] = db_spell
+
+        if update_skill_max_values:  # Update max skill after adding spell.
+            self.caster.skill_manager.update_skills_max_value()
 
         # If this spell was preceded, handle spell supersede.
         # Some spells allow for multiple rank holding, others do not.

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -474,6 +474,9 @@ class SkillManager(object):
         if not character_skill:
             return False
 
+        if skill.value >= skill.max:
+            return True
+
         gray_threshold = skill_line_ability.TrivialSkillLineRankHigh
         yellow_threshold = skill_line_ability.TrivialSkillLineRankLow
         chance = SkillManager._get_skill_gain_chance(character_skill.value, gray_threshold,
@@ -581,7 +584,7 @@ class SkillManager(object):
 
         # Skill gain chance.
         gain_chance = 100 if skill.value < 75 else 2500 / (skill.value - 50)
-        if gain_chance <= 0:
+        if gain_chance <= 0 or skill.value >= skill.max:
             return False
 
         self.set_skill(SkillTypes.FISHING, skill.value + 1)

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -584,11 +584,10 @@ class SkillManager(object):
 
         # Skill gain chance.
         gain_chance = 100 if skill.value < 75 else 2500 / (skill.value - 50)
-        if gain_chance <= 0 or skill.value >= skill.max:
+        if skill.value >= skill.max:
             return True
 
-        self.set_skill(SkillTypes.FISHING, skill.value + 1)
-        self.build_update()
+        self._roll_profession_skill_gain_chance(SkillTypes.FISHING, gain_chance * 10, 1)
         return True
 
     def get_unlocking_attempt_result(self, lock_type: LockTypes, lock_id: int,

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -585,7 +585,7 @@ class SkillManager(object):
         # Skill gain chance.
         gain_chance = 100 if skill.value < 75 else 2500 / (skill.value - 50)
         if gain_chance <= 0 or skill.value >= skill.max:
-            return False
+            return True
 
         self.set_skill(SkillTypes.FISHING, skill.value + 1)
         self.build_update()


### PR DESCRIPTION
* Add missing upper bound checks to `set_skill` calls
* Fix skill value usage in skill_step effect handler
* Fix fishing skill gain chance
* Fix updating max skill when learning a profession spell
* Fix crash when teaching spells are cast on invalid targets