### PR TITLE
Implement scripted spell targets, refactoring

### DIFF
--- a/database/world/WorldDatabaseManager.py
+++ b/database/world/WorldDatabaseManager.py
@@ -1273,6 +1273,30 @@ class WorldDatabaseManager(object):
         world_db_session.close()
         return res
 
+    # Scripted spell targets.
+
+    class SpellScriptTargetHolder:
+        SPELL_SCRIPT_TARGETS: dict[int, list[SpellScriptTarget]] = {}
+
+        @staticmethod
+        def load_spell_script_target(spell_script_target: SpellScriptTarget):
+            if spell_script_target.entry not in WorldDatabaseManager.SpellScriptTargetHolder.SPELL_SCRIPT_TARGETS:
+                WorldDatabaseManager.SpellScriptTargetHolder.SPELL_SCRIPT_TARGETS[spell_script_target.entry] = []
+            WorldDatabaseManager.SpellScriptTargetHolder.SPELL_SCRIPT_TARGETS[spell_script_target.entry].append(spell_script_target)
+
+        @staticmethod
+        def spell_script_targets_get_by_spell(spell_id: int) -> list[SpellScriptTarget]:
+            if spell_id in WorldDatabaseManager.SpellScriptTargetHolder.SPELL_SCRIPT_TARGETS:
+                return WorldDatabaseManager.SpellScriptTargetHolder.SPELL_SCRIPT_TARGETS[spell_id]
+            return []
+
+    @staticmethod
+    def spell_script_target_get_all() -> list[SpellScriptTarget]:
+        world_db_session: scoped_session = SessionHolder()
+        res = world_db_session.query(SpellScriptTarget).all()
+        world_db_session.close()
+        return res
+
     # Quest Gossip.
 
     class QuestGossipHolder:

--- a/database/world/WorldModels.py
+++ b/database/world/WorldModels.py
@@ -1017,6 +1017,14 @@ class SpellTargetPosition(Base):
     target_orientation = Column(Float, nullable=False, server_default=text("0"))
 
 
+class SpellScriptTarget(Base):
+    __tablename__ = 'spell_script_target'
+
+    entry = Column(MEDIUMINT(8), primary_key=True, nullable=False, server_default=text("0"))
+    target_type = Column(TINYINT(1), nullable=False, server_default=text("0"))
+    target_entry = Column(MEDIUMINT(8), primary_key=True, nullable=False, server_default=text("0"))
+
+
 class NpcVendorTemplateBase:
     pass
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1842,7 +1842,7 @@ begin not atomic
         insert into `applied_updates` values ('081020231');
     end if;
 
