### PR TITLE
Update system and minor fixes.

### DIFF
--- a/database/world/WorldDatabaseManager.py
+++ b/database/world/WorldDatabaseManager.py
@@ -55,10 +55,25 @@ class WorldDatabaseManager(object):
         world_db_session.close()
         return res
 
+    class UnitClassLevelStatsHolder:
+        CLASS_LEVEL_STATS: [int, [int, PlayerClasslevelstats]] = {}
+
+        @staticmethod
+        def load_player_class_level_stats(stats):
+            if stats.class_ not in WorldDatabaseManager.UnitClassLevelStatsHolder.CLASS_LEVEL_STATS:
+                WorldDatabaseManager.UnitClassLevelStatsHolder.CLASS_LEVEL_STATS[stats.class_] = {}
+            WorldDatabaseManager.UnitClassLevelStatsHolder.CLASS_LEVEL_STATS[stats.class_][stats.level] = stats
+
+        @staticmethod
+        def get_for_class_level(class_, level) -> Optional[PlayerClasslevelstats]:
+            if class_ not in WorldDatabaseManager.UnitClassLevelStatsHolder.CLASS_LEVEL_STATS:
+                return None
+            return WorldDatabaseManager.UnitClassLevelStatsHolder.CLASS_LEVEL_STATS[class_].get(level, None)
+
     @staticmethod
-    def player_get_class_level_stats(class_, level) -> Optional[PlayerClasslevelstats]:
+    def player_class_level_stats_get_all():
         world_db_session = SessionHolder()
-        res = world_db_session.query(PlayerClasslevelstats).filter_by(level=level, _class=class_).first()
+        res = world_db_session.query(PlayerClasslevelstats).all()
         world_db_session.close()
         return res
 

--- a/database/world/WorldModels.py
+++ b/database/world/WorldModels.py
@@ -611,7 +611,7 @@ class NpcText(Base):
 class PlayerClasslevelstats(Base):
     __tablename__ = 'player_classlevelstats'
 
-    _class = Column('class', TINYINT(3), primary_key=True, nullable=False)
+    class_ = Column('class', TINYINT(3), primary_key=True, nullable=False)
     level = Column(TINYINT(3), primary_key=True, nullable=False)
     basehp = Column(SMALLINT(5), nullable=False)
     basemana = Column(SMALLINT(5), nullable=False)

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -28,6 +28,9 @@ class WorldLoader:
         WorldLoader.load_pickpocketing_loot_templates()
         WorldLoader.load_item_loot_templates()
 
+        # Player class level stats.
+        WorldLoader.load_player_class_level_stats()
+
         # Spells.
         WorldLoader.load_spells()
         WorldLoader.load_creature_spells()
@@ -90,6 +93,18 @@ class WorldLoader:
         MapManager.initialize_area_tables()
 
     # World data holders
+    @staticmethod
+    def load_player_class_level_stats():
+        class_level_stats = WorldDatabaseManager.player_class_level_stats_get_all()
+        length = len(class_level_stats)
+        count = 0
+
+        for class_level_stat in class_level_stats:
+            WorldDatabaseManager.UnitClassLevelStatsHolder.load_player_class_level_stats(class_level_stat)
+            count += 1
+            Logger.progress('Loading player class level stats...', count, length)
+
+        return length
 
     @staticmethod
     def load_gameobject_scripts():

--- a/game/world/WorldManager.py
+++ b/game/world/WorldManager.py
@@ -17,6 +17,7 @@ from network.packet.PacketWriter import *
 from utils.Logger import Logger
 from utils.ChatLogManager import ChatLogManager
 from utils.constants.AuthCodes import AuthCode
+from utils.constants.MiscCodes import ObjectTypeIds
 
 STARTUP_TIME = time()
 WORLD_ON = True
@@ -229,12 +230,40 @@ class WorldServerSessionHandler:
                                         max_instances=1)
         player_update_scheduler.start()
 
