### PR TITLE
Fixes.

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1850,6 +1850,17 @@ begin not atomic
         -- Guns
         UPDATE `trainer_template` SET `spell` = '5992' WHERE (`template_entry` = '23') and (`spell` = '3830');
         UPDATE `trainer_template` SET `spell` = '5992' WHERE (`template_entry` = '26') and (`spell` = '3830');
+
+        UPDATE `creature_template` SET `armor`=685, `dmg_min`=37.5879, `dmg_max`=49.8247, `attack_power`=54, `base_attack_time`=2000, `ranged_attack_time`=2000, `unit_flags`=64, `ranged_dmg_max`=27.8801, `ranged_attack_power`=44 WHERE `entry`=2068;
+        UPDATE `creature_template` SET `armor`=615, `dmg_min`=31.3535, `dmg_max`=41.4931, `attack_power`=48, `base_attack_time`=2000, `ranged_attack_time`=2000, `ranged_dmg_min`=17.3575, `ranged_dmg_max`=23.322, `ranged_attack_power`=40 WHERE `entry` IN (2060, 2061, 2062, 2063, 2064, 2065, 2066, 2067);
+        UPDATE `creature_template` SET `speed_walk`=1, `dmg_min`=26.2333, `dmg_max`=34.7785, `attack_power`=64, `ranged_dmg_min`=24.519, `ranged_dmg_max`=33.0643, `ranged_attack_power`=52, `armor`=791, `spell_id1`=2589, `spell_list_id`=20580, `faction`=68, `unit_flags`=32768, `script_name`='', `ai_name`='EventAI' WHERE `entry`=2058;
+        UPDATE `creature_template` SET `ai_name`='EventAI', `script_name`='' WHERE `entry` IN (2060, 2061, 2062, 2063, 2064, 2065, 2066, 2067, 2068);
+
+
+        REPLACE INTO `creature_spells` (`entry`, `name`, `spellId_1`, `probability_1`, `castTarget_1`, `targetParam1_1`, `targetParam2_1`, `castFlags_1`, `delayInitialMin_1`, `delayInitialMax_1`, `delayRepeatMin_1`, `delayRepeatMax_1`, `scriptId_1`, `spellId_2`, `probability_2`, `castTarget_2`, `targetParam1_2`, `targetParam2_2`, `castFlags_2`, `delayInitialMin_2`, `delayInitialMax_2`, `delayRepeatMin_2`, `delayRepeatMax_2`, `scriptId_2`, `spellId_3`, `probability_3`, `castTarget_3`, `targetParam1_3`, `targetParam2_3`, `castFlags_3`, `delayInitialMin_3`, `delayInitialMax_3`, `delayRepeatMin_3`, `delayRepeatMax_3`, `scriptId_3`, `spellId_4`, `probability_4`, `castTarget_4`, `targetParam1_4`, `targetParam2_4`, `castFlags_4`, `delayInitialMin_4`, `delayInitialMax_4`, `delayRepeatMin_4`, `delayRepeatMax_4`, `scriptId_4`, `spellId_5`, `probability_5`, `castTarget_5`, `targetParam1_5`, `targetParam2_5`, `castFlags_5`, `delayInitialMin_5`, `delayInitialMax_5`, `delayRepeatMin_5`, `delayRepeatMax_5`, `scriptId_5`, `spellId_6`, `probability_6`, `castTarget_6`, `targetParam1_6`, `targetParam2_6`, `castFlags_6`, `delayInitialMin_6`, `delayInitialMax_6`, `delayRepeatMin_6`, `delayRepeatMax_6`, `scriptId_6`, `spellId_7`, `probability_7`, `castTarget_7`, `targetParam1_7`, `targetParam2_7`, `castFlags_7`, `delayInitialMin_7`, `delayInitialMax_7`, `delayRepeatMin_7`, `delayRepeatMax_7`, `scriptId_7`, `spellId_8`, `probability_8`, `castTarget_8`, `targetParam1_8`, `targetParam2_8`, `castFlags_8`, `delayInitialMin_8`, `delayInitialMax_8`, `delayRepeatMin_8`, `delayRepeatMax_8`, `scriptId_8`) VALUES
+        (20580, 'Deathstalker Faerleia', 2589, 100, 1, 0, 0, 0, 6, 20, 1, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+
+        UPDATE `quest_template` SET `StartScript`=452 WHERE `entry`=452;
         
         insert into applied_updates values ('240620231');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1840,5 +1840,18 @@ begin not atomic
 
         insert into`applied_updates`values ('220620231');
     end if;
+
+    -- 24/06/2023 1
+    if(select count(*) from applied_updates where id = '240620231') = 0 then
+        -- Bows
+        UPDATE `trainer_template` SET `spell` = '5991' WHERE (`template_entry` = '23') and (`spell` = '3828');
+        UPDATE `trainer_template` SET `spell` = '5991' WHERE (`template_entry` = '26') and (`spell` = '3828');
+        
+        -- Guns
+        UPDATE `trainer_template` SET `spell` = '5992' WHERE (`template_entry` = '23') and (`spell` = '3830');
+        UPDATE `trainer_template` SET `spell` = '5992' WHERE (`template_entry` = '26') and (`spell` = '3830');
+        
+        insert into applied_updates values ('240620231');
+    end if;
 end $
 delimiter ;

--- a/game/world/WorldSessionStateHandler.py
+++ b/game/world/WorldSessionStateHandler.py
@@ -124,6 +124,7 @@ class WorldSessionStateHandler(object):
         try:
             player_mgr.synchronize_db_player()
             RealmDatabaseManager.character_update(player_mgr.player)
+            player_mgr.enchantment_manager.save()
             player_mgr.pet_manager.save()
             player_mgr.quest_manager.save()
         except AttributeError as ae:

--- a/game/world/managers/objects/script/AIEventHandler.py
+++ b/game/world/managers/objects/script/AIEventHandler.py
@@ -23,6 +23,9 @@ class AIEventHandler:
         self._events = {}
         self.event_locks: dict[int: EventLock] = {}
 
+    def reset(self):
+        self.event_locks.clear()
+
     def on_spawn(self):
         events = self._event_get_by_type(CreatureAIEventTypes.AI_EVENT_TYPE_ON_SPAWN)
         for event in events:
@@ -42,11 +45,10 @@ class AIEventHandler:
                 continue
 
             choices = ScriptHelpers.get_filtered_event_scripts(event)
-            random_script = choice(choices)
+            script = choice(choices)
 
-            if random_script:
-                self.creature.script_handler.enqueue_script(self.creature, source, ScriptTypes.SCRIPT_TYPE_AI,
-                                                            random_script)
+            if script:
+                self.creature.script_handler.enqueue_script(self.creature, source, ScriptTypes.SCRIPT_TYPE_AI, script)
 
     def on_damage_taken(self, attacker=None):
         events = self._event_get_by_type(CreatureAIEventTypes.AI_EVENT_TYPE_HP)
@@ -63,10 +65,10 @@ class AIEventHandler:
             if current_hp_percent > event.event_param1 or current_hp_percent < event.event_param2:
                 continue
 
-            script_id = event.action1_script
-            if script_id:
+            script = event.action1_script
+            if script:
                 self._lock_event(event, now)
-                self.creature.script_handler.enqueue_script(self.creature, attacker, ScriptTypes.SCRIPT_TYPE_AI, script_id)
+                self.creature.script_handler.enqueue_script(self.creature, attacker, ScriptTypes.SCRIPT_TYPE_AI, script)
 
     def on_idle(self):
         events = self._event_get_by_type(CreatureAIEventTypes.AI_EVENT_TYPE_OUT_OF_COMBAT)
@@ -81,12 +83,10 @@ class AIEventHandler:
             if event.event_chance != 100 and randint(0, 100) > event.event_chance:
                 continue
             choices = ScriptHelpers.get_filtered_event_scripts(event)
-            random_script = choice(choices)
+            script = choice(choices)
 
-            if random_script:
-                self.creature.script_handler.last_hp_event_id = event.id
-                self.creature.script_handler.enqueue_script(self.creature, killer, ScriptTypes.SCRIPT_TYPE_AI,
-                                                            random_script)
+            if script:
+                self.creature.script_handler.enqueue_script(self.creature, killer, ScriptTypes.SCRIPT_TYPE_AI, script)
 
     def on_emote_received(self, player, emote):
         events = self._event_get_by_type(CreatureAIEventTypes.AI_EVENT_TYPE_RECEIVE_EMOTE)
@@ -96,10 +96,9 @@ class AIEventHandler:
 
             # TODO: Check conditions (EmoteId, Condition, CondValue1, CondValue2).
 
-            script_id = event.action1_script
-            if script_id:
-                self.creature.script_handler.enqueue_script(self.creature, player, ScriptTypes.SCRIPT_TYPE_AI,
-                                                            script_id)
+            script = event.action1_script
+            if script:
+                self.creature.script_handler.enqueue_script(self.creature, player, ScriptTypes.SCRIPT_TYPE_AI, script)
 
     def _event_get_by_type(self, event_type):
         # Skip for controlled units.

--- a/game/world/managers/objects/script/ConditionChecker.py
+++ b/game/world/managers/objects/script/ConditionChecker.py
@@ -663,13 +663,24 @@ class ConditionChecker:
         return target.is_alive
 
     @staticmethod
-    def check_condition_map_event_targets(_condition, _source, _target):
+    def check_condition_map_event_targets(condition, _source, _target):
+        from game.world.managers.maps.MapManager import MapManager
         # Requires Map.
         # True if all extra targets that are part of the given event satisfy the given condition.
         # Condition_value1 = event id.
         # Condition_value2 = condition id.
-        Logger.warning('CONDITION_MAP_EVENT_TARGETS is not implemented.')
-        return False
+        satisfied = True
+        unit = _source if _source else _target
+        map_ = MapManager.get_map(unit.map_id, unit.instance_id)
+        if not map_:
+            return False
+        scripted_event = map_.map_event_manager.get_map_event_data(condition.value1)
+        if scripted_event:
+            for event_target in scripted_event.event_targets:
+                satisfied = satisfied and ConditionChecker.validate(condition.value2, _source, event_target)
+                if not satisfied:
+                    return False
+        return satisfied
 
     @staticmethod
     def check_condition_object_is_spawned(_condition, _source, target):

--- a/game/world/managers/objects/script/ConditionChecker.py
+++ b/game/world/managers/objects/script/ConditionChecker.py
@@ -1,6 +1,6 @@
 import datetime
 from database.world.WorldDatabaseManager import WorldDatabaseManager
-from utils.constants.ConditionCodes import ConditionType, ConditionFlags, ConditionTargetsInternal
+from utils.constants.ConditionCodes import ConditionType, ConditionFlags, ConditionTargetsInternal, EscortConditionFlags
 from utils.Logger import Logger
 from utils.constants.MiscCodes import ObjectTypeIds, QuestState, ObjectTypeFlags
 from utils.constants.UnitCodes import Genders, PowerTypes, UnitFlags
@@ -387,14 +387,21 @@ class ConditionChecker:
         # Checks if the source and target are alive and the distance between them.
         # Condition_value1 = EscortConditionFlags.
         # Condition_value2 = distance.
-        # Doesn't appear to be used in 0.5.3.
         if not ConditionChecker.is_creature(source) or not ConditionChecker.is_player(target):
-            return False
-
-        if source.location.distance(target.location) <= condition.value2 and source.is_alive and target.is_alive:
             return True
 
-        # TODO: implement EscortConditionFlags + handle optional source/target.
+        if condition.value1 & EscortConditionFlags.CF_ESCORT_SOURCE_DEAD:
+            if not source.is_alive:
+                return True
+
+        if condition.value1 & EscortConditionFlags.CF_ESCORT_TARGET_DEAD:
+            if not target.is_alive or not target.is_online:
+                return True
+
+        if condition.value2:
+            if not source.location.distance(target.location) <= condition.value2:
+                return True
+
         return False
 
     @staticmethod

--- a/game/world/managers/objects/script/ScriptHandler.py
+++ b/game/world/managers/objects/script/ScriptHandler.py
@@ -394,26 +394,28 @@ class ScriptHandler:
         # datalong2 = distance or 0
         # datalong3 = (bool) group
         quest_target = None
-        if command.source and command.source.quest_target:
-            quest_target = command.source.quest_target
-        elif command.target and command.target.quest_target:
-            quest_target = command.target.quest_target
+        if not ConditionChecker.is_player(command.source) and not ConditionChecker.is_player(command.target):
+            Logger.warning('ScriptHandler: handle_script_command_quest_explored failed, no player found!')
+            return True  # Abort.
 
-        if not quest_target:
+        player = command.source if ConditionChecker.is_player(command.source) else command.target
+        quest_giver = command.target if ConditionChecker.is_player(command.source) else command.source
+
+        if not quest_giver:
             Logger.warning('ScriptHandler: handle_script_command_quest_explored failed, no quest_target found!')
-            return
+            return True
 
-        if command.datalong not in quest_target.quest_manager.active_quests:
-            return
+        if command.datalong not in player.quest_manager.active_quests:
+            return True
 
-        in_range = command.source.location.distance(quest_target.location) <= command.datalong2
-        if command.datalong3 and quest_target.group_manager and in_range:
-            quest_target.group_manager.reward_quest_completion(quest_target, command.datalong)
+        in_range = player.location.distance(quest_giver.location) <= command.datalong2
+        if command.datalong3 and player.group_manager and in_range:
+            player.group_manager.reward_quest_completion(player, command.datalong)
             return
 
         if in_range:
-            quest_target.quest_manager.active_quests[command.datalong].set_explored_or_event_complete()
-            quest_target.quest_manager.reward_quest_event()
+            player.quest_manager.active_quests[command.datalong].set_explored_or_event_complete()
+            player.quest_manager.reward_quest_event()
 
     @staticmethod
     def handle_script_command_kill_credit(_command):
@@ -1150,7 +1152,7 @@ class ScriptHandler:
                            f'({command.source.map_id}) and/or instance ({command.source.instance_id}).')
             return
 