-    -- 23/10/2023 1
+    -- 3/12/2023 1
     if (SELECT COUNT(*) FROM `applied_updates` WHERE id='231020231') = 0 then
         CREATE TABLE `spell_script_target` (
           `entry` mediumint(8) unsigned NOT NULL DEFAULT 0,

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1861,7 +1861,7 @@ begin not atomic
                                               (7035, 1, 4251), (7036, 1, 4252), (7078, 1, 4965),
                                               (7078, 1, 4967), (7078, 1, 4968), (7728, 0, 92015);
 
-        INSERT INTO `applied_updates` VALUES (231020231);
+        INSERT INTO `applied_updates` VALUES (031220231);
     end if;
 end $
 delimiter ;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1841,5 +1841,27 @@ begin not atomic
         
         insert into `applied_updates` values ('081020231');
     end if;
+
+    -- 23/10/2023 1
+    if (SELECT COUNT(*) FROM `applied_updates` WHERE id='231020231') = 0 then
+        CREATE TABLE `spell_script_target` (
+          `entry` mediumint(8) unsigned NOT NULL DEFAULT 0,
+          `target_type` tinyint(1) unsigned NOT NULL DEFAULT 0,
+          `target_entry` mediumint(8) NOT NULL DEFAULT 0,
+          PRIMARY KEY (`entry`,`target_entry`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+        INSERT INTO `spell_script_target` (`entry`, `target_type`, `target_entry`) VALUES
+                                              (4130, 1, 2760), (4131, 1, 2761), (4132, 1, 2762),
+                                              (4170, 1, 2595), (4170, 1, 2596), (4170, 1, 11054),
+                                              (5628, 1, 2006), (5628, 1, 2007), (5628, 1, 2008),
+                                              (5628, 1, 2009), (5628, 1, 2010), (5628, 1, 2011),
+                                              (5628, 1, 2012), (5628, 1, 2013), (5628, 1, 2014),
+                                              (5628, 1, 2039), (6955, 1, 4946), (7022, 1, 4945),
+                                              (7035, 1, 4251), (7036, 1, 4252), (7078, 1, 4965),
+                                              (7078, 1, 4967), (7078, 1, 4968), (7728, 0, 92015);
+
+        INSERT INTO `applied_updates` VALUES (231020231);
+    end if;
 end $
 delimiter ;

--- a/game/world/WorldLoader.py
+++ b/game/world/WorldLoader.py
@@ -35,6 +35,7 @@ class WorldLoader:
 
         # Spells.
         WorldLoader.load_spells()
+        WorldLoader.load_spell_script_targets()
         WorldLoader.load_creature_spells()
 
         #  Scripts.
@@ -547,6 +548,20 @@ class WorldLoader:
 
             count += 1
             Logger.progress('Loading spells...', count, length)
+
+        return length
+
+    @staticmethod
+    def load_spell_script_targets():
+        script_targets = WorldDatabaseManager.spell_script_target_get_all()
+        length = len(script_targets)
+        count = 0
+
+        for script_target in script_targets:
+            WorldDatabaseManager.SpellScriptTargetHolder.load_spell_script_target(script_target)
+
+            count += 1
+            Logger.progress('Loading spell script targets...', count, length)
 
         return length
 

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -194,17 +194,21 @@ class EffectTargets:
             units = source.get_map().get_surrounding_units(source, include_players=True)
             units = list(units[0].values()) + list(units[1].values())
 
+        scripted_targets = WorldDatabaseManager.SpellScriptTargetHolder.\
+            spell_script_targets_get_by_spell(target_effect.casting_spell.spell_entry.ID)
+
         if not enemies_only and not friends_only and not distance_loc and not \
-                casting_spell.spell_entry.TargetCreatureType:
+                casting_spell.spell_entry.TargetCreatureType and not scripted_targets:
             return units  # No filters provided.
 
         return EffectTargets._filter_unit_targets(units, casting_spell,
                                                   enemies_only=enemies_only, friends_only=friends_only,
-                                                  distance_loc=distance_loc, radius=radius)
+                                                  distance_loc=distance_loc, radius=radius,
+                                                  target_entries=[t.target_entry for t in scripted_targets])
 
     @staticmethod
     def _filter_unit_targets(units, casting_spell, enemies_only=False, friends_only=False,
-                             distance_loc=None, radius=-1):
+                             distance_loc=None, radius=-1, target_entries=None):
         filtered_units = []
         unit_type_restriction = casting_spell.spell_entry.TargetCreatureType
 
@@ -212,6 +216,9 @@ class EffectTargets:
         for unit in units:
             # Unit type.
             if unit_type_restriction and not unit_type_restriction & (1 << unit.creature_type - 1):
+                continue
+
+            if target_entries and unit.get_type_id() != ObjectTypeIds.ID_UNIT or unit.entry not in target_entries:
                 continue
 
             # Friendliness.
@@ -250,11 +257,10 @@ class EffectTargets:
     def resolve_random_enemy_chain_in_area(casting_spell, target_effect):
         Logger.warning(f'Unimplemented implicit target called for spell {casting_spell.spell_entry.ID}')
 
-    # TODO missing spell_script_target table for filtering A targets.
-    #  Related to issue https://github.com/The-Alpha-Project/alpha-core/issues/1258
     @staticmethod
     def resolve_area_effect_custom(casting_spell, target_effect):
-        Logger.warning(f'Unimplemented scripted targets called for spell {casting_spell.spell_entry.ID}')
+        # Always paired with TARGET_ALL_AROUND_CASTER,
+        # which applied the scripted restriction due to filtering in get_surrounding_unit_targets.
         return target_effect.targets.resolved_targets_a
 
     @staticmethod

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -543,9 +543,14 @@ class EffectTargets:
     def resolve_script(casting_spell, target_effect):
         Logger.warning(f'Unimplemented implicit target called for spell {casting_spell.spell_entry.ID}')
 
+    # Only used by warlock class quest summoning spells (7728, 7729).
     @staticmethod
     def resolve_gameobject_script_near_caster(casting_spell, target_effect):
-        Logger.warning(f'Unimplemented implicit target called for spell {casting_spell.spell_entry.ID}')
+        caster = casting_spell.spell_caster
+        surrounding_gos = [go for go in caster.get_map().get_surrounding_gameobjects(caster).values()]
+        script_targets = WorldDatabaseManager.SpellScriptTargetHolder.\
+            spell_script_targets_get_by_spell(target_effect.casting_spell.spell_entry.ID)
+        return [go for go in surrounding_gos if go.entry in script_targets]
 
     # Used by is_area_of_effect_spell.
     AREA_TARGETS = {

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -242,7 +242,7 @@ class SpellManager:
                                f'({item.get_name()}) could not be found in the spell database.')
                 continue
 
-            casting_spell = self.try_initialize_spell(spell, spell_target, target_mask, item)
+            casting_spell = self.try_initialize_spell(spell, spell_target, target_mask, source_item=item)
             if not casting_spell:
                 continue
 
@@ -256,18 +256,17 @@ class SpellManager:
         if not spell or not spell_target:
             return
 
-        if not validate:
-            initialized_spell = self.try_initialize_spell(spell, spell_target, target_mask,
-                                                          triggered=triggered, validate=validate)
-            self.start_spell_cast(initialized_spell=initialized_spell)
+        initialized_spell = self.try_initialize_spell(spell, spell_target, target_mask,
+                                                      triggered=triggered, validate=validate)
+        if not initialized_spell:
             return
 
-        self.start_spell_cast(spell, spell_target, target_mask, triggered=triggered)
+        self.start_spell_cast(initialized_spell=initialized_spell)
 
     def try_initialize_spell(self, spell: Spell, spell_target, target_mask, source_item=None,
                              triggered=False, triggered_by_spell=None, hide_result=False,
                              validate=True, creature_spell=None) -> Optional[CastingSpell]:
-        spell = CastingSpell(spell, self.caster, spell_target, target_mask, source_item,
+        spell = CastingSpell(spell, self.caster, spell_target, target_mask, source_item=source_item,
                              triggered=triggered, triggered_by_spell=triggered_by_spell,
                              hide_result=hide_result,
                              creature_spell=creature_spell)
@@ -276,8 +275,8 @@ class SpellManager:
         return spell if self.validate_cast(spell) else None
 
     def start_spell_cast(self, spell: Optional[Spell] = None, spell_target=None, target_mask=SpellTargetMask.SELF,
-                         source_item=None, triggered=False, initialized_spell: Optional[CastingSpell] = None):
-        casting_spell = self.try_initialize_spell(spell, spell_target, target_mask, source_item, triggered=triggered) \
+                         initialized_spell: Optional[CastingSpell] = None):
+        casting_spell = self.try_initialize_spell(spell, spell_target, target_mask) \
             if not initialized_spell else initialized_spell
 
         if not casting_spell:

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -173,7 +173,13 @@ class SpellManager:
                 continue
             spell_template = DbcDatabaseManager.SpellHolder.spell_get_by_id(spell_id)
             if spell_template and spell_template.AttributesEx & SpellAttributesEx.SPELL_ATTR_EX_CAST_WHEN_LEARNED:
-                self.start_spell_cast(spell_template, self.caster, SpellTargetMask.SELF)
+                # Hide result since this cast can fail (Battle Stance already applied).
+                spell_cast = self.try_initialize_spell(spell_template, self.caster,
+                                                                SpellTargetMask.SELF,
+                                                                triggered=True, hide_result=True)
+                if not spell_cast:
+                    continue
+                self.start_spell_cast(initialized_spell=spell_cast)
 
     def apply_passive_spell_effects(self, spell_template):
         if not spell_template.Attributes & SpellAttributes.SPELL_ATTR_PASSIVE:

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -351,6 +351,9 @@ class AuraManager:
                 self.remove_aura(aura)
 
     def remove_aura(self, aura, canceled=False):
+        if aura.index not in self.active_auras:
+            return
+
         AuraEffectHandler.handle_aura_effect_change(aura, aura.target, remove=True)
         if not self.active_auras.pop(aura.index, None):
             return

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -460,8 +460,9 @@ class UnitManager(ObjectManager):
             return
 
         spell_entry = DbcDatabaseManager.SpellHolder.spell_get_by_id(1604)
-        spell = attacker.spell_manager.try_initialize_spell(spell_entry, self, SpellTargetMask.UNIT, validate=False)
-        attacker.spell_manager.start_spell_cast(initialized_spell=spell, triggered=True)
+        spell = attacker.spell_manager.try_initialize_spell(spell_entry, self, SpellTargetMask.UNIT,
+                                                            triggered=True, validate=False)
+        attacker.spell_manager.start_spell_cast(initialized_spell=spell)
 
     def handle_melee_attack_procs(self, damage_info):
         damage_info.target.aura_manager.check_aura_procs(damage_info=damage_info, is_melee_swing=True)

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -361,7 +361,7 @@ class StatManager(object):
     def calculate_item_stats(self):
         # Creature-only calculations.
         if self.unit_mgr.get_type_id() == ObjectTypeIds.ID_UNIT:
-            min_damage, max_damage = unpack('<2H', pack('<I', self.unit_mgr.damage))
+            min_damage, max_damage = self.unit_mgr.dmg_min, self.unit_mgr.dmg_max
             main_min_dmg = min_damage
             main_max_dmg = max_damage
             weapon_reach = 0

--- a/utils/constants/SpellCodes.py
+++ b/utils/constants/SpellCodes.py
@@ -540,6 +540,11 @@ class SpellImplicitTargets(IntEnum):
     TARGET_GAMEOBJECT_SCRIPT_NEAR_CASTER = 40  # 7728, 7729
 
 
+class SpellScriptTarget(IntEnum):
+    TARGET_GAMEOBJECT = 0
+    TARGET_UNIT = 1
+
+
 class SpellMissInfo(IntEnum):
     MISS_NONE = 0x0
     MISS_PHYSICAL = 0x1


### PR DESCRIPTION
* Fix aura remove being called multiple times sometimes (closes #1258)
* Implement scripted spell targets (#1258, fixes Gnarlpine Vengeance having incorrect targets)
* Fix Battle Stance application showing an error to warriors when respawning
* Refactor spell initialization flow to be more consistent with how parameters are passed