### PR TITLE
Namigator tweaks.

### DIFF
--- a/game/world/managers/CommandManager.py
+++ b/game/world/managers/CommandManager.py
@@ -814,10 +814,11 @@ class CommandManager(object):
     @staticmethod
     def los(world_session, args):
         unit = CommandManager._target_or_self(world_session)
-        los = MapManager.los_check(unit.map_id, world_session.player_mgr.get_ray_position(), unit.get_ray_position())
+        source_ray = world_session.player_mgr.get_ray_position()
+        dest_ray = unit.get_ray_position()
+        los = MapManager.los_check(unit.map_id, source_ray, dest_ray)
 
-        return 0, f'Is in line of sight: {los}\nSource: {world_session.player_mgr.location}\nTarget: ' \
-                  f'{unit.location}\nMap: {unit.map_id}'
+        return 0, f'Is in line of sight: {los}\nSource: {source_ray}\nTarget: {dest_ray}\nMap: {unit.map_id}'
 
     @staticmethod
     def kick(world_session, args):

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -270,23 +270,25 @@ class MapManager:
         if MapManager._check_tile_load(map_id, x, y, adt_x, adt_y) != MapTileStates.READY:
             return current_z, True
 
-        z_values = MAPS_NAMIGATOR[map_id].query_heights(float(x), float(y))
-        secondary_z = MAPS_NAMIGATOR[map_id].query_z(x, y, current_z, x, y)
+        heights = MAPS_NAMIGATOR[map_id].query_heights(float(x), float(y))
+        query_z = MAPS_NAMIGATOR[map_id].query_z(x, y, current_z, x, y)
 
-        if secondary_z:
-            if z_values:
-                z_values.append(secondary_z)
+        if query_z:
+            # Did found heights, append found Z.
+            if heights:
+                heights.append(query_z)
+            # No heights, use found Z.
             else:
-                z_values = [secondary_z]
+                heights = [query_z]
 
-        if len(z_values) == 0:
+        if len(heights) == 0:
             Logger.warning(f'[NAMIGATOR] Unable to find Z for Map {map_id} ADT [{adt_x},{adt_y}] X {x} Y {y}')
             return current_z, True
 
         # We are only interested in the resulting Z near to the Z we know.
-        z_values = sorted(z_values, key=lambda _z: abs(current_z - _z))
+        heights = sorted(heights, key=lambda _z: abs(current_z - _z))
 
-        return z_values[0], False
+        return heights[0], False
 
     @staticmethod
     def los_check(map_id, start_vector, end_vector):

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -452,8 +452,9 @@ class MapManager:
                 val_4 = MapManager.get_height(map_id, map_tile_x, map_tile_y, tile_local_x + 1, tile_local_y + 1)
                 bottom_height = MapManager._lerp(val_3, val_4, x_normalized)
                 calculated_z = MapManager._lerp(top_height, bottom_height, y_normalized)  # Z
-                # If maps Z is quite different, cascade into nav Z, if that also fails, current Z will be returned.
-                if math.fabs(current_z - calculated_z) >= 1.0 and current_z:
+                # If maps Z is different or exactly the same, try nav Z, if that also fails, current Z will be returned.
+                diff = math.fabs(current_z - calculated_z)
+                if (diff > 1.0 or not diff) and current_z:
                     return MapManager.calculate_nav_z(map_id, x, y, current_z)
                 return calculated_z, False
             except:

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -271,6 +271,13 @@ class MapManager:
             return current_z, True
 
         z_values = MAPS_NAMIGATOR[map_id].query_heights(float(x), float(y))
+        secondary_z = MAPS_NAMIGATOR[map_id].query_z(x, y, current_z, x, y)
+
+        if secondary_z:
+            if z_values:
+                z_values.append(secondary_z)
+            else:
+                z_values = [secondary_z]
 
         if len(z_values) == 0:
             Logger.warning(f'[NAMIGATOR] Unable to find Z for Map {map_id} ADT [{adt_x},{adt_y}] X {x} Y {y}')

