### PR TITLE
Pet autocast implementation, bug/crash fixes

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1051,5 +1051,12 @@ begin not atomic
         insert into `applied_updates` values ('010920231');
     end if;
 
+    -- 08/09/2023 1
+    IF (SELECT COUNT(*) FROM `applied_updates` WHERE id='080920231') = 0 THEN
+        UPDATE `creature_template` SET `trainer_id` = 280 WHERE `entry` IN (3620, 4901);
+
+        INSERT INTO `applied_updates` VALUES ('080920231');
+    end if;
+
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1054,7 +1054,7 @@ begin not atomic
     -- 08/09/2023 1
     IF (SELECT COUNT(*) FROM `applied_updates` WHERE id='080920231') = 0 THEN
         UPDATE `creature_template` SET `trainer_id` = 280 WHERE `entry` IN (3620, 4901);
-
+        UPDATE `creature_template` SET `trainer_id` = 287 WHERE `entry` IN (3624);
         INSERT INTO `applied_updates` VALUES ('080920231');
     end if;
 

--- a/game/world/managers/CommandManager.py
+++ b/game/world/managers/CommandManager.py
@@ -807,7 +807,9 @@ class CommandManager(object):
     @staticmethod
     def die(world_session, args):
         unit = CommandManager._target_or_self(world_session)
-        world_session.player_mgr.deal_damage(unit, DamageInfoHolder(total_damage=unit.health))
+        world_session.player_mgr.deal_damage(unit, DamageInfoHolder(attacker=world_session.player_mgr,
+                                                                    target=unit,
+                                                                    total_damage=unit.health))
 
         return 0, ''
 

--- a/game/world/managers/objects/ai/PetAI.py
+++ b/game/world/managers/objects/ai/PetAI.py
@@ -33,6 +33,8 @@ class PetAI(CreatureAI):
         if self.move_state == PetMoveState.AT_RANGE and self.pending_spell_cast:
             spell, target, autocast = self.pending_spell_cast
             self.do_spell_cast(spell, target, autocast=autocast, validate_range=False)
+        elif self.move_state != PetMoveState.MOVE_RANGE:
+            self.pending_spell_cast = None
 
         if owner.get_type_id() == ObjectTypeIds.ID_PLAYER:
             if self.creature.combat_target and not self.creature.combat_target.is_alive:

--- a/game/world/managers/objects/ai/PetAI.py
+++ b/game/world/managers/objects/ai/PetAI.py
@@ -168,7 +168,8 @@ class PetAI(CreatureAI):
                 return
 
             casting_spell = self.creature.spell_manager.try_initialize_spell(spell, target, target_mask, validate=False)
-            if casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_APPLY_AREA_AURA):
+            if casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_APPLY_AREA_AURA) or \
+                casting_spell.is_self_targeted():
                 target = self.creature  # Override target if the spell can be cast on self.
 
             if not casting_spell.casts_on_swing():

--- a/game/world/managers/objects/ai/PetAI.py
+++ b/game/world/managers/objects/ai/PetAI.py
@@ -1,11 +1,12 @@
 from typing import Optional
 
 from database.dbc.DbcDatabaseManager import DbcDatabaseManager
+from game.world.managers.objects.ObjectManager import ObjectManager
 from game.world.managers.objects.ai.CreatureAI import CreatureAI
 from utils.constants.CustomCodes import Permits
 from utils.constants.MiscCodes import ObjectTypeIds, MoveType
 from utils.constants.PetCodes import PetCommandState, PetReactState, PetMoveState
-from utils.constants.SpellCodes import SpellTargetMask
+from utils.constants.SpellCodes import SpellTargetMask, SpellEffects
 from utils.constants.UnitCodes import UnitStates
 
 
@@ -13,7 +14,7 @@ class PetAI(CreatureAI):
     def __init__(self, creature):
         super().__init__(creature)
         self.move_state = PetMoveState.AT_HOME
-        self.pending_spell_cast: Optional[tuple[int, object]] = None
+        self.pending_spell_cast: Optional[tuple[int, ObjectManager]] = None
         if creature:
             self.update_allies_timer = 0
             self.allies = ()
@@ -24,6 +25,9 @@ class PetAI(CreatureAI):
         owner = self.creature.get_charmer_or_summoner()
         if not self.creature or not owner:
             return
