### PR TITLE
Update to barrens oases chain rework #1202 updates.sql

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -3292,31 +3292,38 @@ begin not atomic
     end if;
 
 
-    if (select count(*) from `applied_updates` where id='0108202301') = 0 then
---mostly devwr4 teaching klorine28 what to do (thanks)
--- Update DisplayID, name and static_flags. for mud thresh
-UPDATE `creature_template` SET `display_id1` = '1752', `name` = 'Mud Thresh', `static_flags` = '268697616' WHERE (`entry` = '3461');
-
--- Update the related quest text and reward money. for the quest altered being
-UPDATE `quest_template` SET `Details` = 'Your findings are incredible, $N.  These oases hold properties that must come from an outside source.  Or perhaps an inside one.$B$BI want to know how these fissures are affecting the beasts who drink from the oases\ water.$B$BHunt mud threshers at the Lushwater and Stagnant Oases.  Bring me their hides so I may examine them.', `Objectives` = 'Bring 8 Mud Thresh Hides to Tonga Runetotem at the Crossroads.', `OfferRewardText` = 'Thank you, $N.  Studying the beasts of an area can tell much about the area itself.  We shall see what tale these hides tell.$B$BPlease accept my gratitude for your aid ... and perhaps you can use these coins.  I find that I do not need them.', `RequestItemsText` = 'How goes your collection?  Did you get the hides?', `RewOrReqMoney` = '750' WHERE (`entry` = '880');
-
---The spell_list already points to 34610 in 'creature_spells', which already has the spell set, update its name.
-UPDATE `creature_spells` SET `name` = 'Barrens - Mud Thresher' WHERE (`entry` = '34610');
-
--- Bring those spawns outside water into water.
--- https://db.thealphaproject.eu/index.php?action=show_quest&id=880 (Helps)
-UPDATE `spawns_creatures` SET `position_x` = '-1070.88', `position_y` = '-2200.54', `position_z` = '78.3212' WHERE (`spawn_id` = '14962');
-UPDATE `spawns_creatures` SET `position_x` = '-1121.84', `position_y` = '-2247.62', `position_z` = '78.4574' WHERE (`spawn_id` = '14946');
-UPDATE `spawns_creatures` SET `position_x` = '-1115.4', `position_z` = '78.3876' WHERE (`spawn_id` = '14941');
-UPDATE `spawns_creatures` SET `position_x` = '-1091.6', `position_y` = '-2038.12', `position_z` = '78.199' WHERE (`spawn_id` = '14966');
-UPDATE `spawns_creatures` SET `position_x` = '-1078.92', `position_y` = '-2021.58', `position_z` = '78.25' WHERE (`spawn_id` = '14944');
-UPDATE `spawns_creatures` SET `position_x` = '-1212.26', `position_y` = '-2998.36', `position_z` = '85.95' WHERE (`spawn_id` = '14960');
-UPDATE `spawns_creatures` SET `position_x` = '-1250.93', `position_z` = '86.114' WHERE (`spawn_id` = '14953');
-UPDATE `spawns_creatures` SET `position_x` = '-1261.16', `position_z` = '86.16' WHERE (`spawn_id` = '14967');
-UPDATE `spawns_creatures` SET `position_x` = '-1317.19', `position_z` = '86.161' WHERE (`spawn_id` = '14973');
-UPDATE `spawns_creatures` SET `position_x` = '-1279.18', `position_y` = '-2969.77', `position_z` = '86.16' WHERE (`spawn_id` = '14969');
-UPDATE `spawns_creatures` SET `position_x` = '-1237.41', `position_y` = '-2970.69', `position_z` = '86.1426' WHERE (`spawn_id` = '14968');
-        insert into`applied_updates`values ('0108202301');
+    if (select count(*) from `applied_updates` where id='010820231') = 0 then
+        --01/08/2023
+        --mostly devwr4 teaching klorine28 what to do (thanks)
+        >>> static_flags = 268959760  <- Current Flags
+        >>> static_flags |= 262144    <- Add AQUATIC
+        >>> static_flags &= ~524288   <- Remove AMPHIBIOUS
+        
+        static_flags:
+        268697616
+        -- Update DisplayID, name and static_flags. for mud thresh
+        UPDATE `creature_template` SET `display_id1` = '1752', `name` = 'Mud Thresh', `static_flags` = '268697616' WHERE (`entry` = '3461');
+        
+        -- Update the related quest text and reward money. for the quest altered being
+        UPDATE `quest_template` SET `Details` = 'Your findings are incredible, $N.  These oases hold properties that must come from an outside source.  Or perhaps an inside one.$B$BI want to know how these fissures are affecting the beasts who drink from the oases\ water.$B$BHunt mud threshers at the Lushwater and Stagnant Oases.  Bring me their hides so I may examine them.', `Objectives` = 'Bring 8 Mud Thresh Hides to Tonga Runetotem at the Crossroads.', `OfferRewardText` = 'Thank you, $N.  Studying the beasts of an area can tell much about the area itself.  We shall see what tale these hides tell.$B$BPlease accept my gratitude for your aid ... and perhaps you can use these coins.  I find that I do not need them.', `RequestItemsText` = 'How goes your collection?  Did you get the hides?', `RewOrReqMoney` = '750' WHERE (`entry` = '880');
+        
+        --The spell_list already points to 34610 in 'creature_spells', which already has the spell set, update its name.
+        UPDATE `creature_spells` SET `name` = 'Barrens - Mud Thresher' WHERE (`entry` = '34610');
+        
+        -- Bring those spawns outside water into water.
+        -- https://db.thealphaproject.eu/index.php?action=show_quest&id=880 (Helps)
+        UPDATE `spawns_creatures` SET `position_x` = '-1070.88', `position_y` = '-2200.54', `position_z` = '78.3212' WHERE (`spawn_id` = '14962');
+        UPDATE `spawns_creatures` SET `position_x` = '-1121.84', `position_y` = '-2247.62', `position_z` = '78.4574' WHERE (`spawn_id` = '14946');
+        UPDATE `spawns_creatures` SET `position_x` = '-1115.4', `position_z` = '78.3876' WHERE (`spawn_id` = '14941');
+        UPDATE `spawns_creatures` SET `position_x` = '-1091.6', `position_y` = '-2038.12', `position_z` = '78.199' WHERE (`spawn_id` = '14966');
+        UPDATE `spawns_creatures` SET `position_x` = '-1078.92', `position_y` = '-2021.58', `position_z` = '78.25' WHERE (`spawn_id` = '14944');
+        UPDATE `spawns_creatures` SET `position_x` = '-1212.26', `position_y` = '-2998.36', `position_z` = '85.95' WHERE (`spawn_id` = '14960');
+        UPDATE `spawns_creatures` SET `position_x` = '-1250.93', `position_z` = '86.114' WHERE (`spawn_id` = '14953');
+        UPDATE `spawns_creatures` SET `position_x` = '-1261.16', `position_z` = '86.16' WHERE (`spawn_id` = '14967');
+        UPDATE `spawns_creatures` SET `position_x` = '-1317.19', `position_z` = '86.161' WHERE (`spawn_id` = '14973');
+        UPDATE `spawns_creatures` SET `position_x` = '-1279.18', `position_y` = '-2969.77', `position_z` = '86.16' WHERE (`spawn_id` = '14969');
+        UPDATE `spawns_creatures` SET `position_x` = '-1237.41', `position_y` = '-2970.69', `position_z` = '86.1426' WHERE (`spawn_id` = '14968');
+        insert into`applied_updates`values ('010820231');
     end if;
 
 end $

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -3291,10 +3291,9 @@ begin not atomic
         insert into`applied_updates`values ('310720231');
     end if;
 
