### PR TITLE
Navigation/Movement

### DIFF
--- a/game/world/managers/abstractions/Vector.py
+++ b/game/world/managers/abstractions/Vector.py
@@ -112,9 +112,15 @@ class Vector(object):
 
     # https://math.stackexchange.com/a/2045181
     # a map_id of -1 will make Z ignore map information.
-    def get_point_in_between(self, offset, vector=None, x=0, y=0, z=0, map_id=-1):
+    def get_point_in_between(self, unit, offset, vector=None, x=0, y=0, z=0, map_id=-1):
         if not vector:
             vector = Vector(x=x, y=y, z=z)
+
+        # Namigator.
+        point_in_between = unit.get_map().find_point_in_between_vectors(offset, unit.location, vector)
+        if point_in_between:
+            # Convert Namigator tuple to Vector.
+            return Vector(point_in_between[0], point_in_between[1], point_in_between[2])
 
         general_distance = self.distance(vector)
         # Location already in the given offset
@@ -149,6 +155,15 @@ class Vector(object):
         z, z_locked = Vector.calculate_z(x, y, map_id, self.z, is_rand_point=True)
 
         return Vector(x, y, z, z_locked=z_locked)
+
+    # Namigator, returns a random point from a circle within or slightly outside of the given radius.
+    def find_random_point_around_circle(self, unit, radius):
+        random_point = unit.get_map().find_random_point_around_circle(unit.location, radius)
+        if not random_point:
+            return self.get_random_point_in_radius(radius, map_id=unit.map_id)
+        else:
+            # Convert Namigator tuple to Vector.
+            return Vector(random_point[0], random_point[1], random_point[2])
 
     def get_point_in_radius_and_angle(self, radius, angle, final_orientation=-1, map_id=-1):
         x = self.x + (radius * math.cos(self.o + angle))

--- a/game/world/managers/maps/Map.py
+++ b/game/world/managers/maps/Map.py
@@ -129,6 +129,12 @@ class Map:
     def calculate_path(self, start_vector, end_vector, los=False) -> tuple:  # bool failed, in_place, path list.
         return self.map_manager.calculate_path(self.map_id, start_vector, end_vector, los=los)
 
+    def find_point_in_between_vectors(self, offset, start_location, end_location):
+        return self.map_manager.find_point_in_between_vectors(self.map_id, offset, start_location, end_location)
+
+    def find_random_point_around_circle(self, location, radius):
+        return self.map_manager.find_random_point_around_circle(self.map_id, location, radius)
+
     def calculate_z_for_object(self, world_object):
         return self.map_manager.calculate_z_for_object(world_object)
 

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -442,6 +442,11 @@ class MapManager:
                 if not z_locked:
                     return nav_z, False
 
+            # Check if we have .map data for this request.
+            tile = MAPS_TILES[map_id][adt_x][adt_y]
+            if not tile or not tile.has_maps:
+                return current_z, True
+
             try:
                 calculated_z = MapManager.get_normalized_height_for_cell(map_id, x, y, adt_x, adt_y, cell_x, cell_y)
                 # Tolerance.

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -27,7 +27,8 @@ MAPS_TILES = dict()
 # Holds namigator instances per Map.
 MAPS_NAMIGATOR: dict[int, Namigator] = dict()
 # Holds maps which have no navigation data in alpha.
-MAPS_NO_NAVIGATION = {2, 13, 25, 29, 30, 34, 35, 37, 42, 43, 44, 47, 48, 70, 90, 109, 129}
+# UnderMine, test, ScottTest, Test, PVPZone1/2, Collin, SunkenTemple.
+MAPS_NO_NAVIGATION = {2, 13, 25, 29, 30, 37, 42, 109}
 
 AREAS = {}
 AREA_LIST = DbcDatabaseManager.area_get_all_ids()
@@ -310,6 +311,33 @@ class MapManager:
 
         failed, in_place, _ = MapManager.calculate_path(src_object.map_id, src_object.location, dst_object.location)
         return not failed
