### PR TITLE
Various pet/spell bug fixes

### DIFF
--- a/game/world/managers/objects/ai/AIFactory.py
+++ b/game/world/managers/objects/ai/AIFactory.py
@@ -46,10 +46,11 @@ class AIFactory:
         #      if selected_ai:
         #          return selected_ai
 
-        if creature.is_pet():
-            selected_ai = PetAI(creature)
-        elif creature.is_totem():
+        if creature.is_totem():
             selected_ai = TotemAI(creature)
+        elif creature.is_controlled():
+            # Use PetAI for any controlled creature.
+            selected_ai = PetAI(creature)
 
         # TODO: EventAI assigned but creature is Pet.
         #  if not selected_ai and ai_name and creature.is_pet() and ai_name == 'EventAI':

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -108,7 +108,7 @@ class EffectTargets:
         has_hostile = HOSTILE_IMPLICIT_TARGETS.intersection(implicit_targets)
 
         if has_friendly != has_hostile:
-            return has_friendly, has_hostile
+            return bool(has_friendly), bool(has_hostile)
 
         # Spells with implicit target set to 0 can have both friendly and hostile targets.
         # These spells include passives, testing spells and npc spells.

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -454,9 +454,6 @@ class EffectTargets:
         units = EffectTargets.get_surrounding_unit_targets(target_effect, source_unit=caster,
                                                            distance_loc=caster.location,
                                                            radius=target_effect.get_radius())
-
-        if caster in units:
-            units.remove(caster)
         return units
 
     @staticmethod

--- a/game/world/managers/objects/spell/EffectTargets.py
+++ b/game/world/managers/objects/spell/EffectTargets.py
@@ -218,7 +218,7 @@ class EffectTargets:
             if unit_type_restriction and not unit_type_restriction & (1 << unit.creature_type - 1):
                 continue
 
-            if target_entries and unit.get_type_id() != ObjectTypeIds.ID_UNIT or unit.entry not in target_entries:
+            if target_entries and (unit.get_type_id() != ObjectTypeIds.ID_UNIT or unit.entry not in target_entries):
                 continue
 
             # Friendliness.

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -1670,7 +1670,7 @@ class SpellManager:
                 casting_spell.source_item.set_charges(casting_spell.spell_entry.ID, new_charges)
                 instance_charges = new_charges
 
-            # No charges left or should charge usage should remove item.
+            # No charges left or usage should remove item.
             if (not instance_charges or charges_removes_item) and item_entry not in removed_items:
                 self.caster.inventory.remove_items(item_entry, 1)
 

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -452,7 +452,8 @@ class SpellManager:
                         SpellMissReason.MISS_REASON_BLOCKED: ProcFlags.BLOCK
                     }
                     damage_info = DamageInfoHolder(attacker=casting_spell.spell_caster, target=target,
-                                                   proc_victim=proc_flags.get(target_info.result, 0))
+                                                   proc_victim=proc_flags.get(target_info.result, 0),
+                                                   spell_id=casting_spell.spell_entry.ID)
 
                     # Effects are not applied for misses. Handle procs from them on cast.
                     self.handle_damage_event_procs(damage_info)
@@ -463,7 +464,8 @@ class SpellManager:
                 applied_targets.append(target.guid)
 
     def handle_damage_event_procs(self, damage_info: DamageInfoHolder):
-        if damage_info.total_damage + damage_info.absorb > 0:  # Dazed applied through absorb until 0.5.5.
+        if not damage_info.spell_id and \
+                damage_info.total_damage + damage_info.absorb > 0:  # Dazed applied through absorb until 0.5.5.
             damage_info.target.handle_melee_daze_chance(damage_info.attacker)
 
         # Overpower proc.

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -243,7 +243,7 @@ class AuraManager:
             is_unique = applied_spell_entry.AttributesEx & SpellAttributesEx.SPELL_ATTR_EX_AURA_UNIQUE
             is_stacking = applied_aura.can_stack
 
