### PR TITLE
Fixes.

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -2835,7 +2835,7 @@ begin not atomic
         UPDATE `quest_template` SET `Details` = 'Searching Edwin VanCleef\'s person, you discover, among other things, an unsent letter. It is addressed to Baros Alexston, the City Architect of Stormwind, Trade District.$B$BIt appears to be recently written and sealed.' WHERE (`entry` = '373');
 
         -- Remove vendor flag from Yarlyn Amberstill, Rabbit Crate did not exist.
-        UPDATE `alpha_world`.`creature_template` SET `npc_flags` = '0' WHERE (`entry` = '1263');
+        UPDATE `creature_template` SET `npc_flags` = '0' WHERE (`entry` = '1263');
 
         insert into applied_updates values ('270620241');
     end if;

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -2834,6 +2834,9 @@ begin not atomic
         -- Baros Alexston @ Trade District.
         UPDATE `quest_template` SET `Details` = 'Searching Edwin VanCleef\'s person, you discover, among other things, an unsent letter. It is addressed to Baros Alexston, the City Architect of Stormwind, Trade District.$B$BIt appears to be recently written and sealed.' WHERE (`entry` = '373');
 
+        -- Remove vendor flag from Yarlyn Amberstill, Rabbit Crate did not exist.
+        UPDATE `alpha_world`.`creature_template` SET `npc_flags` = '0' WHERE (`entry` = '1263');
+
         insert into applied_updates values ('270620241');
     end if;
 

--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -2826,5 +2826,16 @@ begin not atomic
         insert into applied_updates values ('260620241');
     end if;
 
+    -- 27/06/2024 1
+	if (select count(*) from applied_updates where id='270620241') = 0 then
+        -- Suspicious Barrel placement.
+        UPDATE `spawns_gameobjects` SET `spawn_positionX` = '-4746.282', `spawn_positionY` = '-3530.934', `spawn_positionZ` = '297.854' WHERE (`spawn_id` = '11525');
+        
+        -- Baros Alexston @ Trade District.
+        UPDATE `quest_template` SET `Details` = 'Searching Edwin VanCleef\'s person, you discover, among other things, an unsent letter. It is addressed to Baros Alexston, the City Architect of Stormwind, Trade District.$B$BIt appears to be recently written and sealed.' WHERE (`entry` = '373');
+
+        insert into applied_updates values ('270620241');
+    end if;
+
 end $
 delimiter ;


### PR DESCRIPTION
- Closes #1376
- Quest The Unsent Letter should now hint Baros Alexston location @ Trade District.
- Closes #1380 (Tested it and both were pulled, maybe related to the pet fixes).