### PR TITLE
Improve movement updates within transports

### DIFF
--- a/game/world/WorldManager.py
+++ b/game/world/WorldManager.py
@@ -227,6 +227,7 @@ class WorldServerSessionHandler:
             WorldServerSessionHandler.build_scheduler('Player', WorldSessionStateHandler.update_players, 0.1, 1),
             WorldServerSessionHandler.build_scheduler('Creature', MapManager.update_creatures, 0.2, 1),
             WorldServerSessionHandler.build_scheduler('Gameobject', MapManager.update_gameobjects, 1.0, 1),
+            WorldServerSessionHandler.build_scheduler('Transport', MapManager.update_transports, 0.1, 1),
             WorldServerSessionHandler.build_scheduler('DynObject', MapManager.update_dynobjects, 1.0, 1),
             WorldServerSessionHandler.build_scheduler('Spawn', MapManager.update_spawns, 1.0, 1),
             WorldServerSessionHandler.build_scheduler('Corpse', MapManager.update_corpses, 10.0, 1),

--- a/game/world/managers/maps/Cell.py
+++ b/game/world/managers/maps/Cell.py
@@ -21,6 +21,7 @@ class Cell:
         self.cell_lock = RLock()
         # Instances.
         self.gameobjects = dict()
+        self.transports = dict()
         self.creatures = dict()
         self.players = dict()
         self.dynamic_objects = dict()
@@ -97,6 +98,8 @@ class Cell:
             self.creatures[world_object.guid] = world_object
         elif world_object.is_gameobject():
             self.gameobjects[world_object.guid] = world_object
+            if world_object.is_transport():
+                self.transports[world_object.guid] = world_object
         elif world_object.is_dyn_object():
             self.dynamic_objects[world_object.guid] = world_object
         elif world_object.is_corpse():
@@ -122,7 +125,14 @@ class Cell:
         with self.cell_lock:
             # Update gameobject instances.
             for guid, gameobject in list(self.gameobjects.items()):
-                gameobject.update(now)
+                if guid not in self.transports:
+                    gameobject.update(now)
+
+    def update_transports(self, now):
+        with self.cell_lock:
+            # Update transport instances.
+            for guid, transport in list(self.transports.items()):
+                transport.update(now)
 
     def update_dynobjects(self, now):
         with self.cell_lock:
@@ -180,6 +190,7 @@ class Cell:
             return True
         elif world_object.is_gameobject() and guid in self.gameobjects:
             self.gameobjects.pop(world_object.guid, None)
+            self.transports.pop(world_object.guid, None)
             return True
         elif world_object.is_dyn_object() and guid in self.dynamic_objects:
             self.dynamic_objects.pop(world_object.guid, None)

--- a/game/world/managers/maps/GridManager.py
+++ b/game/world/managers/maps/GridManager.py
@@ -391,6 +391,12 @@ class GridManager:
             for key in list(self.active_cell_keys):
                 self.cells[key].update_gameobjects(now)
 
+    def update_transports(self):
+        with self.grid_lock:
+            now = time.time()
+            for key in list(self.active_cell_keys):
+                self.cells[key].update_transports(now)
+
     def update_dynobjects(self):
         with self.grid_lock:
             now = time.time()

--- a/game/world/managers/maps/Map.py
+++ b/game/world/managers/maps/Map.py
@@ -286,6 +286,9 @@ class Map:
     def update_gameobjects(self):
         self.grid_manager.update_gameobjects()
 
+    def update_transports(self):
+        self.grid_manager.update_transports()
+
     def update_dynobjects(self):
         self.grid_manager.update_dynobjects()
 

--- a/game/world/managers/maps/MapManager.py
+++ b/game/world/managers/maps/MapManager.py
@@ -595,6 +595,12 @@ class MapManager:
                 instance_map.update_gameobjects()
 
     @staticmethod
+    def update_transports():
+        for map_id, instances in list(MAPS.items()):
+            for instance_map in list(instances.values()):
+                instance_map.update_transports()
+
+    @staticmethod
     def update_dynobjects():
         for map_id, instances in list(MAPS.items()):
             for instance_map in list(instances.values()):

--- a/game/world/managers/objects/gameobjects/managers/TransportManager.py
+++ b/game/world/managers/objects/gameobjects/managers/TransportManager.py
@@ -11,8 +11,9 @@ from utils.Logger import Logger
 from utils.constants.MiscCodes import GameObjectStates, HighGuid
 
 
-# TODO: Players automatically desync to other player viewers when inside transports.
-#  this seems to be all client related since we've tried many changes based on other cores and nothing seems to work.
+# TODO: The current way of handling movement updates within transports is hacky.
+#  Players seem to disappear for each other if updates aren't synchronized with the transport's update.
+#  It's likely that the client's implementation for calculating positions within transports is flawed:
 #  From 0.5.4 patch notes. 'fixed problems with elevators.'
 #  From 0.7.1 patch notes. 'fixed multiple crashes related to both players and pets on elevators'
 class TransportManager(GameObjectManager):

--- a/game/world/managers/objects/gameobjects/managers/TransportManager.py
+++ b/game/world/managers/objects/gameobjects/managers/TransportManager.py
@@ -25,7 +25,6 @@ class TransportManager(GameObjectManager):
         self.total_time = 0.0
         self.current_segment = 0
         self.path_nodes: dict[int, TransportAnimation] = {}