-            if is_unique or is_same_source or not aura.harmful and not (is_similar and is_stacking):
+            if (is_unique or is_same_source or not aura.harmful) and not (is_similar and is_stacking):
                 # Remove similar applied aura if it's unique, a buff or from the same caster.
                 # Ignore if this is a stacking buff; add_aura will just add a dose in that case.
                 # We can also ignore ranks here, as attempting to cast a lower rank buff will fail in validation.

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -380,6 +380,11 @@ class AuraManager:
         for aura in list(self.active_auras.values()):
             self.remove_aura(aura)
 
+    def remove_hostile_auras(self):
+        for aura in list(self.active_auras.values()):
+            if aura.caster.can_attack_target(self.unit_mgr):
+                self.remove_aura(aura)
+
     def cancel_auras_by_spell_id(self, spell_id, source_restriction=None):
         auras = self.get_auras_by_spell_id(spell_id)
 

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -1474,7 +1474,7 @@ class UnitManager(ObjectManager):
         if not is_immune:
             return False
 
-        if not is_friendly and (not source or self.can_attack_target(source)):
+        if not is_friendly and (not source or source.can_attack_target(self)):
             return True  # Immune, hostile source.
 
         # Immune, friendly source. Check for friendly immunity.

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -798,7 +798,12 @@ class UnitManager(ObjectManager):
         elif is_periodic and not self.threat_manager.has_aggro_from(source):
             return True
 
-        self.threat_manager.add_threat(source, damage_info.total_damage)
+        # Add thread according to damage.
+        if damage_info.total_damage:
+            self.threat_manager.add_threat(source, damage_info.total_damage)
+        else:
+            # No damage dealt - add minimal threat.
+            self.threat_manager.add_threat(source)
         return True
 
     def receive_healing(self, amount, source=None):

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -847,13 +847,13 @@ class UnitManager(ObjectManager):
 
         damage_info = self.calculate_spell_damage(damage, miss_reason, hit_flags, spell_effect, target)
 
-        is_cast_on_swing = spell.casts_on_swing()
+        cast_on_swing = spell.casts_on_swing() and not spell_effect.aura_type
 
-        if is_cast_on_swing:
+        if cast_on_swing:
             self.handle_melee_attack_procs(damage_info)
 
         # TODO Should other spells give skill too?
-        if is_cast_on_swing or spell.is_ranged_weapon_attack():
+        if cast_on_swing or spell.is_ranged_weapon_attack():
             self.handle_combat_skill_gain(damage_info)
             target.handle_combat_skill_gain(damage_info)
 

--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -798,7 +798,7 @@ class UnitManager(ObjectManager):
         elif is_periodic and not self.threat_manager.has_aggro_from(source):
             return True
 
-        # Add thread according to damage.
+        # Add threat according to damage.
         if damage_info.total_damage:
             self.threat_manager.add_threat(source, damage_info.total_damage)
         else:

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -264,12 +264,12 @@ class CreatureManager(UnitManager):
             if self.addon.mount_display_id > 0:
                 self.mount(self.addon.mount_display_id)
 
-        # Cast default auras for this unit.
-        self.apply_default_auras()
-
         # Stats.
         self.stat_manager.init_stats()
         self.stat_manager.apply_bonuses(replenish=True)
+
+        # Cast default auras for this unit.
+        self.apply_default_auras()
 
         # Movement.
         self.movement_manager.initialize()

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -422,8 +422,8 @@ class CreatureManager(UnitManager):
         # Flag creature as currently evading.
         self.is_evading = True
 
-        # Remove all auras on evade.
-        self.aura_manager.remove_all_auras()
+        # Remove hostile auras.
+        self.aura_manager.remove_hostile_auras()
 
         if not self.static_flags & CreatureStaticFlags.NO_AUTO_REGEN:
             self.replenish_powers()

--- a/game/world/managers/objects/units/creature/CreatureManager.py
+++ b/game/world/managers/objects/units/creature/CreatureManager.py
@@ -325,6 +325,14 @@ class CreatureManager(UnitManager):
                and (self.subtype == CustomCodes.CreatureSubtype.SUBTYPE_PET
                     or GuidUtils.extract_high_guid(self.guid) == HighGuid.HIGHGUID_PET)
 
