### PR TITLE
Fix #1354 #1277 #1353

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -2125,5 +2125,31 @@ begin not atomic
 
         insert into applied_updates values ('180420242');
     end if;
+
+    -- 27/04/2024 1
+    if (SELECT COUNT(*) FROM `applied_updates` WHERE id='270420241') = 0 then
+        -- We apply Dwarf PH for the SW dwarf, at this point, they're most likely should use standard PH
+        UPDATE `creature_template` SET `display_id1` = 2584 WHERE `entry` IN (5413, 5384, 1472, 1416);
+
+        -- Darnassus Rogue Pet Trainer #1354 - Syurna 
+        DELETE FROM `spawns_creatures` WHERE (`spawn_entry1` = 4163) AND (`spawn_id` IN (46312));
+        INSERT INTO `spawns_creatures` (`spawn_id`, `spawn_entry1`, `spawn_entry2`, `spawn_entry3`, `spawn_entry4`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`, `wander_distance`, `health_percent`, `mana_percent`, `movement_type`, `spawn_flags`, `visibility_mod`, `ignored`) VALUES
+        (46312, 4163, 0, 0, 0, 1, 9839.778, 2334.644, 1314.257, 4.683, 300, 300, 0, 100, 100, 0, 0, 0, 0);
+
+        -- Darnassus Rogue Pet Trainer #1354 - Anishar
+        DELETE FROM `spawns_creatures` WHERE (`spawn_entry1` = 4215) AND (`spawn_id` IN (46470));
+        INSERT INTO `spawns_creatures` (`spawn_id`, `spawn_entry1`, `spawn_entry2`, `spawn_entry3`, `spawn_entry4`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`, `wander_distance`, `health_percent`, `mana_percent`, `movement_type`, `spawn_flags`, `visibility_mod`, `ignored`) VALUES
+        (46470, 4215, 0, 0, 0, 1, 9863.184, 2347.502, 1321.573, 4.302, 300, 300, 0, 100, 100, 0, 0, 0, 0);
+
+        -- Darnassus Rogue Pet Trainer #1354 - Erion
+        DELETE FROM `spawns_creatures` WHERE (`spawn_entry1` = 4214) AND (`spawn_id` IN (46469));
+        INSERT INTO `spawns_creatures` (`spawn_id`, `spawn_entry1`, `spawn_entry2`, `spawn_entry3`, `spawn_entry4`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`, `wander_distance`, `health_percent`, `mana_percent`, `movement_type`, `spawn_flags`, `visibility_mod`, `ignored`) VALUES
+        (46469, 4214, 0, 0, 0, 1, 9864.543, 2335.039, 1321.583, 4.3, 300, 300, 0, 100, 100, 0, 0, 0, 0);
+
+        -- Unlit Poor Torch #1277
+        UPDATE `item_template` SET `display_id` = 2618 WHERE (`entry` = 6183);
+
+        INSERT INTO `applied_updates` VALUES ('270420241');
+    end if;
 end $
 delimiter ;

--- a/game/world/managers/objects/ai/PetAI.py
+++ b/game/world/managers/objects/ai/PetAI.py
@@ -202,8 +202,8 @@ class PetAI(CreatureAI):
             spell = DbcDatabaseManager.SpellHolder.spell_get_by_id(spell_data & 0xFFFF)
             target = self.creature.combat_target if self.creature.combat_target else \
                 self.creature.get_charmer_or_summoner()
-            casting_spell = self.creature.spell_manager.try_initialize_spell(spell, target,
-                                                                             SpellTargetMask.UNIT, validate=False)
+            casting_spell = self.creature.spell_manager.try_initialize_spell(spell, target, SpellTargetMask.UNIT, 
+                                                                             validate=False, is_pet_auto_cast=True)
 
             if casting_spell.has_only_harmful_effects() != bool(self.creature.combat_target):
                 continue  # Cast harmful spells when attacking, helpful when not.

--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -60,8 +60,11 @@ class CastingSpell:
 
     dynamic_object: Optional[DynamicObjectManager]
 
+    is_pet_auto_cast = False
+
     def __init__(self, spell, caster, initial_target, target_mask, source_item=None,
-                 triggered=False, hide_result=False, triggered_by_spell=None, creature_spell=None):
+                 triggered=False, hide_result=False, triggered_by_spell=None, 
+                 creature_spell=None, is_pet_auto_cast=False):
         self.spell_entry = spell
         self.spell_caster = caster
         self.source_item = source_item
@@ -71,6 +74,7 @@ class CastingSpell:
         self.triggered_by_spell = triggered_by_spell
         self.hide_result = hide_result
         self.creature_spell = creature_spell
+        self.is_pet_auto_cast = is_pet_auto_cast
 
         self.dynamic_object = None
         self.duration_entry = DbcDatabaseManager.spell_duration_get_by_id(spell.DurationIndex)

--- a/game/world/managers/objects/spell/SpellManager.py
+++ b/game/world/managers/objects/spell/SpellManager.py
@@ -272,11 +272,10 @@ class SpellManager:
 
     def try_initialize_spell(self, spell: Spell, spell_target, target_mask, source_item=None,
                              triggered=False, triggered_by_spell=None, hide_result=False,
-                             validate=True, creature_spell=None) -> Optional[CastingSpell]:
+                             validate=True, creature_spell=None, is_pet_auto_cast=False) -> Optional[CastingSpell]:
         spell = CastingSpell(spell, self.caster, spell_target, target_mask, source_item=source_item,
                              triggered=triggered, triggered_by_spell=triggered_by_spell,
-                             hide_result=hide_result,
-                             creature_spell=creature_spell)
+                             hide_result=hide_result,creature_spell=creature_spell, is_pet_auto_cast=is_pet_auto_cast)
         if not validate:
             return spell
         return spell if self.validate_cast(spell) else None
@@ -1688,21 +1687,25 @@ class SpellManager:
             # Do not broadcast errors upon creature spell cast validate() failing.
             if spell_id not in self.casting_spells and casting_spell.creature_spell:
                 return
+            
+            charmer_or_summoner = self.caster.get_charmer_or_summoner()
+            is_pet = charmer_or_summoner != None
+            if is_pet:
+                # Only broadcast errors upon manual pet spell cast failing.
+                if not casting_spell.is_pet_auto_cast:
+                    charmer_or_summoner.pet_manager.handle_cast_result(spell_id, error)
+                return
+            
             data = pack('<QIB', self.caster.guid, spell_id, error)
             packet = PacketWriter.get_packet(OpCode.SMSG_SPELL_FAILURE, data)
             self.caster.get_map().send_surrounding(packet, self.caster, include_self=is_player)
 
-        if not is_player:
-            charmer_or_summoner = self.caster.get_charmer_or_summoner()
-            if charmer_or_summoner:
-                charmer_or_summoner.pet_manager.handle_cast_result(spell_id, error)
-            return
-
         # Only players receive cast results.
-        if error == SpellCheckCastResult.SPELL_NO_ERROR:
-            data = pack('<IB', spell_id, SpellCastStatus.CAST_SUCCESS)
-        else:
-            data = pack('<I2B', spell_id, SpellCastStatus.CAST_FAILED, error) if misc_data == -1 else \
-                   pack('<I2BI', spell_id, SpellCastStatus.CAST_FAILED, error, misc_data)
+        if is_player:
+            if error == SpellCheckCastResult.SPELL_NO_ERROR:
+                data = pack('<IB', spell_id, SpellCastStatus.CAST_SUCCESS)
+            else:
+                data = pack('<I2B', spell_id, SpellCastStatus.CAST_FAILED, error) if misc_data == -1 else \
+                    pack('<I2BI', spell_id, SpellCastStatus.CAST_FAILED, error, misc_data)
 
-        self.caster.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_CAST_RESULT, data))
+            self.caster.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_CAST_RESULT, data))


### PR DESCRIPTION
Pet Mana Message
=====

- Spamming  "Not Enough Mana" no longer occurs when a pet is autocasting OOM
- The message only appears if the player clicks on a pet spell without it having mana

Don't know if it's the correct behaviour, I can simply avoid the message all the time, even in pet manual cast if that's better #1353 

Rogue Trainer
======

Fix Darnassus rogue trainers pos #1354 

Unlit Poor Torch 
=========

Fix #1277 

Dwarf
=====

Apply dwarf placeholder display_id for 4 in Stormwind 