-        map_.map_event_manager.end_event(command.source, command.datalong, command.datalong2)
+        map_.map_event_manager.end_event(command.datalong, command.datalong2)
 
     @staticmethod
     def handle_script_command_add_map_event_target(command):

--- a/game/world/managers/objects/script/ScriptHandler.py
+++ b/game/world/managers/objects/script/ScriptHandler.py
@@ -405,14 +405,13 @@ class ScriptHandler:
 
         if command.datalong not in quest_target.quest_manager.active_quests:
             return
+
         in_range = command.source.location.distance(quest_target.location) <= command.datalong2
-        if command.datalong3:
-            if quest_target.group_manager and in_range:
-                quest_target.group_manager.reward_quest_completion(quest_target, command.datalong)
-            elif in_range:
-                quest_target.quest_manager.active_quests[command.datalong].set_explored_or_event_complete()
-                quest_target.quest_manager.reward_quest_event()
-        elif in_range:
+        if command.datalong3 and quest_target.group_manager and in_range:
+            quest_target.group_manager.reward_quest_completion(quest_target, command.datalong)
+            return
+
+        if in_range:
             quest_target.quest_manager.active_quests[command.datalong].set_explored_or_event_complete()
             quest_target.quest_manager.reward_quest_event()
 

--- a/game/world/managers/objects/script/ScriptedEvent.py
+++ b/game/world/managers/objects/script/ScriptedEvent.py
@@ -32,7 +32,7 @@ class ScriptedEvent:
         if self.expire_time >= now:
             if self.failure_condition and ConditionChecker.validate(self.failure_condition, self.source, self.target):
                 self.end_event(False)
