### PR TITLE
Spell, equipment and skill bug fixes

### DIFF
--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -393,6 +393,9 @@ class CastingSpell:
     def has_only_harmful_effects(self):
         return all([effect.is_harmful() for effect in self.get_effects()])
 
+    def has_only_helpful_effects(self):
+        return all([not effect.is_harmful() for effect in self.get_effects()])
+
     def get_charm_effect(self) -> Optional[SpellEffect]:
         for spell_effect in self.get_effects():
             if spell_effect.aura_type in [AuraTypes.SPELL_AURA_MOD_CHARM, AuraTypes.SPELL_AURA_MOD_POSSESS]:

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -770,15 +770,14 @@ class SpellEffectHandler:
             return
         
         skill_max = (step * 5)
-        skill_id = casting_spell.spell_entry.EffectMiscValue_2
-        if skill_id <= 0:
-            return
+        skill_id = effect.misc_value
         
         if not target.skill_manager.has_skill(skill_id):
             target.skill_manager.add_skill(skill_id)
 
         current_skill = target.skill_manager.get_total_skill_value(skill_id, no_bonus=True)
-        target.skill_manager.set_skill(skill_id, max(1, current_skill), skill_max)
+        target.skill_manager.set_skill(skill_id, max(1, current_skill),
+                                       skill_max if skill_max < 1000 else -1)
         target.skill_manager.build_update()
 
     @staticmethod

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -449,6 +449,9 @@ class SpellManager:
                     damage_info = DamageInfoHolder(attacker=casting_spell.spell_caster, target=target,
                                                    proc_victim=proc_flags.get(target_info.result, 0))
 
+                    # Effects are not applied for misses. Handle procs from them on cast.
+                    self.handle_damage_event_procs(damage_info)
+
                 for proc_target in (target, casting_spell.spell_caster):
                     if proc_target.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
                         proc_target.aura_manager.check_aura_procs(involved_cast=casting_spell, damage_info=damage_info)

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -1107,12 +1107,15 @@ class SpellManager:
 
         # Unit target checks.
         if casting_spell.initial_target_is_unit_or_player():
-            # Basic effect harmfulness/attackability check for fully harmful spells.
+            # Basic effect harmfulness/attackability check.
             # For unit-targeted AoE spells, skip validation for self casts.
             # The client checks this for player casts, but not pet casts.
+            is_harmful = casting_spell.has_only_harmful_effects()
+            has_mixed_targets = not is_harmful and not casting_spell.has_only_helpful_effects()
+
             if (not casting_spell.is_area_of_effect_spell() or validation_target is not self.caster) and \
-                    casting_spell.has_only_harmful_effects() and \
-                    not self.caster.can_attack_target(validation_target):
+                    not has_mixed_targets and \
+                    is_harmful != self.caster.can_attack_target(validation_target):
                 self.send_cast_result(casting_spell, SpellCheckCastResult.SPELL_FAILED_BAD_TARGETS)
                 return False
 

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -124,6 +124,8 @@ class AuraEffectHandler:
                                                                              triggered_by_spell=source_spell,
                                                                              validate=False)
 
+        initialized_spell.force_instant_cast()  # Only 1949 (Hellfire) and 6750, others are instant.
+
         # Also copy initial target selection as periodically triggered spells shouldn't be able to change their target.
         initialized_spell.targeted_unit_on_cast_start = source_spell.targeted_unit_on_cast_start
         effect_target.spell_manager.start_spell_cast(initialized_spell=initialized_spell)

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -839,6 +839,10 @@ class UnitManager(ObjectManager):
         damage_info = self.calculate_spell_damage(damage, miss_reason, hit_flags, spell_effect, target)
 
         is_cast_on_swing = spell.casts_on_swing()
+
+        if is_cast_on_swing:
+            self.handle_melee_attack_procs(damage_info)
+
         # TODO Should other spells give skill too?
         if is_cast_on_swing or spell.is_ranged_weapon_attack():
             self.handle_combat_skill_gain(damage_info)

--- a/game/world/managers/objects/units/player/InventoryManager.py
+++ b/game/world/managers/objects/units/player/InventoryManager.py
@@ -381,9 +381,14 @@ class InventoryManager(object):
                 self.is_bag_pos(target_slot) and self.get_container(target_slot):  # Equipped bags
             self.remove_bag(target_slot)
 
-        # Update the quest db state if needed. (Destroying item).
         if not swap_item and clear_slot:
+            # Update the quest db state if needed. (Destroying item).
             self.owner.quest_manager.pop_item(target_item.item_template.entry)
+
+            # Update equipment.
+            if target_item.is_equipped():
+                target_item.current_slot = InventorySlots.SLOT_BANK_END
+                self.handle_equipment_change(target_item)
 
     def remove_items(self, entry, count, include_bank=False):
         for container_slot in self.containers:

--- a/game/world/managers/objects/units/player/InventoryManager.py
+++ b/game/world/managers/objects/units/player/InventoryManager.py
@@ -694,9 +694,8 @@ class InventoryManager(object):
         # Handle spells interrupt.
         self.owner.spell_manager.handle_equipment_change()
 
-        # Handle enchantments auras removal.
-        self.owner.enchantment_manager.handle_equipment_change(source_item)
-        self.owner.enchantment_manager.handle_equipment_change(dest_item)
+        # Update equipment effects.
+        self.owner.enchantment_manager.handle_equipment_change(source_item, dest_item)
 
         # Bonus application.
         self.owner.stat_manager.apply_bonuses()

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -444,12 +444,11 @@ class SkillManager(object):
 
         # Magic values from VMaNGOS.
         if maximum_skill * 0.9 > current_unmodified_skill:
-            chance = (maximum_skill * 0.9 * 0.05) / current_unmodified_skill
+            chance = (maximum_skill * 0.9 * 0.5) / current_unmodified_skill
         else:
             level_modifier = self.get_max_rank(skill_id, level=config.Unit.Player.Defaults.max_level) / maximum_skill
 
-            chance = (0.5 - 0.0168966 * current_unmodified_skill * level_modifier + 0.0152069 * maximum_skill * level_modifier) / 100
-
+            chance = 0.5 - level_modifier * (0.0168966 * current_unmodified_skill - 0.0152069 * maximum_skill)
             skill_diff_from_max = maximum_skill - current_unmodified_skill
             if skill_diff_from_max <= 3:
                 chance *= (0.5 / (4 - skill_diff_from_max))


### PR DESCRIPTION
* Fix spell misses and melee spells not triggering procs (closes #1180)
* Fix periodic proc spells not ignoring cast time (Hellfire)
* Fix pets being able to target enemies with helpful spells
* Fix enchants not applying when swapping two items with the same enchant
* Fix equipment stats/enchants persisting if destroyed while equipped
* Fix weapon skills learned from trainers having a max skill of 1000
* Correct skill gain formulas for combat skills