### PR TITLE
Proc spell fixes

### DIFF
--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -857,8 +857,9 @@ class SpellManager:
         # The client expects the source to only be set for unit casters.
         source_unit = self.caster.guid if self.caster.get_type_mask() & ObjectTypeFlags.TYPE_UNIT else 0
 
-        data = [self.caster.guid, source_unit,
-                casting_spell.spell_entry.ID, casting_spell.cast_flags]
+        # Exclude proc flag from GO - proc casts are visible in 0.5.5 screenshots.
+        data = [self.caster.guid, source_unit, casting_spell.spell_entry.ID,
+                casting_spell.cast_flags & ~SpellCastFlags.CAST_FLAG_PROC]
 
         signature = '<2QIHB'  # caster, source, ID, flags .. (targets, ammo info).
 

--- a/game/world/managers/objects/spell/aura/AuraEffectHandler.py
+++ b/game/world/managers/objects/spell/aura/AuraEffectHandler.py
@@ -224,7 +224,7 @@ class AuraEffectHandler:
                 spell.initial_target = effect_target
                 break
 
-        effect_target.spell_manager.start_spell_cast(initialized_spell=spell)
+        caster.spell_manager.start_spell_cast(initialized_spell=spell)
 
     @staticmethod
     def handle_track_creatures(aura, effect_target, remove):

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -716,6 +716,15 @@ class UnitManager(ObjectManager):
                                        spell_school=spell.get_damage_school(),
                                        spell_miss_reason=miss_reason, hit_info=hit_flags)
 
+        if spell.casts_on_swing():
+            damage_info.hit_info |= HitInfo.DEFERRED_LOGGING
+
+        if miss_reason in {SpellMissReason.MISS_REASON_EVADED, SpellMissReason.MISS_REASON_IMMUNE}:
+            damage_info.target_state = VictimStates.VS_IMMUNE
+
+        if miss_reason != SpellMissReason.MISS_REASON_NONE:
+            return damage_info
+
         subclass = 0
         if self.get_type_id() == ObjectTypeIds.ID_PLAYER and damage_info.attack_type != -1:
             equipped_weapon = self.get_current_weapon_for_attack_type(damage_info.attack_type)
@@ -734,13 +743,6 @@ class UnitManager(ObjectManager):
         else:
             damage_info.base_damage = self.stat_manager.apply_bonuses_for_damage(base_damage, spell_school,
                                                                                  target, subclass)
-
-        if spell.casts_on_swing():
-            damage_info.hit_info |= HitInfo.DEFERRED_LOGGING
-
-        if miss_reason in {SpellMissReason.MISS_REASON_EVADED, SpellMissReason.MISS_REASON_IMMUNE}:
-            damage_info.target_state = VictimStates.VS_IMMUNE
-            return damage_info
 
         # From 0.5.5 patch notes:
         #     "Critical hits with ranged weapons now do 100% extra damage."


### PR DESCRIPTION
* Fix proc casts (Chilled etc.) not being displayed in combat log
* Fix damage shield effects (Lightning Shield etc.) ignoring miss result roll

Fixes both parts of #1221, but damage shield resists are not displayed in combat log.