-            elif self.failure_condition and ConditionChecker.validate(self.success_condition, self.source, self.target):
+            elif self.success_condition and ConditionChecker.validate(self.success_condition, self.source, self.target):
                 self.end_event(True)
         else:
             self.end_event(False)

--- a/game/world/managers/objects/script/ScriptedEvent.py
+++ b/game/world/managers/objects/script/ScriptedEvent.py
@@ -28,11 +28,14 @@ class ScriptedEvent:
         if self.ended:
             return
 
+        # While active, keep checking fail/success conditions.
         if self.expire_time >= now:
-            if ConditionChecker.validate(self.failure_condition, self.source, self.target):
+            if self.failure_condition and ConditionChecker.validate(self.failure_condition, self.source, self.target):
                 self.end_event(False)
-            elif ConditionChecker.validate(self.success_condition, self.source, self.target):
+            elif self.failure_condition and ConditionChecker.validate(self.success_condition, self.source, self.target):
                 self.end_event(True)
+        else:
+            self.end_event(False)
 
     def end_event(self, success):
         self.ended = True

--- a/game/world/managers/objects/spell/ExtendedSpellData.py
+++ b/game/world/managers/objects/spell/ExtendedSpellData.py
@@ -243,7 +243,7 @@ class ProfessionInfo:
 
 
 class EnchantmentInfo:
-    _NAME_TO_SLOT = {
+    _NAME_TO_INV_TYPE = {
         'boot': {InventoryTypes.FEET},
         'glove': {InventoryTypes.HAND},
         'bracer': {InventoryTypes.WRIST},
@@ -253,10 +253,11 @@ class EnchantmentInfo:
 
     @staticmethod
     def can_apply_to_item(source_spell, item):
-        for key, value in EnchantmentInfo._NAME_TO_SLOT.items():
+        for key, inv_types in EnchantmentInfo._NAME_TO_INV_TYPE.items():
             if key in source_spell.spell_entry.Name_enUS.lower():
-                return item.item_template.inventory_type in value
+                return item.item_template.inventory_type in inv_types
         return True
+
 
 class UnitSpellsValidator:
     # TODO: For further investigation:

--- a/game/world/managers/objects/spell/ExtendedSpellData.py
+++ b/game/world/managers/objects/spell/ExtendedSpellData.py
@@ -1,6 +1,7 @@
 import math
 from typing import Optional
 
+from utils.constants.ItemCodes import InventoryTypes
 from utils.constants.SpellCodes import ShapeshiftForms, TotemSlots, SpellMechanic, AuraTypes
 from utils.constants.UnitCodes import Teams, PowerTypes
 
@@ -240,6 +241,22 @@ class ProfessionInfo:
                 return skill_id
         return 0
 
+
+class EnchantmentInfo:
+    _NAME_TO_SLOT = {
+        'boot': {InventoryTypes.FEET},
+        'glove': {InventoryTypes.HAND},
+        'bracer': {InventoryTypes.WRIST},
+        'chest': {InventoryTypes.CHEST, InventoryTypes.ROBE},
+        'cloak': {InventoryTypes.CLOAK}
+    }
+
+    @staticmethod
+    def can_apply_to_item(source_spell, item):
+        for key, value in EnchantmentInfo._NAME_TO_SLOT.items():
+            if key in source_spell.spell_entry.Name_enUS.lower():
+                return item.item_template.inventory_type in value
+        return True
 
 class UnitSpellsValidator:
     # TODO: For further investigation:

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -96,7 +96,7 @@ class SpellManager:
             cast_ui_spells = self.caster.skill_manager.get_cast_ui_spells_for_skill_id(skill.ID)
             # Player doesn't have any cast UI for this spell yet.
             if cast_ui_spells and not self.spells.keys() & cast_ui_spells:
-                # Get cast UI with lowest spell ID (lowest rank where applicable).
+                # Get cast UI with the lowest spell ID (lowest rank where applicable).
                 cast_ui_spell = min(cast_ui_spells)
                 if self.can_learn_spell(cast_ui_spell):
                     self.learn_spell(cast_ui_spell)

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -1207,11 +1207,15 @@ class SpellManager:
                     self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_ERROR)
                     return False
 
+            # TODO: It seems like players are supposed to be able to apply a different enchant,
+            #  maybe the spell error 'SPELL_FAILED_ITEM_ALREADY_ENCHANTED' was used to prevent the same enchant
+            #  from being applied again? But yet again you could apply the same enchant if you want to renew
+            #  charges/durations.
             # Do not allow to enchant if it has an existent permanent enchantment.
-            if not has_t_enchant_effect and \
-                    EnchantmentManager.get_permanent_enchant_value(casting_spell.initial_target) != 0:
-                self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_ITEM_ALREADY_ENCHANTED)
-                return False
+            # if not has_t_enchant_effect and \
+            #         EnchantmentManager.get_permanent_enchant_value(casting_spell.initial_target) != 0:
+            #     self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_ITEM_ALREADY_ENCHANTED)
+            #     return False
 
         # Spell learning/teaching checks.
         taught_spells = [effect.trigger_spell_id for effect in casting_spell.get_effects()

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -1197,6 +1197,7 @@ class SpellManager:
             #  e.g. Enchant bracers would still work on legs, chest, etc. So maybe they had some filtering by name?
             if not ExtendedSpellData.EnchantmentInfo.can_apply_to_item(casting_spell, casting_spell.initial_target):
                 self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS)