+
+        if not self.pending_spell_cast:
+            self._perform_auto_cast()
 
         if self.move_state == PetMoveState.AT_RANGE and self.pending_spell_cast:
             spell_id, target = self.pending_spell_cast
@@ -165,13 +169,52 @@ class PetAI(CreatureAI):
 
             spell = DbcDatabaseManager.SpellHolder.spell_get_by_id(spell_id)
             casting_spell = self.creature.spell_manager.try_initialize_spell(spell, target, target_mask, validate=False)
-            range_max = casting_spell.range_entry.RangeMax
-            if self.creature.location.distance(target.location) > range_max:
-                pet_movement.move_in_range(target, range_max, casting_spell.get_cast_time_secs())
-                self.pending_spell_cast = (spell_id, target)
-                return
+            if not casting_spell.casts_on_swing():
+                range_max = casting_spell.range_entry.RangeMax
+                if self.creature.location.distance(target.location) > range_max:
+                    pet_movement.move_in_range(target, range_max, casting_spell.get_cast_time_secs())
+                    self.pending_spell_cast = (spell_id, target)
+                    return
 
         self.creature.spell_manager.handle_cast_attempt(spell_id, target, target_mask)
+
+    def _perform_auto_cast(self):
+        if self.creature.spell_manager.is_casting():
+            return
+
+        controlled_pet = self.creature.get_charmer_or_summoner().pet_manager.get_active_controlled_pet()
+        if not controlled_pet:
+            return
+
+        action_bar = controlled_pet.get_pet_data().action_bar
+        spell_set = [spell_button for spell_button in action_bar if spell_button >> 24 & 0x40]
+
+        for spell_data in spell_set:
+            spell = DbcDatabaseManager.SpellHolder.spell_get_by_id(spell_data & 0xFFFF)
+            target = self.creature.combat_target if self.creature.combat_target else \
+                self.creature.get_charmer_or_summoner()
+            casting_spell = self.creature.spell_manager.try_initialize_spell(spell, target,
+                                                                             SpellTargetMask.UNIT, validate=False)
+            if casting_spell.has_only_harmful_effects():
+                if not self.creature.combat_target:
+                    continue
+                self.do_spell_cast(spell.ID, self.creature.combat_target)
+                break
+
+            # Helpful/neutral spell. Always autocast on master if target is required.
+            # Implement some basic checks so existing spells work properly when set on autocast.
+            if casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_APPLY_AURA,
+                                                SpellEffects.SPELL_EFFECT_APPLY_AREA_AURA) and \
+                target.aura_manager.has_aura_by_spell_id(spell.ID):
+                continue  # Aura already applied - Flameblade, Blood Pact etc.
+
+            if casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_INSTAKILL):
+                continue  # ignore Sacrificial Shield.
+
+            if not casting_spell.meets_casting_requisites():
+                continue
+
+            self.do_spell_cast(spell.ID, target)
 
     def command_state_update(self):
         self.creature.spell_manager.remove_casts()

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -35,6 +35,7 @@ class CastingSpell:
     triggered = False
     triggered_by_spell = None
     creature_spell = None
+    hide_result: bool
 
     object_target_results: dict[int, TargetMissInfo] = {}  # Assigned on cast - contains guids and results on successful hits/misses/blocks etc.
     spell_target_mask: SpellTargetMask
@@ -60,7 +61,7 @@ class CastingSpell:
     dynamic_object: Optional[DynamicObjectManager]
 
     def __init__(self, spell, caster, initial_target, target_mask, source_item=None,
-                 triggered=False, triggered_by_spell=None, creature_spell=None):
+                 triggered=False, hide_result=False, triggered_by_spell=None, creature_spell=None):
         self.spell_entry = spell
         self.spell_caster = caster
         self.source_item = source_item
@@ -68,6 +69,7 @@ class CastingSpell:
         self.spell_target_mask = target_mask
         self.triggered = triggered or triggered_by_spell is not None
         self.triggered_by_spell = triggered_by_spell
+        self.hide_result = hide_result
         self.creature_spell = creature_spell
 
         self.dynamic_object = None

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -380,6 +380,12 @@ class CastingSpell:
     def has_pet_target(self):
         return self.spell_entry.ImplicitTargetA_1 == SpellImplicitTargets.TARGET_PET
 