+    def is_controlled(self):
+        owner = self.get_charmer_or_summoner()
+        if not owner:
+            return False
+
+        owner_controlled_pet = owner.pet_manager.get_active_controlled_pet()
+        return owner_controlled_pet and owner_controlled_pet.creature is self
+
     def is_temp_summon(self):
         return self.summoner and self.subtype in \
                {CustomCodes.CreatureSubtype.SUBTYPE_TEMP_SUMMON, CustomCodes.CreatureSubtype.SUBTYPE_TOTEM}
@@ -428,9 +436,8 @@ class CreatureManager(UnitManager):
         if not self.static_flags & CreatureStaticFlags.NO_AUTO_REGEN:
             self.replenish_powers()
 
-        # Pets should return to owner on evading, not to spawn position. This case at this moment only affects
-        # creature summoned pets since player summoned pets will never enter this method.
-        if self.is_pet() or self.is_at_home():
+        # Pets should return to owner on evading, not to spawn position.
+        if self.is_controlled() or self.is_at_home():
             # Should turn off flag since we are not sending move packets.
             self.is_evading = False
             self.on_at_home()

--- a/game/world/managers/objects/units/creature/ThreatManager.py
+++ b/game/world/managers/objects/units/creature/ThreatManager.py
@@ -122,7 +122,7 @@ class ThreatManager:
         charmer_or_summoner = source.get_charmer_or_summoner()
         if charmer_or_summoner and not self.has_aggro_from(charmer_or_summoner):
             # Set pet owner in combat as well.
-            self.add_threat(charmer_or_summoner)
+            self.add_threat(charmer_or_summoner, 0)
 
     def get_hostile_target(self) -> Optional[UnitManager]:
         max_threat_holder = self._get_max_threat_holder()

--- a/game/world/managers/objects/units/movement/MovementManager.py
+++ b/game/world/managers/objects/units/movement/MovementManager.py
@@ -46,8 +46,8 @@ class MovementManager:
         # Make sure to flush any existent behaviors if this was re-initialized.
         self.flush()
 
-        if self.unit.is_pet():
-            is_default = False if self.unit.charmer else True
+        if self.unit.is_controlled():
+            is_default = self.unit.is_pet()
             self.set_behavior(PetMovement(spline_callback=self.spline_callback, is_default=is_default))
         elif self.unit.has_wander_type():
             self.set_behavior(WanderingMovement(spline_callback=self.spline_callback, is_default=True))

--- a/game/world/managers/objects/units/pet/PetManager.py
+++ b/game/world/managers/objects/units/pet/PetManager.py
@@ -61,8 +61,10 @@ class PetManager:
         self._handle_creature_spawn_detach(creature, is_permanent)
         if PetSlot.PET_SLOT_TOTEM_START <= pet_slot < PetSlot.PET_SLOT_END:
             creature.subtype = CustomCodes.CreatureSubtype.SUBTYPE_TOTEM
-        else:
+        elif is_permanent:
             creature.subtype = CustomCodes.CreatureSubtype.SUBTYPE_PET
+        else:
+            creature.subtype = CustomCodes.CreatureSubtype.SUBTYPE_TEMP_SUMMON
 
         if pet_index == -1:
             # Pet not in database.


### PR DESCRIPTION
* Fix charm auras not working due to evade clearing auras
* Fix enemies attacking pet's owner if pet initiates combat by missing
* Make temporarily charmed creatures use same AI and movement as permanent pets
* Fix AoE spell effects failing to resolve targets
* Fix some AoE effects incorrectly excluding the caster
* Fix stacking auras not stacking
* Initialize creature stats before applying default auras
    * Stats being updated (due to aura application) when uninitialized leads to a crash after previous StatManager update
* Fix DoT auras from on-swing spells and dodged/blocked/parried spells proccing dazed
* Fix auras from dead enemies not being dispellable