### PR TITLE
Spell harmfulness/interrupt fixes

### DIFF
--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -120,8 +120,8 @@ class EffectTargets:
 
         # Neutral targets can target any unit. Use target context if given to resolve.
         if NEUTRAL_IMPLICIT_TARGETS.intersection(implicit_targets):
-            return not unit_target or not self.casting_spell.spell_caster.can_attack_target(unit_target), \
-                unit_target is None
+            can_attack = self.casting_spell.spell_caster.can_attack_target(unit_target) if unit_target else None
+            return (not can_attack, can_attack) if unit_target is not None else (True, True)
 
         return True, True
 

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -120,7 +120,7 @@ class EffectTargets:
             return not unit_target or not self.casting_spell.spell_caster.can_attack_target(unit_target), \
                 unit_target is None
 
-        return False, True
+        return True, True
 
     def resolve_targets(self):
         if not self.simple_targets:

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -194,7 +194,8 @@ class EffectTargets:
 
     @staticmethod
     def resolve_area_effect_custom(casting_spell, target_effect):
-        Logger.warning(f'Unimplemented implicit target called for spell {casting_spell.spell_entry.ID}')
+        # TODO missing spell_script_target table for filtering A targets.
+        return target_effect.targets.resolved_targets_a
 
     @staticmethod
     def resolve_chain_damage(casting_spell, target_effect):

--- a/game/world/managers/objects/spell/SpellEffect.py
+++ b/game/world/managers/objects/spell/SpellEffect.py
@@ -181,9 +181,8 @@ class SpellEffect:
         # take into account initial target friendliness and the nature of the effect's implicit targets.
         target = self.casting_spell.initial_target if self.casting_spell.initial_target_is_unit_or_player() else None
 
-        if self.effect_type == SpellEffects.SPELL_EFFECT_APPLY_AURA:
-            if self.casting_spell.spell_entry.Attributes & SpellAttributes.SPELL_ATTR_AURA_IS_DEBUFF:
-                return True
+        if self.aura_type and self.casting_spell.spell_entry.Attributes & SpellAttributes.SPELL_ATTR_AURA_IS_DEBUFF:
+            return True
 
         can_target_friendly, can_target_hostile = self.targets.get_target_hostility_info(unit_target=target)
 

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -339,9 +339,12 @@ class SpellEffectHandler:
             effect.area_aura_holder = AreaAuraHolder(effect)
             previous_targets = []
         else:
-            previous_targets = effect.targets.previous_targets_a if effect.targets.previous_targets_a else []
+            # B is always specifying for area auras if set (only 6672, 6755).
+            previous_targets = effect.targets.previous_targets_b if effect.targets.previous_targets_b else \
+                effect.targets.previous_targets_a if effect.targets.previous_targets_a else []
 
-        current_targets = effect.targets.resolved_targets_a
+        current_targets = effect.targets.resolved_targets_b if effect.targets.resolved_targets_b else \
+            effect.targets.resolved_targets_a
 
         new_targets = [unit for unit in current_targets if
                        unit not in previous_targets]  # Targets that can't have the aura yet.

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -820,7 +820,8 @@ class SpellManager:
             # Refresh targets.
             casting_spell.resolve_target_info_for_effect(effect.effect_index)
 
-            if effect.is_periodic() and not effect.has_periodic_ticks_remaining():
+            if effect.is_periodic() and not effect.has_periodic_ticks_remaining() or \
+                casting_spell.get_duration() != -1 and effect.applied_aura_duration <= 0:
                 is_finished = True
 
             self.apply_spell_effects(casting_spell, update=True, update_index=effect.effect_index)

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -604,7 +604,7 @@ class UnitManager(ObjectManager):
         self.mana_regen_timer = min(5, self.mana_regen_timer + elapsed)
 
         # Mana regen disruption.
-        if self.spell_manager.get_casting_spell():
+        if self.spell_manager.get_casting_spell(ignore_melee=True):
             self.mana_regen_timer = 0
 
         # Every 2 seconds.

--- a/game/world/managers/objects/units/pet/ActivePet.py
+++ b/game/world/managers/objects/units/pet/ActivePet.py
@@ -3,6 +3,7 @@ from game.world.managers.maps.MapManager import MapManager
 from game.world.managers.objects.units.pet.PetData import PetData
 from game.world.managers.objects.units.player.StatManager import UnitStats
 from utils.Logger import Logger
+from utils.constants.MiscCodes import ObjectTypeFlags
 from utils.constants.PetCodes import PetSlot
 from utils.constants.UnitCodes import MovementTypes
 from utils.constants.UpdateFields import UnitFields
@@ -142,6 +143,9 @@ class ActivePet:
                 movement_type = spawn.movement_type
             else:
                 Logger.error(f'Unable to locate SpawnCreature with id {self.creature.spawn_id} upon pet detach.')
+
+        if pet_data.summon_spell_id and self._pet_manager.owner.get_type_mask() & ObjectTypeFlags.TYPE_UNIT:
+            self._pet_manager.owner.spell_manager.unlock_spell_cooldown(pet_data.summon_spell_id)
 
         if self.is_permanent():
             pet_data.save(self.creature)

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -434,13 +434,22 @@ class StatManager(object):
                             current = self.item_stats.get(stat_type, 0)
                             self.item_stats[stat_type] = current + stat.value
 
-                    # Add resistances/block.
+                    # Add resistances.
                     separate_stats = {UnitStats.RESISTANCE_PHYSICAL: item.item_template.armor,
                                       UnitStats.RESISTANCE_HOLY: item.item_template.holy_res,
                                       UnitStats.RESISTANCE_FIRE: item.item_template.fire_res,
                                       UnitStats.RESISTANCE_NATURE: item.item_template.nature_res,
                                       UnitStats.RESISTANCE_FROST: item.item_template.frost_res,
                                       UnitStats.RESISTANCE_SHADOW: item.item_template.shadow_res}
+
+                    # Add resistance enchant bonuses (only armor in 0.5.3).
+                    resistance_enchants = EnchantmentManager.get_enchantments_by_type(item,
+                                                                                      ItemEnchantmentType.RESISTANCE)
+
+                    for res_enchant in resistance_enchants:
+                        res_stat = UnitStats.RESISTANCE_START << res_enchant.effect_spell
+                        separate_stats[res_stat] += res_enchant.effect_points
+
                     for stat, value in separate_stats.items():
                         self.item_stats[stat] = self.item_stats.get(stat, 0) + value
 

--- a/game/world/opcode_handling/handlers/spell/CancelCastHandler.py
+++ b/game/world/opcode_handling/handlers/spell/CancelCastHandler.py
@@ -7,5 +7,8 @@ class CancelCastHandler(object):
     def handle(world_session, reader):
         if len(reader.data) >= 4:  # Avoid handling empty cancel cast packet.
             spell_id = unpack('<I', reader.data[:4])[0]
-            world_session.player_mgr.spell_manager.remove_cast_by_id(spell_id, interrupted=True)
+            current_cast = world_session.player_mgr.spell_manager.get_casting_spell()
+            if not current_cast or current_cast.spell_entry.ID != spell_id:
+                return 0
+            world_session.player_mgr.spell_manager.remove_cast(current_cast, interrupted=True)
         return 0


### PR DESCRIPTION
* Fix harmfulness for some spells with a self-cast component, AoE effect or neutral targets
* Fix non-channeled area auras with a duration never fading
* Fix B targets not being considered for area auras
* Fix spellcasts being interruptible after success
* Hide interrupt message when changing queued melee spell
* Implement armor bonuses from enchants
* Fix Healing Totem cooldown not unlocking if replaced