-        # Player updates.
-        player_update_known_object_scheduler = BackgroundScheduler()
-        player_update_known_object_scheduler._daemon = True
-        player_update_known_object_scheduler.add_job(WorldSessionStateHandler.update_known_players_objects, 'interval',
-                                                     seconds=0.5, max_instances=1)
-        player_update_known_object_scheduler.start()
+        # Known players updates.
+        known_players_scheduler = BackgroundScheduler()
+        known_players_scheduler._daemon = True
+        known_players_scheduler.add_job(WorldSessionStateHandler.update_known_world_objects, 'interval',
+                                        seconds=0.5, max_instances=1, args=(ObjectTypeIds.ID_PLAYER,))
+        known_players_scheduler.start()
+
+        # Known creatures updates.
+        known_creatures_scheduler = BackgroundScheduler()
+        known_creatures_scheduler._daemon = True
+        known_creatures_scheduler.add_job(WorldSessionStateHandler.update_known_world_objects, 'interval',
+                                          seconds=1, max_instances=1, args=(ObjectTypeIds.ID_UNIT,))
+        known_creatures_scheduler.start()
+
+        # Known gameobjects updates.
+        known_gameobjects_scheduler = BackgroundScheduler()
+        known_gameobjects_scheduler._daemon = True
+        known_gameobjects_scheduler.add_job(WorldSessionStateHandler.update_known_world_objects, 'interval',
+                                                  seconds=2, max_instances=1, args=(ObjectTypeIds.ID_GAMEOBJECT,))
+        known_gameobjects_scheduler.start()
+
+        # Known dynamic objects updates.
+        known_dynobjects_scheduler = BackgroundScheduler()
+        known_dynobjects_scheduler._daemon = True
+        known_dynobjects_scheduler.add_job(WorldSessionStateHandler.update_known_world_objects, 'interval',
+                                                     seconds=1, max_instances=1, args=(ObjectTypeIds.ID_DYNAMICOBJECT,))
+        known_dynobjects_scheduler.start()
+
+        # Known corpse objects updates.
+        known_corpses_scheduler = BackgroundScheduler()
+        known_corpses_scheduler._daemon = True
+        known_corpses_scheduler.add_job(WorldSessionStateHandler.update_known_world_objects, 'interval',
+                                                      seconds=2, max_instances=1, args=(ObjectTypeIds.ID_CORPSE,))
+        known_corpses_scheduler.start()
 
         # Creature updates.
         creature_update_scheduler = BackgroundScheduler()

--- a/game/world/WorldSessionStateHandler.py
+++ b/game/world/WorldSessionStateHandler.py
@@ -1,6 +1,7 @@
 import time
 from database.realm.RealmDatabaseManager import *
 from utils.Logger import Logger
+from utils.constants.MiscCodes import ObjectTypeIds
 
 WORLD_SESSIONS = []
 
@@ -96,14 +97,14 @@ class WorldSessionStateHandler(object):
                 session.player_mgr.update(now)
 
     @staticmethod
-    def update_known_players_objects():
+    def update_known_world_objects(object_type):
         for session in WORLD_SESSIONS:
             if not session.player_mgr or not session.player_mgr.online:
                 continue
-            if session.player_mgr.update_lock or not session.player_mgr.update_known_objects_on_tick:
+            if session.player_mgr.update_lock or object_type not in session.player_mgr.pending_known_object_types_updates:
                 continue
-            session.player_mgr.update_known_objects_on_tick = False
-            session.player_mgr.update_known_world_objects()
+            session.player_mgr.pending_known_object_types_updates.remove(object_type)
+            session.player_mgr.update_known_objects_for_type(object_type)
 
     @staticmethod
     def save_characters():

--- a/game/world/managers/maps/Cell.py
+++ b/game/world/managers/maps/Cell.py
@@ -128,7 +128,7 @@ class Cell:
         if world_object:
             player.update_world_object_on_me(world_object, has_changes, has_inventory_changes)
         else:
-            player.update_known_objects_on_tick = True
+            player.enqueue_known_objects_update()
 
     def remove(self, world_object):
         guid = world_object.guid

--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -113,7 +113,7 @@ class GridManager:
             if world_object.is_temp_summon() or world_object.is_pet():
                 summoner = world_object.get_charmer_or_summoner()
                 if summoner.get_type_id() == ObjectTypeIds.ID_PLAYER:
-                    summoner.update_known_world_object(world_object)
+                    summoner.update_not_known_world_object(world_object)
 
             self._update_players_surroundings(cell.key)
 

--- a/game/world/managers/objects/farsight/Camera.py
+++ b/game/world/managers/objects/farsight/Camera.py
@@ -23,7 +23,7 @@ class Camera:
 
     def update_camera_on_players(self):
         for player_mgr in list(self.players.values()):
-            player_mgr.update_known_objects_on_tick = True
+            player_mgr.enqueue_known_objects_update()
 
     def has_player(self, player_mgr):
         return player_mgr.guid in self.players