+    def is_self_targeted(self):
+        return {self.spell_entry.ImplicitTargetA_1, self.spell_entry.ImplicitTargetB_1,
+                self.spell_entry.ImplicitTargetA_2, self.spell_entry.ImplicitTargetB_2,
+                self.spell_entry.ImplicitTargetA_3, self.spell_entry.ImplicitTargetB_3} == \
+            {SpellImplicitTargets.TARGET_INITIAL, SpellImplicitTargets.TARGET_SELF}
+
     def get_totem_slot_type(self):
         totem_tool_id = self.get_required_tools()[0]
         totem_slot = TotemHelpers.get_totem_slot_type_by_tool(totem_tool_id)

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -1654,9 +1654,6 @@ class SpellManager:
                 self.caster.inventory.remove_items(item_entry, 1)
 
     def send_cast_result(self, casting_spell, error, misc_data=-1):
-        # TODO CAST_SUCCESS_KEEP_TRACKING
-        #  cast_status = SpellCastStatus.CAST_SUCCESS if error == SpellCheckCastResult.SPELL_CAST_OK else SpellCastStatus.CAST_FAILED
-
         is_player = self.caster.get_type_id() == ObjectTypeIds.ID_PLAYER
         spell_id = casting_spell.spell_entry.ID
 

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -265,10 +265,11 @@ class SpellManager:
         self.start_spell_cast(spell, spell_target, target_mask, triggered=triggered)
 
     def try_initialize_spell(self, spell: Spell, spell_target, target_mask, source_item=None,
-                             triggered=False, triggered_by_spell=None,
+                             triggered=False, triggered_by_spell=None, hide_result=False,
                              validate=True, creature_spell=None) -> Optional[CastingSpell]:
         spell = CastingSpell(spell, self.caster, spell_target, target_mask, source_item,
                              triggered=triggered, triggered_by_spell=triggered_by_spell,
+                             hide_result=hide_result,
                              creature_spell=creature_spell)
         if not validate:
             return spell
@@ -1658,6 +1659,9 @@ class SpellManager:
 
         is_player = self.caster.get_type_id() == ObjectTypeIds.ID_PLAYER
         spell_id = casting_spell.spell_entry.ID
+
+        if casting_spell.hide_result:
+            error = SpellCheckCastResult.SPELL_FAILED_DONT_REPORT
 
         # Send spell failure only if this was an active spell.
         if error != SpellCheckCastResult.SPELL_NO_ERROR:

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -444,6 +444,10 @@ class UnitManager(ObjectManager):
         if attacker.get_type_mask() & ObjectTypeFlags.TYPE_PLAYER:
             return
 
+        owner = attacker.get_charmer_or_summoner()
+        if owner and owner.get_type_mask() & ObjectTypeFlags.TYPE_PLAYER:
+            return
+
         # Not attack from behind, ignore.
         if self.location.has_in_arc(attacker.location, math.pi):
             return

--- a/game/world/managers/objects/units/pet/ActivePet.py
+++ b/game/world/managers/objects/units/pet/ActivePet.py
@@ -66,8 +66,8 @@ class ActivePet:
         # From VMaNGOS.
         delay_mod = pet_data.creature_template.base_attack_time / 2000
         damage_base = pet_data.get_level() * 1.05
-        damage_min = self.creature.creature_template.dmg_min if reset else damage_base * 1.15 * delay_mod
-        damage_max = self.creature.creature_template.dmg_max if reset else damage_base * 1.45 * delay_mod
+        damage_min = self.creature.dmg_min if reset else damage_base * 1.15 * delay_mod
+        damage_max = self.creature.dmg_max if reset else damage_base * 1.45 * delay_mod
 
         pet_stats = WorldDatabaseManager.get_pet_level_stats_by_entry_and_level(pet_data.creature_template.entry,
                                                                                 pet_data.get_level())

--- a/game/world/managers/objects/units/pet/PetData.py
+++ b/game/world/managers/objects/units/pet/PetData.py
@@ -48,6 +48,7 @@ class PetData:
             return
 
         if not creature_instance:
+            # TODO How should pet health/mana be calculated?
             stats = WorldDatabaseManager.CreatureClassLevelStatsHolder.creature_class_level_stats_get_by_class_and_level(
                 self.creature_template.unit_class, min(self._level, 255)
             )

