### PR TITLE
Inventory fixes.

### DIFF
--- a/game/world/opcode_handling/handlers/inventory/SplitItemHandler.py
+++ b/game/world/opcode_handling/handlers/inventory/SplitItemHandler.py
@@ -31,4 +31,11 @@ class SplitItemHandler(object):
             new_stack_count = source_item.item_instance.stackcount - count
             source_item.set_stack_count(new_stack_count)
 
+            source_container = inventory.get_container(source_bag_slot)
+            if source_container and not source_container.is_backpack:
+                source_container.build_container_update_packet()
+
+            if inventory.update_locked:
+                inventory.update_locked = False
+
         return 0

--- a/game/world/opcode_handling/handlers/inventory/SwapItemHandler.py
+++ b/game/world/opcode_handling/handlers/inventory/SwapItemHandler.py
@@ -8,6 +8,7 @@ class SwapItemHandler(object):
     def handle(world_session, reader):
         if len(reader.data) >= 4:  # Avoid handling empty swap item packet.
             dest_bag, dest_slot, source_bag, source_slot = unpack('<4B', reader.data[:4])
+            inventory = world_session.player_mgr.inventory
 
             if dest_bag == 0xFF:
                 dest_bag = InventorySlots.SLOT_INBACKPACK.value
@@ -15,4 +16,8 @@ class SwapItemHandler(object):
                 source_bag = InventorySlots.SLOT_INBACKPACK.value
 
             world_session.player_mgr.inventory.swap_item(source_bag, source_slot, dest_bag, dest_slot)
+
+            if inventory.update_locked:
+                inventory.update_locked = False
+
         return 0


### PR DESCRIPTION
- Closes #1367
- Fix not being able to Split->Stack items from/to bank bags slots.
- Fix frozen inventory updates after swapping/splitting items from a bank bag into player bags.