--- a/game/world/managers/objects/script/ScriptHandler.py
+++ b/game/world/managers/objects/script/ScriptHandler.py
@@ -43,6 +43,8 @@ class ScriptHandler:
         if not script_commands:
             if self.owner.get_type_id() == ObjectTypeIds.ID_UNIT and self.owner.creature_template.script_name:
                 Logger.warning(f'Unimplemented advanced script: {self.owner.creature_template.script_name}.')
+            else:
+                Logger.warning(f'Unimplemented advanced script: {self.owner.gobject_template.script_name}.')
             return
         script_commands.sort(key=lambda command: command.delay)
         new_script = Script(script_id, script_commands, source, target, self, delay=delay, ooc_event=ooc_event)

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -572,6 +572,11 @@ class SpellEffectHandler:
         charge_location = caster.location.get_point_in_between(distance, target.location, map_id=caster.map_id)
         charge_location.face_point(target.location)
 
+        # Invalid Z can cause players to fall off terrain.
+        if charge_location.z_locked:
+            Logger.warning('Unable to calculate valid point for Charge/HeroicLeap, invalid Z.')
+            return
+
         # Stop movement if target is currently moving with waypoints.
         target.movement_manager.stop()
 

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -574,7 +574,10 @@ class SpellEffectHandler:
 
         # Invalid Z can cause players to fall off terrain.
         if charge_location.z_locked:
-            Logger.warning('Unable to calculate valid point for Charge/HeroicLeap, invalid Z.')
+            Logger.warning(f'Unable to calculate valid Z for Charge/HeroicLeap at Map {caster.map_id} '
+                           f'X {charge_location.x} '
+                           f'Y {charge_location.y} '
+                           f'Z {charge_location.z}.')
             return
 
         # Stop movement if target is currently moving with waypoints.

--- a/game/world/managers/objects/units/movement/behaviors/ChaseMovement.py
+++ b/game/world/managers/objects/units/movement/behaviors/ChaseMovement.py
@@ -98,4 +98,7 @@ class ChaseMovement(BaseMovement):
 
     # override
     def reset(self):
+        # Make sure the last known position gets updated.
+        if self.spline:
+            self.spline.update_to_now()
         self.spline = None

--- a/game/world/managers/objects/units/movement/helpers/SplineBuilder.py
+++ b/game/world/managers/objects/units/movement/helpers/SplineBuilder.py
@@ -1,3 +1,4 @@
+from game.world.managers.maps.MapManager import MapManager
 from game.world.managers.objects.units.movement.helpers.Spline import Spline
 from utils.constants.UnitCodes import SplineType, SplineFlags
 
@@ -21,6 +22,11 @@ class SplineBuilder:
 
     @staticmethod
     def build_stop_spline(unit, extra_time_seconds=0):
+        # Update Z on the spot.
+        z, z_locked = MapManager.calculate_z_for_object(unit)
+        if not z_locked:
+            unit.location.z = z
+
         return Spline(
             unit=unit,
             spline_type=SplineType.SPLINE_TYPE_STOP,

--- a/game/world/managers/objects/units/player/quest/QuestManager.py
+++ b/game/world/managers/objects/units/player/quest/QuestManager.py
@@ -914,9 +914,9 @@ class QuestManager(object):
         # Check chosen reward item.
         reward_items = {}
         rew_item_choice_list = list(filter((0).__ne__, QuestHelpers.generate_rew_choice_item_list(quest)))
-
+        rew_item_choice_count = list(filter((0).__ne__, QuestHelpers.generate_rew_choice_count_list(quest)))
         if item_choice < len(rew_item_choice_list) and rew_item_choice_list[item_choice] > 0:
-            reward_items[rew_item_choice_list[item_choice]] = 1
+            reward_items[rew_item_choice_list[item_choice]] = rew_item_choice_count[item_choice]
 
         # Check not chosen reward item(s).
         rew_item_list = list(filter((0).__ne__, QuestHelpers.generate_rew_item_list(quest)))


### PR DESCRIPTION
- Merge results from both query_heights and query_z in calculate_z in order to reduce cases in which Namigator returns above wmo Z's.
- Prevent Charge/HeroicLeap from triggering on Z locked result. (Unable to calculate a valid Z)
- Update unit Z upon forced movement manager stop() calls which interrupts an active spline.