### PR TITLE
Instance display_id rework

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1840,5 +1840,294 @@ begin not atomic
 
         insert into`applied_updates`values ('220620231');
     end if;
+
+    -- 24/06/2023 1
+    if (select count(*) from `applied_updates` where id='240620231') = 0 then
+
+        -- RAZORFEN DOWN
+
+        -- Quillguard
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4436;
+        
+        -- Warrior
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4435;
+        
+        -- Defender
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4442;
+        
+        -- Geomancer
+        UPDATE `creature_template`
+        SET `display_id1`=1964
+        WHERE `entry`=4442;
+        
+        -- Overlord
+        UPDATE `creature_template`
+        SET `display_id1`=2449
+        WHERE `entry`=4420;
+        
+        -- Speakhide
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4438;
+        
+        -- Death...
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4518;
+        
+        -- Earthbraker
+        UPDATE `creature_template`
+        SET `display_id1`=1964
+        WHERE `entry`=4525;
+        
+        -- Totemic
+        UPDATE `creature_template`
+        SET `display_id1`=1964
+        WHERE `entry`=4440;
+        
+        -- Champion
+        UPDATE `creature_template`
+        SET `display_id1`=1964
+        WHERE `entry`=4623;
+        
+        -- Defender
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4442;
+        
+        -- Groundshaker
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4523;
+        
+        -- Dustweaver
+        UPDATE `creature_template`
+        SET `display_id1`=1964
+        WHERE `entry`=4522;
+        
+        -- Beast
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4531;
+        
+        -- Aggem
+        UPDATE `creature_template`
+        SET `display_id1`=2449
+        WHERE `entry`=4424;
+        
+        -- Geomancer
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4520;
+        
+        -- Acolyte 
+        UPDATE `creature_template`
+        SET `display_id1`=1964
+        WHERE `entry`=4515;
+        
+        -- Adept
+        UPDATE `creature_template`
+        SET `display_id1`=1964
+        WHERE `entry`=4516;
+        
+        -- Jagba
+        UPDATE `creature_template`
+        SET `display_id1`=2449
+        WHERE `entry`=4428;
+        
+        -- Master
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4532;
+        
+        -- Warrior
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4435;
+        
+        -- Quillbeast
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4426;
+        
+        -- Sage
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4518;
+        
+        -- Seer
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4519;
+        
+        -- Guardian
+        UPDATE `creature_template`
+        SET `display_id1`=1964
+        WHERE `entry`=4427;
+        
+        -- Ward keeper
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4625;
+        
+        -- Charlga
+        UPDATE `creature_template`
+        SET `display_id1`=2449
+        WHERE `entry`=4421;
+        
+        -- Priest
+        UPDATE `creature_template`
+        SET `display_id1`=1963
+        WHERE `entry`=4517;
+        
+        -- Halmgar
+        UPDATE `creature_template`
+        SET `display_id1`=2449
+        WHERE `entry`=4842;
+        
+        -- Warden
+        UPDATE `creature_template`
+        SET `display_id1`=1964
+        WHERE `entry`=4437;
+        
+        -- Agamar
+        UPDATE `creature_template`
+        SET `display_id1`=2453
+        WHERE `entry`=4511;
+        
+        -- Rotting Agamar
+        UPDATE `creature_template`
+        SET `display_id1`=2453
+        WHERE `entry`=4512;
+        
+        -- Blood Of Agamaggan
+        UPDATE `creature_template`
+        SET `display_id1`=2028
+        WHERE `entry`=4541;
+        
+        -- Blind hunter
+        UPDATE `creature_template`
+        SET `display_id1`=1566
+        WHERE `entry`=4425;
+
+        -- SHADOWFANG
+        
+        -- Worg
+        UPDATE `creature_template`
+        SET `display_id1`=784
+        WHERE `entry`=3862;
+        
+        -- Vile Bat
+        UPDATE `creature_template`
+        SET `display_id1`=1954
+        WHERE `entry`=3866;
+
+        -- DEADMINES
+        
+        -- Defias Companion 
+        UPDATE `creature_template`
+        SET `display_id1`=1419
+        WHERE `entry`=3450;
+
+        -- WAILLING CAVERN
+        
+        -- Lady anaconda 
+        UPDATE `creature_template`
+        SET `display_id1`=2575
+        WHERE `entry`=3671;
+        
+        -- Lord Cobrhan
+        UPDATE `creature_template`
+        SET `display_id1`=2572
+        WHERE `entry`=3669;
+        
+        -- Deviate Lasher
+        UPDATE `creature_template`
+        SET `display_id1`=4091
+        WHERE `entry`=5055;
+        
+        -- Deviate Viper 
+        UPDATE `creature_template`
+        SET `display_id1`=3205
+        WHERE `entry`=5755;
+        
+        -- Deviate Adder
+        UPDATE `creature_template`
+        SET `display_id1`=3006
+        WHERE `entry`=5048;
+        
+        --  Lord Serpentis
+        UPDATE `creature_template`
+        SET `display_id1`=2572
+        WHERE `entry`=3673;
+        
+        -- Lord Pythas
+        UPDATE `creature_template`
+        SET `display_id1`=2572
+        WHERE `entry`=3670;
+        
+        -- Naralex
+        UPDATE `creature_template`
+        SET `display_id1`=2572
+        WHERE `entry`=3679;
+        
+        -- Kresh 
+        UPDATE `creature_template`
+        SET `display_id1`=2308
+        WHERE `entry`=3653;
+        
+        -- Akumai Snapjaw
+        UPDATE `creature_template`
+        SET `display_id1`=2308
+        WHERE `entry`=4825;
+        
+        -- Twilight Lord
+        UPDATE `creature_template`
+        SET `display_id1`=495
+        WHERE `entry`=4832;
+        
+        -- See Witch
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=4805;
+        
+        -- Myrmidon
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=4807;
+        
+        -- Ghamoora
+        UPDATE `creature_template`
+        SET `display_id1`=2902
+        WHERE `entry`=4887;
+        
+        -- Tide Priest
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=4802;
+        
+        -- Oracle
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=4803;
+        
+        -- Muckdweller
+        UPDATE `creature_template`
+        SET `display_id1`=3617
+        WHERE `entry`=4819;
+        
+        -- Lord Sarevess
+        UPDATE `creature_template`
+        SET `display_id1`=4036
+        WHERE `entry`=4831;
+        
+        insert into`applied_updates`values ('240620231');
+    end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1910,7 +1910,12 @@ begin not atomic
         UPDATE `creature_template`
         SET `display_id1`=1964
         WHERE `entry`=4522;