+                return False
 
             # Do not allow temporary enchantments in trade slot.
             if has_t_enchant_effect:

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -190,6 +190,10 @@ class UnitManager(ObjectManager):
         # Cheat flags, used by Players.
         self.beast_master = False
 
+        # Relocation (Players/Creatures), Call for help (Creatures)
+        self.relocation_call_for_help_timer = 0
+        self.pending_relocation = False
+
         # Defensive passive spells are not handled through the aura system.
         # The effects will instead flag the unit with these fields.
         self.has_block_passive = False

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -61,8 +61,6 @@ class CreatureManager(UnitManager):
         self.ranged_attack_time = 0
         self.ranged_dmg_min = 0
         self.ranged_dmg_max = 0
-        self.pending_relocation = False
-        self.relocation_call_for_help_timer = 0
         self.destroy_time = 0
         self.destroy_timer = 420  # Standalone instances, destroyed after 7 minutes.
         self.virtual_item_info = {}

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -69,8 +69,6 @@ class CreatureManager(UnitManager):
         self.fully_loaded = False
         self.killed_by = None
         self.known_players = {}
-        # TODO: Temp, see TODO in QuestGiverAcceptQuestHandler
-        self.quest_target = None
 
         # # Managers, will be load upon lazy loading trigger.
         self.loot_manager = None