-    --01/08/2023
+    --01/08/2023 1
     if (select count(*) from `applied_updates` where id='010820231') = 0 then
         
-        --mostly devwr4 teaching klorine28 what to do (thanks)
         -- Update DisplayID, name and static_flags. for mud thresh
         UPDATE `creature_template` SET `display_id1` = '1752', `name` = 'Mud Thresh', `static_flags` = '268697616' WHERE (`entry` = '3461');
         
@@ -3317,7 +3316,9 @@ begin not atomic
         UPDATE `spawns_creatures` SET `position_x` = '-1317.19', `position_z` = '86.161' WHERE (`spawn_id` = '14973');
         UPDATE `spawns_creatures` SET `position_x` = '-1279.18', `position_y` = '-2969.77', `position_z` = '86.16' WHERE (`spawn_id` = '14969');
         UPDATE `spawns_creatures` SET `position_x` = '-1237.41', `position_y` = '-2970.69', `position_z` = '86.1426' WHERE (`spawn_id` = '14968');
+
         insert into`applied_updates`values ('010820231');
+
     end if;
 
 end $

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -3292,5 +3292,12 @@ begin not atomic
     end if;
 
 
+    if (select count(*) from `applied_updates` where id='0108202301') = 0 then
+        --mud Thresh, may need some adjusting also need to figure out how to remove certain spawn locations
+        UPDATE 'creature_template' SET 'level_min' = 15, 'level_max' = 16, 'display_id1' = 1752, 'spell_id1' = 6530, 'name' = "Mud Thresh",  'AQUATIC' = 262144 WHERE (entry = 3461);
+
+        insert into`applied_updates`values ('0108202315');
+    end if;
+
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -3293,10 +3293,30 @@ begin not atomic
 
 
     if (select count(*) from `applied_updates` where id='0108202301') = 0 then
