### PR TITLE
Pet autocast and saving bug fixes

### DIFF
--- a/game/world/managers/objects/ai/PetAI.py
+++ b/game/world/managers/objects/ai/PetAI.py
@@ -214,7 +214,7 @@ class PetAI(CreatureAI):
             if casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_APPLY_AURA,
                                                 SpellEffects.SPELL_EFFECT_APPLY_AREA_AURA) and \
                 target.aura_manager.has_aura_by_spell_id(spell.ID):
-                continue  # Aura already applied (Flameblade, Blood Pact etc.).
+                continue  # Aura already applied (Flameblade, Blood Pact etc.)
 
             if casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_INSTAKILL):
                 continue  # Never autocast Sacrificial Shield.

--- a/game/world/managers/objects/ai/PetAI.py
+++ b/game/world/managers/objects/ai/PetAI.py
@@ -197,9 +197,7 @@ class PetAI(CreatureAI):
         if not controlled_pet:
             return
 
-        action_bar = controlled_pet.get_pet_data().action_bar
-        spell_set = [spell_button for spell_button in action_bar if spell_button >> 24 & 0x40]
-
+        spell_set = controlled_pet.get_pet_data().get_autocast_spells()
         for spell_data in spell_set:
             spell = DbcDatabaseManager.SpellHolder.spell_get_by_id(spell_data & 0xFFFF)
             target = self.creature.combat_target if self.creature.combat_target else \

--- a/game/world/managers/objects/ai/PetAI.py
+++ b/game/world/managers/objects/ai/PetAI.py
@@ -207,29 +207,27 @@ class PetAI(CreatureAI):
             casting_spell = self.creature.spell_manager.try_initialize_spell(spell, target,
                                                                              SpellTargetMask.UNIT, validate=False)
 
-            # Implement some basic checks so existing spells work properly when set on autocast.
+            if casting_spell.has_only_harmful_effects() != bool(self.creature.combat_target):
+                continue  # Cast harmful spells when attacking, helpful when not.
+
+            # Implement some basic checks so pet spells work as expected when set on autocast.
             if casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_APPLY_AURA,
                                                 SpellEffects.SPELL_EFFECT_APPLY_AREA_AURA) and \
                 target.aura_manager.has_aura_by_spell_id(spell.ID):
-                continue  # Aura already applied - Flameblade, Blood Pact etc.
+                continue  # Aura already applied (Flameblade, Blood Pact etc.).
 
+            if casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_INSTAKILL):
+                continue  # Never autocast Sacrificial Shield.
+
+            if casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_HEAL) and \
+                target.health == target.max_health:
+                continue  # Only heal targets not at full health.
+
+            # Check resources before choosing to cast this spell.
             if not self.creature.spell_manager.meets_casting_requisites(casting_spell):
                 continue
 
-            if casting_spell.has_only_harmful_effects():
-                if not self.creature.combat_target:
-                    continue
-                if self.do_spell_cast(spell, target, autocast=True):
-                    break
-                continue
-
-            # Helpful/neutral spell. Always autocast on master if target is required.
-
-            if casting_spell.has_effect_of_type(SpellEffects.SPELL_EFFECT_INSTAKILL):
-                continue  # ignore Sacrificial Shield.
-
-            if self.do_spell_cast(spell, target, autocast=True):
-                break
+            self.do_spell_cast(spell, target, autocast=True)
 
     def command_state_update(self):
         self.creature.spell_manager.remove_casts()

--- a/game/world/managers/objects/units/pet/PetData.py
+++ b/game/world/managers/objects/units/pet/PetData.py
@@ -53,7 +53,7 @@ class PetData:
                 self.creature_template.unit_class, min(self._level, 255)
             )
             health = stats.health
-            mana = stats.power_1
+            mana = stats.mana
         else:
             health = creature_instance.health
             mana = creature_instance.power_1

--- a/game/world/managers/objects/units/pet/PetData.py
+++ b/game/world/managers/objects/units/pet/PetData.py
@@ -163,6 +163,14 @@ class PetData:
         RealmDatabaseManager.character_add_pet_spell(button)
         return True
 
+    def is_spell_autocast(self, spell_id) -> bool:
+        return any([spell_button for spell_button in self.action_bar if
+                    spell_button & 0xFFFF == spell_id and spell_button >> 24 & 0x40])
+
+    def get_autocast_spells(self) -> List[int]:
+        return [spell_button & 0xFFFF for spell_button in self.action_bar if
+                spell_button >> 24 & 0x40]
+
     def get_experience(self):
         return self._experience
 

--- a/game/world/managers/objects/units/pet/PetManager.py
+++ b/game/world/managers/objects/units/pet/PetManager.py
@@ -236,6 +236,13 @@ class PetManager:
             return
 
         if action_id > PetCommandState.COMMAND_DISMISS:  # Highest action ID.
+            if active_pet_unit.spell_manager.is_spell_active(action_id):
+                # If using an area aura spell that's already active (and not on autocast),
+                # cancel it instead of recasting.
+                if not active_pet.get_pet_data().is_spell_autocast(action_id):
+                    active_pet_unit.spell_manager.remove_cast_by_id(action_id, interrupted=False)
+                return
+
             spell = DbcDatabaseManager.SpellHolder.spell_get_by_id(action_id)
             casting_spell = active_pet_unit.spell_manager.try_initialize_spell(spell, target_unit,
                                                                                SpellTargetMask.SELF, validate=False)


### PR DESCRIPTION
* Fix crash when attempting to save pet data
* Correct pet spell autocast logic to only cast helpful spells when not in combat
* Handle attempting to recast pet area auras as canceling them
* Only autocast healing spells when target isn't at max health