@@ -741,7 +739,6 @@ class CreatureManager(UnitManager):
 
     # override
     def respawn(self):
-        self.quest_target = None
         super().respawn()
 
     # override

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -381,6 +381,7 @@ class CreatureManager(UnitManager):
 
     def on_at_home(self):
         self.apply_default_auras()
+        self.object_ai.ai_event_handler.reset()
         self.movement_manager.face_angle(self.spawn_position.o)
         # Scan surrounding for enemies.
         self._on_relocation()

--- a/game/world/managers/objects/units/movement/behaviors/FearMovement.py
+++ b/game/world/managers/objects/units/movement/behaviors/FearMovement.py
@@ -40,6 +40,9 @@ class FearMovement(BaseMovement):
         self.can_move = True
 
     def _trigger_fear(self):
+        # Attack stop if needed, else unit will keep trying to turn towards target.
+        if self.unit.combat_target:
+            self.unit.send_attack_stop(self.unit.combat_target.guid)
         speed = self.unit.running_speed
         if not self.waypoints:
             fear_point = self._get_fear_point()

--- a/game/world/managers/objects/units/player/EnchantmentManager.py
+++ b/game/world/managers/objects/units/player/EnchantmentManager.py
@@ -35,12 +35,15 @@ class EnchantmentManager(object):
                 self.set_item_enchantment(item, slot, entry, duration, charges)
 
     # TODO: Need to optimize item lookup or even move Enchantment updates to a new global thread.
-    def update(self, elapsed):
+    def update(self, elapsed, saving=False):
         self.duration_timer_seconds += elapsed
-        if self.duration_timer_seconds >= 10:
+        if saving or self.duration_timer_seconds >= 10:
             for item in list(self.unit_mgr.inventory.get_backpack().sorted_slots.values()):
                 self._update_item_enchantments(item)
             self.duration_timer_seconds = 0
+
+    def save(self):
+        self.update(0, saving=True)
 
     def _update_item_enchantments(self, item):
         for slot, enchantment in enumerate(item.enchantments):
@@ -50,6 +53,8 @@ class EnchantmentManager(object):
                 if not enchantment.duration and not enchantment.charges:
                     # Remove.
                     self.set_item_enchantment(item, slot, 0, 0, 0, expired=True)
+                elif new_duration:
+                    item.save()
 
     # noinspection PyMethodMayBeStatic
     def _consume_item_charges(self, item, enchantment_slot, used_charges=1):

--- a/game/world/opcode_handling/handlers/quest/QuestGiverAcceptQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverAcceptQuestHandler.py
@@ -46,9 +46,5 @@ class QuestGiverAcceptQuestHandler(object):
             elif is_item or quest_giver.is_within_interactable_distance(player_mgr):
                 player_mgr.quest_manager.handle_accept_quest(quest_id, guid, shared=False, quest_giver=quest_giver,
                                                              is_item=is_item)
-                # TODO: This shouldn't be needed at all, it's only useful for escort quests. EscortAI is needed (or use
-                #  ScriptedMadEvent for them instead, need to think about it).
-                if not is_item:
-                    quest_giver.quest_target = player_mgr
 
         return 0


### PR DESCRIPTION
- Fix Pyrewood Ambush quest https://streamable.com/r8fihl
- Fix ConditionChecker CONDITION_ESCORT.
- Fix CONDITION_MAP_EVENT_TARGETS.
- Fix SCRIPT_COMMAND_QUEST_EXPLORED.
- Fix SCRIPT_COMMAND_END_MAP_EVENT crash.
- Fix locked events not being unlocked after unit reset. (After evade).
- Fix units always trying to turn towards the caster when feared.
- Fix some enchantments not properly validating the item target slot. e.g. Chest enchant on Boots.
- Fix not being able to imbue a temporary enchant on top of a permanent enchanted item.
- Fix not being able to override an enchant, either 'permanent' or temporary.
- Fix temporary enchants persistence, duration reset upon logout login, include enchantments on save character call.
- Fix Guns/Crossbows trainer templates, they should teach both the skill spell and Shoot.
- Share relocation/call_for_help timer for both players and units.