-        --mud Thresh, may need some adjusting also need to figure out how to remove certain spawn locations
-        UPDATE 'creature_template' SET 'level_min' = 15, 'level_max' = 16, 'display_id1' = 1752, 'spell_id1' = 6530, 'name' = "Mud Thresh",  'AQUATIC' = 262144 WHERE (entry = 3461);
+--mostly devwr4 teaching klorine28 what to do (thanks)
+-- Update DisplayID, name and static_flags. for mud thresh
+UPDATE `creature_template` SET `display_id1` = '1752', `name` = 'Mud Thresh', `static_flags` = '268697616' WHERE (`entry` = '3461');
 
-        insert into`applied_updates`values ('0108202315');
+-- Update the related quest text and reward money. for the quest altered being
+UPDATE `quest_template` SET `Details` = 'Your findings are incredible, $N.  These oases hold properties that must come from an outside source.  Or perhaps an inside one.$B$BI want to know how these fissures are affecting the beasts who drink from the oases\ water.$B$BHunt mud threshers at the Lushwater and Stagnant Oases.  Bring me their hides so I may examine them.', `Objectives` = 'Bring 8 Mud Thresh Hides to Tonga Runetotem at the Crossroads.', `OfferRewardText` = 'Thank you, $N.  Studying the beasts of an area can tell much about the area itself.  We shall see what tale these hides tell.$B$BPlease accept my gratitude for your aid ... and perhaps you can use these coins.  I find that I do not need them.', `RequestItemsText` = 'How goes your collection?  Did you get the hides?', `RewOrReqMoney` = '750' WHERE (`entry` = '880');
+
+--The spell_list already points to 34610 in 'creature_spells', which already has the spell set, update its name.
+UPDATE `creature_spells` SET `name` = 'Barrens - Mud Thresher' WHERE (`entry` = '34610');
+
+-- Bring those spawns outside water into water.
+-- https://db.thealphaproject.eu/index.php?action=show_quest&id=880 (Helps)
+UPDATE `spawns_creatures` SET `position_x` = '-1070.88', `position_y` = '-2200.54', `position_z` = '78.3212' WHERE (`spawn_id` = '14962');
+UPDATE `spawns_creatures` SET `position_x` = '-1121.84', `position_y` = '-2247.62', `position_z` = '78.4574' WHERE (`spawn_id` = '14946');
+UPDATE `spawns_creatures` SET `position_x` = '-1115.4', `position_z` = '78.3876' WHERE (`spawn_id` = '14941');
+UPDATE `spawns_creatures` SET `position_x` = '-1091.6', `position_y` = '-2038.12', `position_z` = '78.199' WHERE (`spawn_id` = '14966');
+UPDATE `spawns_creatures` SET `position_x` = '-1078.92', `position_y` = '-2021.58', `position_z` = '78.25' WHERE (`spawn_id` = '14944');
+UPDATE `spawns_creatures` SET `position_x` = '-1212.26', `position_y` = '-2998.36', `position_z` = '85.95' WHERE (`spawn_id` = '14960');
+UPDATE `spawns_creatures` SET `position_x` = '-1250.93', `position_z` = '86.114' WHERE (`spawn_id` = '14953');
+UPDATE `spawns_creatures` SET `position_x` = '-1261.16', `position_z` = '86.16' WHERE (`spawn_id` = '14967');
+UPDATE `spawns_creatures` SET `position_x` = '-1317.19', `position_z` = '86.161' WHERE (`spawn_id` = '14973');
+UPDATE `spawns_creatures` SET `position_x` = '-1279.18', `position_y` = '-2969.77', `position_z` = '86.16' WHERE (`spawn_id` = '14969');
+UPDATE `spawns_creatures` SET `position_x` = '-1237.41', `position_y` = '-2970.69', `position_z` = '86.1426' WHERE (`spawn_id` = '14968');
+        insert into`applied_updates`values ('0108202301');
     end if;
 
 end $

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -3291,16 +3291,15 @@ begin not atomic
         insert into`applied_updates`values ('310720231');
     end if;
 
-    --01/08/2023 1
+    -- 01/08/2023 1
     if (select count(*) from `applied_updates` where id='010820231') = 0 then