+
+    @staticmethod
+    def find_point_in_between_vectors(map_id, offset, start_location, end_location):
+        # If nav tiles disabled or unable to load Namigator, return None..
+        if not config.Server.Settings.use_nav_tiles or not MapManager.NAMIGATOR_LOADED:
+            return None
+
+        # We don't have navs loaded for a given map, return None..
+        namigator = MAPS_NAMIGATOR.get(map_id, None)
+        if not namigator:
+            return None
+
+        return namigator.find_point_in_between_vectors(offset, start_location.x, start_location.y, start_location.z,
+                                                       end_location.x, end_location.y, end_location.z)
+
+    @staticmethod
+    def find_random_point_around_circle(map_id, location, radius):
+        # If nav tiles disabled or unable to load Namigator, return None..
+        if not config.Server.Settings.use_nav_tiles or not MapManager.NAMIGATOR_LOADED:
+            return None
+
+        # We don't have navs loaded for a given map, return None..
+        namigator = MAPS_NAMIGATOR.get(map_id, None)
+        if not namigator:
+            return None
+
+        return namigator.find_random_point_around_circle(location.x, location.y, location.z, radius)
 
     @staticmethod
     def calculate_path(map_id, src_loc, dst_loc, los=False) -> tuple:  # bool failed, in_place, path list.

--- a/game/world/managers/maps/MapTile.py
+++ b/game/world/managers/maps/MapTile.py
@@ -74,15 +74,27 @@ class MapTile(object):
     def load_namigator_data(self, namigator):
         if not config.Server.Settings.use_nav_tiles or not namigator:
             return False
+
+        if not self.map_.is_dungeon() and namigator.has_adts():
+            return self._load_namigator_adt(namigator)
+        else:
+            return self._load_namigator_wmo_map(namigator)
+
+    def _load_namigator_adt(self, namigator):
         try:
             Logger.debug(f'[Namigator] Loading nav ADT, Map:{self.map_id} Tile:{self.adt_x},{self.adt_y}')
             # Notice, namigator has inverted coordinates.
             namigator.load_adt(self.adt_y, self.adt_x)
             self.has_navigation = True
             return True
-        except:
+        except RuntimeError:
             Logger.error(traceback.format_exc())
-            return False
+        return False
+
+    def _load_namigator_wmo_map(self, namigator):
+        Logger.debug(f'[Namigator] Loading nav WMO, Map:{self.map_id} Tile:{self.adt_x},{self.adt_y}')
+        self.has_navigation = True
+        return True
 
     def load_maps_data(self):
         if not config.Server.Settings.use_map_tiles:

--- a/game/world/managers/maps/helpers/Namigator.py
+++ b/game/world/managers/maps/helpers/Namigator.py
@@ -13,5 +13,20 @@ class Namigator:
     def find_path(self, start_x, start_y, start_z, end_x, end_y, end_z):
         pass
 
+    def has_adts(self):
+        pass
+
+    def adt_loaded(self, adt_x, adt_y):
+        pass
+
     def load_adt(self, adt_x, adt_y):
+        pass
+
+    def unload_adt(self, adt_x, adt_y):
+        pass
+
+    def find_random_point_around_circle(self, start_x, start_y, start_z, radius):
+        pass
+
+    def find_point_in_between_vectors(self, distance, start_x, start_y, start_z, end_x, end_y, end_z):
         pass

--- a/game/world/managers/objects/spell/SpellEffectHandler.py
+++ b/game/world/managers/objects/spell/SpellEffectHandler.py
@@ -559,7 +559,7 @@ class SpellEffectHandler:
         # It wasn't until Patch 0.6 that Charge speeded you along a path towards the target, it just teleported you
         # next to the target (there's also video evidence of this behavior).
         distance = caster.location.distance(target.location) - UnitFormulas.combat_distance(leaper, leap_target)
-        charge_location = caster.location.get_point_in_between(distance, target.location, map_id=caster.map_id)
+        charge_location = caster.location.get_point_in_between(caster, distance, target.location, map_id=caster.map_id)
         charge_location.face_point(target.location)
 
         # Always increase Z when not using namigator to protect players from falling off world.
@@ -641,13 +641,13 @@ class SpellEffectHandler:
                     py = target.y
                     pz = target.z
                 else:
-                    location = caster.location.get_random_point_in_radius(radius, caster.map_id)
+                    location = caster.location.find_random_point_around_circle(caster, radius)
                     px = location.x
                     py = location.Y
                     pz = location.z
             else:
                 if radius > 0.0:
-                    location = caster.location.get_random_point_in_radius(radius, caster.map_id)
+                    location = caster.location.find_random_point_around_circle(caster, radius)
                     px = location.x
                     py = location.Y
                     pz = location.z