-        self.load_path_nodes()
         self.stationary_position = self.location.copy()
         self.auto_close_secs = 0
 
@@ -33,6 +32,7 @@ class TransportManager(GameObjectManager):
     def initialize_from_gameobject_template(self, gobject_template):
         super().initialize_from_gameobject_template(gobject_template)
         self.auto_close_secs = self.get_data_field(3, int)
+        self.load_path_nodes()
 
     # override
     def update(self, now):
@@ -40,7 +40,7 @@ class TransportManager(GameObjectManager):
             if self.is_active_object() and self.has_passengers():
                 self._calculate_progress()
                 self._update_passengers()
-            super().update(now)
+        super().update(now)
 
     def load_path_nodes(self):
         for node in DbcDatabaseManager.TransportAnimationHolder.animations_by_entry(self.get_entry()):

--- a/game/world/managers/objects/gameobjects/managers/TransportManager.py
+++ b/game/world/managers/objects/gameobjects/managers/TransportManager.py
@@ -20,7 +20,8 @@ class TransportManager(GameObjectManager):
         super().__init__(**kwargs)
 
         self.passengers = {}
-        self.current_anim_position = self.location
+        self.new_passengers = set()
+        self.current_anim_position = self.location.copy()
         self.path_progress = 0.0
         self.total_time = 0.0
         self.current_segment = 0
@@ -132,19 +133,19 @@ class TransportManager(GameObjectManager):
     def _update_passengers(self):
         for unit in list(self.passengers.values()):
             self.calculate_passenger_position(unit)
-            unit.movement_info.send_surrounding_update()
+            if unit.guid in self.new_passengers:
+                self.new_passengers.discard(unit.guid)
+                unit.movement_info.send_surrounding_update()
 
     def add_passenger(self, unit):
         self.passengers[unit.guid] = unit
+        self.new_passengers.add(unit.guid)
 
     def remove_passenger(self, unit):
         if unit.guid not in self.passengers:
             return
         self.passengers.pop(unit.guid)
-
-    def update_passengers(self):
-        if len(self.passengers) == 0:
-            return
+        self.new_passengers.discard(unit.guid)
 
     def _debug_position(self, location):
         from game.world.managers.objects.gameobjects.GameObjectBuilder import GameObjectBuilder

--- a/game/world/managers/objects/units/movement/MovementInfo.py
+++ b/game/world/managers/objects/units/movement/MovementInfo.py
@@ -92,9 +92,12 @@ class MovementInfo:
         return map_.get_surrounding_gameobject_by_guid(self.owner, self.owner.transport_id)
 
     def _get_bytes(self):
+        # Client seems to expect local coordinates in place of world coordinates for players on transports.
+        location = self.owner.transport_location if self.transport else self.owner.location
+
         data = pack('<2Q9fI', self.owner.guid, self.owner.transport_id, self.owner.transport_location.x,
                     self.owner.transport_location.y, self.owner.transport_location.z, self.owner.transport_location.o,
-                    self.owner.location.x, self.owner.location.y, self.owner.location.z, self.owner.location.o,
+                    location.x, location.y, location.z, location.o,
                     self.owner.pitch, self.owner.movement_flags)
 
         if self.owner.movement_spline:

--- a/game/world/opcode_handling/handlers/player/MovementHandler.py
+++ b/game/world/opcode_handling/handlers/player/MovementHandler.py
@@ -25,6 +25,7 @@ class MovementHandler:
             try:
                 # Get the player or its possessed unit.
                 unit_mover = player_mgr if not player_mgr.possessed_unit else player_mgr.possessed_unit
+                prev_transport = unit_mover.transport_id
                 move_info = unit_mover.movement_info.update(reader, unit_mover)
 
                 # Hacky way to prevent random teleports when colliding with elevators.
@@ -48,8 +49,14 @@ class MovementHandler:
                             player_mgr.stand_state != StandState.UNIT_STANDING:
                         player_mgr.set_stand_state(StandState.UNIT_STANDING)
 
+                transport_changed = prev_transport != unit_mover.transport_id
+                if transport_changed or move_info.transport and player_mgr.guid in move_info.transport.new_passengers:
+                    # Don't send movement update for transport changes and synchronize updates with transport update.
+                    # This is a hacky way to prevent players disappearing for each other when interacting with transports.
+                    return 0
+
                 # Broadcast unit mover movement to surroundings.
-                move_info.send_surrounding_update(opcode=OpCode(reader.opcode))
+                move_info.send_surrounding_update(OpCode(reader.opcode))
 
             except (AttributeError, error):
                 Logger.error(f'Error while handling {reader.opcode_str()}, skipping. Data: {reader.data}')


### PR DESCRIPTION
* Fix transport update and path node loading
* Send transport location in place of world location in movement updates when within transports
    * Closes #978
* When entering transports, don't broadcast movement updates until transport GO has updated
    * This consistently prevents players from disappearing for each other when entering transports, but results may vary when latency is involved
    * Players can still disappear for each other when quickly leaving and entering a transport, or rarely when jumping into the transport. 
    * Consistency could possibly be improved by forcing the transport to update soon after passengers are added
* Update transports every 100ms to reduce skipped movement packets