-        
+
+        -- Wind howler
+        UPDATE `creature_template`
+        SET `display_id1`=69
+        WHERE `entry`=4526;
+
         -- Beast
         UPDATE `creature_template`
         SET `display_id1`=1963


### PR DESCRIPTION
Razorfen Down
==========

Razormane mobs should use white quilboar, except scale there is only 2 very similar models avalaible. We will use one for caster and other for melee with 1.0 scale. We will use a 1.5 scaled models for named.
![WoWScrnShot_052204_024137](https://github.com/The-Alpha-Project/alpha-core/assets/72315006/853f3404-9708-41c5-8a8d-32a6f5d294b4)
![r38](https://github.com/The-Alpha-Project/alpha-core/assets/72315006/e5027677-fb0c-4455-8b47-5945750ef378)
![quilboar](https://github.com/The-Alpha-Project/alpha-core/assets/72315006/1c3bc6e6-9fc4-41da-bda5-1b67bd7370f7)


We will also apply the boar model for boars : Aga'mar Rotting Aga'mar Raging Aga'mar
![agamar](https://github.com/The-Alpha-Project/alpha-core/assets/72315006/80738884-d93b-4b82-b184-8fec064e67f3)

![shyso_5 4_43](https://github.com/The-Alpha-Project/alpha-core/assets/72315006/1ad25f10-6abf-48e5-8ffd-7b3db038dbc3)


Deadmines
==========

There is no parrot model for 0.5.3 (at least i cant find one). It seems that a special carrion bird placeholder was used.

![parrot](https://github.com/The-Alpha-Project/alpha-core/assets/72315006/bce699e4-c781-439b-8b46-253ab16f6e98)

Unused 0.2 scaled carrion bird, it's the same size as a parrot.

Shadowfang
========

![WoWScrnShot_051504_033533](https://github.com/The-Alpha-Project/alpha-core/assets/72315006/8a978acb-7dc3-45f7-a225-436d347aadf9)

Wolf should use black model.



![vilebat](https://github.com/The-Alpha-Project/alpha-core/assets/72315006/d290a824-97dc-4db8-9a69-328266435dd8)

We also update Vile Bat missing display_id


Wailing Cavern
=========

We will use NE PH for NE missing display_id
We will use Naga PH for Naga missing display_id
We will use right scaled turtle display_id (only one model for 0.5.3)
We will use right scaled Wild serpent display_id for Deviate mobs
![k15](https://github.com/The-Alpha-Project/alpha-core/assets/72315006/78bf6c74-c226-4948-a620-06de3ca13faf)