--- a/game/world/managers/objects/units/movement/behaviors/ConfusedMovement.py
+++ b/game/world/managers/objects/units/movement/behaviors/ConfusedMovement.py
@@ -78,16 +78,8 @@ class ConfusedMovement(BaseMovement):
 
     def _get_confused_move_point(self):
         start_point = self.home_position
-        random_point = start_point.get_random_point_in_radius(self.confused_distance, map_id=self.unit.map_id)
+        random_point = start_point.find_random_point_around_circle(self.unit, self.confused_distance)
         map_ = self.unit.get_map()
-        # Check line of sight.
-        if not map_.los_check(self.unit.location, random_point.get_ray_vector(is_terrain=True)):
-            return False, start_point
-
-        # Validate a path to the random point.
-        failed, in_place, path = map_.calculate_path(self.unit.location, random_point, los=True)
-        if failed or len(path) > 1 or in_place or start_point.distance(random_point) < 1:
-            return False, start_point
 
         # Ignore point if 'slope' above 2.5.
         diff = math.fabs(random_point.z - self.unit.location.z)

--- a/game/world/managers/objects/units/movement/behaviors/FearMovement.py
+++ b/game/world/managers/objects/units/movement/behaviors/FearMovement.py
@@ -105,7 +105,7 @@ class FearMovement(BaseMovement):
         if not config.Server.Settings.use_nav_tiles:
             return [fear_point]
         for search_range in range(0, int(SEARCH_RANDOM_RADIUS)):
-            destination = fear_point.get_random_point_in_radius(search_range, self.unit.map_id)
+            destination = fear_point.find_random_point_around_circle(self.unit, search_range)
             failed, in_place, path = self.unit.get_map().calculate_path(self.unit.location, destination)
             if not failed:
                 return path

--- a/game/world/managers/objects/units/movement/behaviors/PetMovement.py
+++ b/game/world/managers/objects/units/movement/behaviors/PetMovement.py
@@ -88,7 +88,8 @@ class PetMovement(BaseMovement):
             return False, None
 
         # Should not probably use RangeMax, but RangeMin can be 0. Ideas?.
-        target_location = self.pet_range_move.target.location.get_point_in_between(self.pet_range_move.range_,
+        target_location = self.pet_range_move.target.location.get_point_in_between(self.unit,
+                                                                                   self.pet_range_move.range_,
                                                                                    vector=self.unit.location)
 
         # At position or heading in that direction.

--- a/game/world/managers/objects/units/movement/behaviors/WanderingMovement.py
+++ b/game/world/managers/objects/units/movement/behaviors/WanderingMovement.py
@@ -61,7 +61,7 @@ class WanderingMovement(BaseMovement):
 
     def _get_wandering_point(self):
         start_point = self.wander_home_position
-        random_point = start_point.get_random_point_in_radius(self.wandering_distance, map_id=self.unit.map_id)
+        random_point = start_point.find_random_point_around_circle(self.unit, self.wandering_distance)
         map_ = self.unit.get_map()
         # Check line of sight.
         if not map_.los_check(self.unit.location, random_point.get_ray_vector(is_terrain=True)):

--- a/game/world/managers/objects/units/movement/helpers/Spline.py
+++ b/game/world/managers/objects/units/movement/helpers/Spline.py
@@ -96,7 +96,7 @@ class Spline(object):
             return pending_waypoint.location
         guessed_distance = self.speed * elapsed
         # This can return None.
-        return self.unit.location.get_point_in_between(guessed_distance, pending_waypoint.location,
+        return self.unit.location.get_point_in_between(self.unit, guessed_distance, pending_waypoint.location,
                                                        map_id=self.unit.map_id)
 
     # noinspection PyMethodMayBeStatic


### PR DESCRIPTION
- Wandering will now use find_random_point_around_circle. (Namigator)
- get_point_in_between  (In travel server side position calculations, pet follow position, fear and spells like Charge) will now use find_point_in_between_vectors (Namigator)
- Update Namigator.py definitions.
- MapTile - Fix navigation loading for Maps with no ADTs.

- Enable pathing/LoS for the following maps:
- StormwindJail
- StormwindPrison
- WailingCaverns
- Monastery
- RazorfenKraul
- Blackfathom
- Uldaman
- Gnomeragon
- RazorfenDowns

* Will wait for https://github.com/namreeb/namigator/issues/70 to be resolved.