-        
-        -- Update DisplayID, name and static_flags. for mud thresh
+        -- Update DisplayID, name and static_flags.
         UPDATE `creature_template` SET `display_id1` = '1752', `name` = 'Mud Thresh', `static_flags` = '268697616' WHERE (`entry` = '3461');
         
-        -- Update the related quest text and reward money. for the quest altered being
-        UPDATE `quest_template` SET `Details` = 'Your findings are incredible, $N.  These oases hold properties that must come from an outside source.  Or perhaps an inside one.$B$BI want to know how these fissures are affecting the beasts who drink from the oases\ water.$B$BHunt mud threshers at the Lushwater and Stagnant Oases.  Bring me their hides so I may examine them.', `Objectives` = 'Bring 8 Mud Thresh Hides to Tonga Runetotem at the Crossroads.', `OfferRewardText` = 'Thank you, $N.  Studying the beasts of an area can tell much about the area itself.  We shall see what tale these hides tell.$B$BPlease accept my gratitude for your aid ... and perhaps you can use these coins.  I find that I do not need them.', `RequestItemsText` = 'How goes your collection?  Did you get the hides?', `RewOrReqMoney` = '750' WHERE (`entry` = '880');
+        -- Update the related quest text and reward money.
+        UPDATE `quest_template` SET `Details` = 'Your findings are incredible, $N.  These oases hold properties that must come from an outside source.  Or perhaps an inside one.$B$BI want to know how these fissures are affecting the beasts who drink from the oases\' water.$B$BHunt mud threshers at the Lushwater and Stagnant Oases.  Bring me their hides so I may examine them.', `Objectives` = 'Bring 8 Mud Thresh Hides to Tonga Runetotem at the Crossroads.', `OfferRewardText` = 'Thank you, $N.  Studying the beasts of an area can tell much about the area itself.  We shall see what tale these hides tell.$B$BPlease accept my gratitude for your aid ... and perhaps you can use these coins.  I find that I do not need them.', `RequestItemsText` = 'How goes your collection?  Did you get the hides?', `RewOrReqMoney` = '750' WHERE (`entry` = '880');
         
-        --The spell_list already points to 34610 in 'creature_spells', which already has the spell set, update its name.
+        -- The spell_list already points to 34610 in 'creature_spells', which already have the spell set, update its name.
         UPDATE `creature_spells` SET `name` = 'Barrens - Mud Thresher' WHERE (`entry` = '34610');
         
         -- Bring those spawns outside water into water.

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -3291,16 +3291,10 @@ begin not atomic
         insert into`applied_updates`values ('310720231');
     end if;
 
-
+    --01/08/2023
     if (select count(*) from `applied_updates` where id='010820231') = 0 then
-        --01/08/2023
-        --mostly devwr4 teaching klorine28 what to do (thanks)
-        >>> static_flags = 268959760  <- Current Flags
-        >>> static_flags |= 262144    <- Add AQUATIC
-        >>> static_flags &= ~524288   <- Remove AMPHIBIOUS
         
-        static_flags:
-        268697616
+        --mostly devwr4 teaching klorine28 what to do (thanks)
         -- Update DisplayID, name and static_flags. for mud thresh
         UPDATE `creature_template` SET `display_id1` = '1752', `name` = 'Mud Thresh', `static_flags` = '268697616' WHERE (`entry` = '3461');
         


### PR DESCRIPTION
all in reference to issue [#1202](https://github.com/The-Alpha-Project/alpha-core/issues/1202)
Changed Oasis Snapjaws to Mud Threshes

added this characteristics:
have the name Mud Thresh
have the DisplayID of 1752
use the same abilities as oasis snapjaws (sling dirt) be the same lvl as oasis snapjaws (the only screenshot where their lvl is seen is lvl 15 and the quest lvl didn't change between 0.7 and 1.12.1) should have "AQUATIC = 262144" flag, since all threshadons can't leave water and walk on land.


need to work out how to remove only this spawn locations: -1117.6 -2031.12 85.6693 1
-1122.4 -2086.23 80.3876 1
-1111.46 -2126.04 78.6348 1
-1130.84 -2252.62 80.4574 1
-1084.52 -2248.63 78.6269 1 
-1052.88 -2203.54 82.3212 1
-1240.82 -2950.69 92.3646 1
-1334.19 -3014.49 91.2894 1
-1316.63 -3044.07 85.2496 1
-1252.16 -3060.85 90.4883 1
-1223.93 -3048.36 93.7596 1
-1232.87 -3014 85.206 1
-1190.59 -3013.13 93.8572 1