### PR TITLE
Spell/aura bug fixes

### DIFF
--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -492,10 +492,10 @@ class CastingSpell:
         mana_cost = self.spell_entry.ManaCost
         power_cost_mod = 0
 
-        if self.spell_caster.get_type_id() == ObjectTypeIds.ID_PLAYER and self.spell_entry.ManaCostPct != 0:
-            mana_cost = self.spell_caster.base_mana * self.spell_entry.ManaCostPct / 100
-
         if self.spell_caster.get_type_id() == ObjectTypeIds.ID_PLAYER:
+            if self.spell_entry.ManaCostPct != 0:
+                mana_cost = self.spell_caster.base_mana * self.spell_entry.ManaCostPct / 100
+
             mana_cost = self.spell_caster.stat_manager.apply_bonuses_for_value(mana_cost, UnitStats.SPELL_SCHOOL_POWER_COST,
                                                                                misc_value=self.spell_entry.School)
         # ManaCostPerLevel is not used by anything relevant, ignore for now (only 271/4513/7290) TODO

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -592,7 +592,8 @@ class SpellManager:
         self.remove_cast(casting_spell, cast_result=SpellCheckCastResult.SPELL_FAILED_INTERRUPTED, interrupted=True)
         self.set_on_cooldown(casting_spell, cooldown_penalty=cooldown_penalty)
 
-    def remove_cast(self, casting_spell, cast_result=SpellCheckCastResult.SPELL_NO_ERROR, interrupted=False) -> bool:
+    def remove_cast(self, casting_spell, cast_result=SpellCheckCastResult.SPELL_NO_ERROR,
+                    interrupted=False, cancel_auras=False) -> bool:
         if casting_spell not in self.casting_spells:
             return False
 
@@ -608,7 +609,7 @@ class SpellManager:
         # Cancel auras applied by an active spell if the spell was interrupted.
         # If the cast finished normally, auras should wear off because of duration.
         # Spell update happens before aura update, last ticks will be skipped if auras are cancelled on cast finish.
-        if casting_spell.cast_state == SpellState.SPELL_STATE_ACTIVE and interrupted:
+        if casting_spell.cast_state == SpellState.SPELL_STATE_ACTIVE and (interrupted or cancel_auras):
             for miss_info in casting_spell.object_target_results.values():  # Get the last effect application results.
                 if not miss_info.target.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
                     continue

--- a/game/world/managers/objects/spell/aura/AppliedAura.py
+++ b/game/world/managers/objects/spell/aura/AppliedAura.py
@@ -76,6 +76,9 @@ class AppliedAura:
             # Check periodic in case of periodic auras with infinite duration.
             self.spell_effect.update_effect_aura(timestamp)
 
+        if not self.passive and self.target is self.caster:
+            self.spell_effect.handle_periodic_resource_cost(timestamp)
+
         if self.is_periodic():
             AuraEffectHandler.handle_aura_effect_change(self, self.target)
 

--- a/game/world/managers/objects/spell/aura/AreaAuraHolder.py
+++ b/game/world/managers/objects/spell/aura/AreaAuraHolder.py
@@ -12,6 +12,7 @@ class AreaAuraHolder:
     def update(self, now):
         if self.effect.applied_aura_duration != -1:
             self.effect.update_effect_aura(now)
+        self.effect.handle_periodic_resource_cost(now)
 
         self.update_effect_on_targets()
         self.effect.remove_old_periodic_effect_ticks()

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -144,14 +144,6 @@ class AuraEffectHandler:
         spell = aura.source_spell
         healing = aura.get_effect_points()
 
-        # Health Funnel is a periodic healing spell, but should act as a leech from the pet owner.
-        if effect_target.get_charmer_or_summoner() == aura.caster:
-            new_source_health = aura.caster.health - healing
-            if new_source_health <= 0:
-                aura.caster.spell_manager.remove_cast_by_id(spell.spell_entry.ID, interrupted=True)
-                return
-            aura.caster.set_health(new_source_health)
-
         aura.caster.apply_spell_healing(effect_target, healing, spell, is_periodic=True)
 
     @staticmethod

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -25,8 +25,10 @@ class AuraEffectHandler:
                          f'{aura.spell_effect.aura_type}) from spell {aura.source_spell.spell_entry.ID}.')
             return
 
-        if not remove and not is_proc and aura_type in PROC_AURA_EFFECTS:
-            return  # Only call proc effects when a proc happens.
+        is_proc_effect = aura_type in PROC_AURA_EFFECTS
+        if not remove and not is_proc and is_proc_effect or \
+                is_proc and not is_proc_effect:
+            return  # Only call proc effects when a proc happens, and only call proc effects on procs.
 
         AURA_EFFECTS[aura.spell_effect.aura_type](aura, effect_target, remove)
 

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -28,7 +28,7 @@ class AuraEffectHandler:
         is_proc_effect = aura_type in PROC_AURA_EFFECTS
         if not remove and not is_proc and is_proc_effect or \
                 is_proc and not is_proc_effect:
-            return  # Only call proc effects when a proc happens, and only call proc effects on procs.
+            return  # Only call proc effects on procs.
 
         AURA_EFFECTS[aura.spell_effect.aura_type](aura, effect_target, remove)
 


### PR DESCRIPTION
* Implement active (health/mana per second) cost for auras
    * Replaces current Health Funnel implementation that incorrectly applies to Mend Pet
* Fix friendly channeled spells not fully interrupting in some cases
* Fix some proc auras applying incorrect effects when proc condition is met