@@ -45,7 +45,7 @@ class Camera:
     def flush(self):
         for player_mgr in list(self.players.values()):
             self.pop_player(player_mgr)
-            player_mgr.update_known_objects_on_tick = True
+            player_mgr.enqueue_known_objects_update()
             spell = player_mgr.spell_manager.get_casting_spell()
             if spell and spell.is_far_sight() and spell.is_channeled():
                 player_mgr.spell_manager.interrupt_casting_spell()

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -533,7 +533,10 @@ class SpellManager:
                 self.apply_spell_effects(casting_spell, partial_targets=targets_due)
 
     def check_spell_interrupts(self, moved=False, turned=False, received_damage=False, hit_info=HitInfo.DAMAGE,
-                               interrupted=False, received_auto_attack=False):  # TODO provide interrupted
+                               interrupted=False, received_auto_attack=False):
+        if not self.casting_spells:
+            return
+
         casting_spell_flag_cases = {
             SpellInterruptFlags.SPELL_INTERRUPT_FLAG_MOVEMENT: moved,
             SpellInterruptFlags.SPELL_INTERRUPT_FLAG_DAMAGE: received_damage,

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -118,6 +118,8 @@ class AuraManager:
     def check_aura_interrupts(self, moved=False, turned=False, changed_stand_state=False, negative_aura_applied=False,
                               received_damage=False, enter_combat=False, attacked=False,
                               cast_spell: Optional[CastingSpell] = None):
+        if not self.active_auras:
+            return
         flag_cases = {
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_ENTER_COMBAT: enter_combat,
             SpellAuraInterruptFlags.AURA_INTERRUPT_FLAG_NOT_MOUNTED: self.unit_mgr.unit_flags & UnitFlags.UNIT_MASK_MOUNTED,

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -338,7 +338,7 @@ class UnitManager(ObjectManager):
         swing_error = AttackSwingError.NONE
         combat_angle = math.pi
 
-        # If neither main hand attack and off hand attack are ready, return.
+        # If neither main hand attack and offhand attack are ready, return.
         if not self.is_attack_ready(AttackTypes.BASE_ATTACK) and \
                 (self.has_offhand_weapon() and not self.is_attack_ready(AttackTypes.OFFHAND_ATTACK)):
             return False
@@ -375,7 +375,7 @@ class UnitManager(ObjectManager):
                 self.attacker_state_update(self.combat_target, AttackTypes.BASE_ATTACK)
                 self.set_attack_timer(AttackTypes.BASE_ATTACK, main_attack_delay)
 
-            # Off hand attack.
+            # Offhand attack.
             if self.has_offhand_weapon() and self.is_attack_ready(AttackTypes.OFFHAND_ATTACK):
                 # Prevent both hand attacks at the same time.
                 if self.attack_timers[AttackTypes.BASE_ATTACK] < 500:
@@ -1642,8 +1642,10 @@ class UnitManager(ObjectManager):
         # Leave combat if needed.
         self.leave_combat()
 
-        # Flush movement manager.
+        # Flush movement manager and notify none movement flags to observers.
         self.movement_manager.flush()
+        self.movement_flags = MoveFlags.MOVEFLAG_NONE
+        MapManager.send_surrounding(self.generate_movement_packet(), self, include_self=False)
 
         # Reset threat manager.
         self.threat_manager.reset()
@@ -1672,8 +1674,7 @@ class UnitManager(ObjectManager):
         self.spell_manager.remove_casts()
         self.aura_manager.handle_death()
 
-        # Reset movement and unit state flags.
-        self.movement_flags = MoveFlags.MOVEFLAG_NONE
+        # Reset unit state flags.
         self.unit_state = UnitStates.NONE
 
         return True

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -1726,6 +1726,9 @@ class UnitManager(ObjectManager):
 
         self.set_stand_state(StandState.UNIT_STANDING)
 
+    def get_map(self):
+        return MapManager.get_map(self.map_id, self.instance_id)
+
     # Implemented by CreatureManager and PlayerManager
     def get_bytes_0(self):
         pass

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -535,8 +535,7 @@ class CreatureManager(UnitManager):
                 if self.object_ai:
                     self.object_ai.update_ai(elapsed)
                 # Attack Update.
-                if self.combat_target:
-                    self.attack_update(elapsed)
+                self.attack_update(elapsed)
             # Dead creature with no spawn point, handle destroy.
             elif not self._check_destroy(elapsed):
                 return  # Creature destroyed.

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -490,7 +490,7 @@ class CreatureManager(UnitManager):
 
     # override
     def is_active_object(self):
-        if not self.is_spawned or not self.initialized:
+        if not self.fully_loaded or not self.is_spawned or not self.initialized:
             return False
         
         return self.has_waypoints_type() or self.creature_group \
@@ -509,7 +509,11 @@ class CreatureManager(UnitManager):
         if now > self.last_tick > 0:
             elapsed = now - self.last_tick
 
-            if self.is_alive and self.is_active_object():
+            is_active = self.is_active_object()
+            if not is_active:
+                return
+
+            if self.is_alive:
                 # Time to live checks for standalone instances.
                 if not self._check_time_to_live(elapsed):
                     return  # Creature destroyed.

--- a/game/world/managers/objects/units/creature/ThreatManager.py
+++ b/game/world/managers/objects/units/creature/ThreatManager.py
@@ -2,7 +2,6 @@ import random
 from dataclasses import dataclass
 from typing import Optional
 
-from database.dbc.DbcDatabaseManager import DbcDatabaseManager
 from game.world.managers.maps.MapManager import MapManager
 from game.world.managers.objects.units.UnitManager import UnitManager
 from utils.Logger import Logger

--- a/game/world/managers/objects/units/movement/MovementInfo.py
+++ b/game/world/managers/objects/units/movement/MovementInfo.py
@@ -81,8 +81,8 @@ class MovementInfo:
         self.transport = None
 
     def _get_transport(self):
-        from game.world.managers.maps.MapManager import MapManager
-        return MapManager.get_surrounding_gameobject_by_guid(self.owner, self.owner.transport_id).transport_manager
+        map_ = self.owner.get_map()
+        return map_.get_surrounding_gameobject_by_guid(self.owner, self.owner.transport_id).transport_manager
 
     def get_bytes(self):
         data = pack('<2Q9fI', self.owner.guid, self.owner.transport_id, self.owner.transport_location.x,

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -119,12 +119,13 @@ class StatManager(object):
         self.aura_stats_percentual = {}
 
     def init_stats(self):
-        base_stats = WorldDatabaseManager.player_get_class_level_stats(self.unit_mgr.class_, self.unit_mgr.level)
+        base_stats = WorldDatabaseManager.UnitClassLevelStatsHolder.get_for_class_level(self.unit_mgr.class_,
+                                                                                        self.unit_mgr.level)
 
         if not base_stats:
             if self.unit_mgr.level > 60:
                 # Default to max available base stats, level 60.
-                base_stats = WorldDatabaseManager.player_get_class_level_stats(self.unit_mgr.class_, 60)
+                base_stats = WorldDatabaseManager.UnitClassLevelStatsHolder.get_for_class_level(self.unit_mgr.class_, 60)
                 Logger.warning(f'Unsupported base stats for level ({self.unit_mgr.level})'
                                f' Unit class ({Classes(self.unit_mgr.class_).name})'
                                f' Unit type ({ObjectTypeIds(self.unit_mgr.get_type_id()).name})'

--- a/game/world/opcode_handling/handlers/interface/CharCreateHandler.py
+++ b/game/world/opcode_handling/handlers/interface/CharCreateHandler.py
@@ -51,8 +51,8 @@ class CharCreateHandler(object):
 
         if result == CharCreate.CHAR_CREATE_SUCCESS:
             map_, zone, x, y, z, o = CharCreateHandler.get_starting_location(race, class_)
-            base_stats = WorldDatabaseManager.player_get_class_level_stats(class_,
-                                                                           config.Unit.Player.Defaults.starting_level)
+            level = config.Unit.Player.Defaults.starting_level
+            base_stats = WorldDatabaseManager.UnitClassLevelStatsHolder.get_for_class_level(class_, level)
             character = Character(account_id=world_session.account_mgr.account.id,
                                   realm_id=config.Server.Connection.Realm.local_realm_id,
                                   name=name,


### PR DESCRIPTION
- Short circuit spell/aura interrupt checks.
- Do not update creatures which are not yet ready.
- Improve creatures lazy initialization time by caching level stats.
- Decouple known object updates, one scheduler per object type.
- Creatures swing timers should be updated when out of combat.
- Moveflags reset should be notified to surroundings upon dying. (Fixes sliding corpses).