### PR TITLE
Binding system rework

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1870,13 +1870,15 @@ begin not atomic
         update item_template set bonding = 0 where class in (2, 4);
         -- Then, set all rings to unique.
         update item_template set max_count = 1 where inventory_type = 11;
-        -- Last, set individual items to Bind on Equip where applicable.
+        -- Set individual items to Bind on Equip where applicable.
         -- Boss drops.
         update item_template set bonding = 2 where entry in(6392, 5423, 1292, 5193, 6320, 5198, 5202, 5191, 2816, 5201, 3748, 1156, 6220, 888, 6318, 6324, 1155, 5426, 6321, 5194, 5192);
         -- Drops from instanced rare spawns. Separated for easier removal because I'm not sure the boss rule applies to them.
         update item_template set bonding = 2 where entry in(5443, 2942, 3228, 2941);
         -- Rare Crafting items.
         update item_template set bonding = 2 where entry in(4262, 3844, 4327, 2870, 4320, 4253);
+        -- Lastly, set all rewards from dungeon quests to Bind on Pickup.
+        update item_template set bonding = 1 where entry in(4197, 4980, 6414, 2037, 2036, 2033, 2906, 3324, 1893, 2074, 2089, 6094, 4746, 6335, 4534, 3041, 4197, 6087, 2041, 2042, 3562, 1264, 3400, 1317);
 
         INSERT INTO `applied_updates` VALUES ('311220231');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1872,7 +1872,7 @@ begin not atomic
         update item_template set max_count = 1 where inventory_type = 11;
         -- Set individual items to Bind on Equip where applicable.
         -- Boss drops.
-        update item_template set bonding = 2 where entry in(6392, 5423, 1292, 5193, 6320, 5198, 5202, 5191, 2816, 5201, 3748, 1156, 6220, 888, 6318, 6324, 1155, 5426, 6321, 5194, 5192);
+        update item_template set bonding = 2 where entry in(6392, 5423, 1292, 5193, 6320, 5198, 5202, 5191, 2816, 5201, 3748, 1156, 6220, 888, 6318, 6324, 1155, 5426, 6321, 5194, 5192, 5196, 5197, 5199, 5195, 872, 6226, 6323, 3191, 6319, 3230, 6340, 6314, 3078);
         -- Drops from instanced rare spawns. Separated for easier removal because I'm not sure the boss rule applies to them.
         update item_template set bonding = 2 where entry in(5443, 2942, 3228, 2941);
         -- Rare Crafting items.

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1863,5 +1863,22 @@ begin not atomic
 
         INSERT INTO `applied_updates` VALUES (031220231);
     end if;
+
+    -- 31/12/2023 1
+    if (SELECT COUNT(*) FROM `applied_updates` WHERE id='311220231') = 0 then
+        -- First, reset bonding for all weapons and armor.
+        update item_template set bonding = 0 where class in (2, 4);
+        -- Then, set all rings to unique.
+        update item_template set max_count = 1 where inventory_type = 11;
+        -- Last, set individual items to Bind on Equip where applicable.
+        -- Boss drops.
+        update item_template set bonding = 2 where entry in(6392, 5423, 1292, 5193, 6320, 5198, 5202, 5191, 2816, 5201, 3748, 1156, 6220, 888, 6318, 6324, 1155, 5426, 6321, 5194, 5192);
+        -- Drops from instanced rare spawns. Separated for easier removal because I'm not sure the boss rule applies to them.
+        update item_template set bonding = 2 where entry in(5443, 2942, 3228, 2941);
+        -- Rare Crafting items.
+        update item_template set bonding = 2 where entry in(4262, 3844, 4327, 2870, 4320, 4253);
+
+        INSERT INTO `applied_updates` VALUES ('311220231');
+    end if;
 end $
 delimiter ;


### PR DESCRIPTION
Closes #1293 

- Resets all binding on armor and weapons.
- Makes all rings Unique.
- Sets all instanced boss drops, instanced rare spawn drops and rare crafted items to Bind on Equip.
- Sets all dungeon quest rewards to Bind on Pickup.

Note: instanced rare spawns aren't bosses, but I've added them anyway unless @GizzleBizzle tells me not to.