--- a/game/world/managers/objects/units/pet/PetData.py
+++ b/game/world/managers/objects/units/pet/PetData.py
@@ -5,6 +5,7 @@ from typing import List
 from database.dbc.DbcDatabaseManager import DbcDatabaseManager
 from database.realm.RealmDatabaseManager import RealmDatabaseManager
 from database.realm.RealmModels import CharacterPet, CharacterPetSpell
+from database.world.WorldDatabaseManager import WorldDatabaseManager
 from database.world.WorldModels import CreatureTemplate
 from utils import Formulas
 from utils.GuidUtils import GuidUtils
@@ -46,8 +47,15 @@ class PetData:
         if not self.permanent or not self._dirty or not self._is_player_owned():
             return
 
-        health = -1 if not creature_instance else creature_instance.health
-        mana = -1 if not creature_instance else creature_instance.power_1
+        if not creature_instance:
+            stats = WorldDatabaseManager.CreatureClassLevelStatsHolder.creature_class_level_stats_get_by_class_and_level(
+                self.creature_template.unit_class, min(self._level, 255)
+            )
+            health = stats.health
+            mana = stats.power_1
+        else:
+            health = creature_instance.health
+            mana = creature_instance.power_1
 
         character_pet = self._get_character_pet(health=health, mana=mana)
 
@@ -67,11 +75,7 @@ class PetData:
     def set_dirty(self):
         self._dirty = True
 
-    def _get_character_pet(self, health=-1, mana=-1) -> CharacterPet:
-        # TODO Stats shouldn't be directly from creature data.
-        health = health if health != -1 else self.creature_template.health
-        mana = mana if mana != -1 else self.creature_template.power_1
-
+    def _get_character_pet(self, health, mana) -> CharacterPet:
         character_pet = CharacterPet(
             pet_id=self.pet_id if self.pet_id != -1 else None,
             owner_guid=self.owner_guid,

--- a/game/world/managers/objects/units/pet/PetData.py
+++ b/game/world/managers/objects/units/pet/PetData.py
@@ -69,8 +69,8 @@ class PetData:
 
     def _get_character_pet(self, health=-1, mana=-1) -> CharacterPet:
         # TODO Stats shouldn't be directly from creature data.
-        health = health if health != -1 else self.creature_template.health_max
-        mana = mana if mana != -1 else self.creature_template.mana_max
+        health = health if health != -1 else self.creature_template.health
+        mana = mana if mana != -1 else self.creature_template.power_1
 
         character_pet = CharacterPet(
             pet_id=self.pet_id if self.pet_id != -1 else None,

--- a/game/world/managers/objects/units/pet/PetManager.py
+++ b/game/world/managers/objects/units/pet/PetManager.py
@@ -71,7 +71,7 @@ class PetManager:
                 # If pet data exists, set_active_pet_level will assign the proper level.
                 pet_level = creature.level
 
-            pet_data = self._add_pet(creature.creature_template, summon_spell_id, pet_level, is_permanent)
+            pet_data = self._add_pet(creature, summon_spell_id, pet_level, is_permanent)
             if is_permanent:
                 pet_index = len(self.permanent_pets) - 1
         else:
@@ -104,12 +104,13 @@ class PetManager:
         return self.set_creature_as_pet(totem_creature, totem_spell.spell_entry.ID,
                                         PetSlot.PET_SLOT_TOTEM_START + totem_slot)
 
-    def _add_pet(self, creature_template: CreatureTemplate, summon_spell_id: int, level: int, permanent: bool) -> PetData:
-        pet_data = PetData(-1, creature_template.name, 0, creature_template, self.owner.guid, level,
+    def _add_pet(self, creature: CreatureManager, summon_spell_id: int, level: int, permanent: bool) -> PetData:
+        pet_data = PetData(-1, creature.creature_template.name, 0,
+                           creature.creature_template, self.owner.guid, level,
                            0, summon_spell_id, permanent=permanent)
 
         if pet_data.permanent:
-            pet_data.save()
+            pet_data.save(creature_instance=creature)
             self.permanent_pets.append(pet_data)
         return pet_data
 


### PR DESCRIPTION
* Implement basic pet autocast behavior
    * No spell-specific behavior, no global cooldown etc. Simply casting harmful spells on cooldown in combat, helpful outside of combat on master
* Fix pet saving crashes related to new creature stat system
* Fix some pet trainers having an invalid trainer id
* Fix player-controlled pets dazing players
* Fix .die crashing when used on a player (warrior?) in godmode