### PR TITLE
Spell / Aura fixes

### DIFF
--- a/game/world/managers/objects/spell/CastingSpell.py
+++ b/game/world/managers/objects/spell/CastingSpell.py
@@ -11,7 +11,7 @@ from game.world.managers.objects.dynamic.DynamicObjectManager import DynamicObje
 from game.world.managers.objects.item.ItemManager import ItemManager
 from game.world.managers.objects.spell import ExtendedSpellData
 from game.world.managers.objects.spell.EffectTargets import TargetMissInfo, EffectTargets
-from game.world.managers.objects.spell.ExtendedSpellData import TotemHelpers, SpellThreatMechanics
+from game.world.managers.objects.spell.ExtendedSpellData import TotemHelpers, SpellThreatInfo
 from game.world.managers.objects.units.DamageInfoHolder import DamageInfoHolder
 from game.world.managers.objects.units.player.StatManager import UnitStats
 from game.world.managers.objects.spell.SpellEffect import SpellEffect
@@ -292,7 +292,7 @@ class CastingSpell:
 
     def generates_threat(self):
         return (not self.spell_entry.AttributesEx & SpellAttributesEx.SPELL_ATTR_EX_NO_THREAT
-                and SpellThreatMechanics.spell_should_generate_threat(self.spell_entry.ID))
+                and SpellThreatInfo.spell_generates_threat(self.spell_entry.ID))
 
     def generates_threat_on_miss(self):
         return self.spell_entry.AttributesEx & SpellAttributesEx.SPELL_ATTR_EX_THREAT_ON_MISS

--- a/game/world/managers/objects/spell/ExtendedSpellData.py
+++ b/game/world/managers/objects/spell/ExtendedSpellData.py
@@ -341,14 +341,15 @@ class SpellEffectMechanics:
         return SpellMechanic.MECHANIC_SLEEP if \
             spell_id in SpellEffectMechanics._SLEEP_MECHANIC_SPELLS else None
 
-class SpellThreatMechanics:
+
+class SpellThreatInfo:
     _NON_COMBAT_STUN_SPELLS = (
-        700, 1090, 2937, # Sleep.
-        2070, 6770, 6771, # Sap.
-        6358 # Seduction.
+        700, 1090, 2937,   # Sleep.
+        2070, 6770, 6771,  # Sap.
+        6358               # Seduction.
     )
 
     # According to evidence from screenshots, neither Sleep, Sap nor Seduction gets the player in combat.
     @staticmethod
-    def spell_should_generate_threat(spell_id) -> bool:
-        return spell_id not in SpellThreatMechanics._NON_COMBAT_STUN_SPELLS
+    def spell_generates_threat(spell_id) -> bool:
+        return spell_id not in SpellThreatInfo._NON_COMBAT_STUN_SPELLS

--- a/game/world/managers/objects/spell/ExtendedSpellData.py
+++ b/game/world/managers/objects/spell/ExtendedSpellData.py
@@ -130,6 +130,22 @@ class AuraSourceRestrictions:
         return False
 
 
+class AuraTargetRestrictions:
+    # Only one target can be slept at a time.
+    SLEEP_SPELLS = {700, 1090, 2937}
+
+    GROUPS = [SLEEP_SPELLS]
+
+    @staticmethod
+    def is_single_target_aura(spell_id: int):
+        return any(spell_id in group for group in AuraTargetRestrictions.GROUPS)
+
+    @staticmethod
+    def are_colliding_auras(spell_id_1: int, spell_id_2: int):
+        return any(spell_id_1 in group and spell_id_2 in group
+                   for group in AuraTargetRestrictions.GROUPS)
+
+
 class CastPositionRestrictions:
     CASTABLE_FROM_BEHIND = {
         53, 2589, 2590, 2591, 7159, 7463,  # Backstab

--- a/game/world/managers/objects/spell/aura/AuraManager.py
+++ b/game/world/managers/objects/spell/aura/AuraManager.py
@@ -407,9 +407,12 @@ class AuraManager:
 
         # Remove tracked single-target aura.
         if AuraTargetRestrictions.is_single_target_aura(aura.spell_id):
-            source_auras = AuraManager.SINGLE_TARGET_AURAS.get(aura.caster.guid) or []
-            source_auras.remove(aura)
-            AuraManager.SINGLE_TARGET_AURAS[aura.caster.guid] = source_auras
+            source_auras = AuraManager.SINGLE_TARGET_AURAS.get(aura.caster.guid, [])
+            source_auras = [a for a in source_auras if a != aura]
+            if not source_auras:
+                AuraManager.SINGLE_TARGET_AURAS.pop(aura.caster.guid, None)
+            else:
+                AuraManager.SINGLE_TARGET_AURAS[aura.caster.guid] = source_auras
 
         self.write_aura_to_unit(aura, clear=True)
 

--- a/utils/constants/SpellCodes.py
+++ b/utils/constants/SpellCodes.py
@@ -507,6 +507,16 @@ class AuraState(IntEnum):
     AURA_STATE_HEALTH_20_PERCENT = 2
 
 
+class AuraFlags(IntEnum):
+    AURA_FLAG_NONE                  = 0x00,
+    AURA_FLAG_CANCELABLE            = 0x01,
+    AURA_FLAG_EFF_INDEX_2           = 0x02,
+    AURA_FLAG_EFF_INDEX_1           = 0x04,
+    AURA_FLAG_EFF_INDEX_0           = 0x08,
+
+    AURA_FLAG_ALL                   = 0x0F
+
+
 class SpellImplicitTargets(IntEnum):
     TARGET_INITIAL = 0
     TARGET_SELF = 1


### PR DESCRIPTION
* Implement single target restriction for [Sleep](https://db.thealphaproject.eu/index.php?action=show_spell&id=700)
* Fix cast validation for self-targeted debuffs ([Ferocity](https://db.thealphaproject.eu/index.php?action=show_spell&id=4154))
* Fix generating unit aura flags
    * Likely closes #406
* Minor refactor to `SpellThreatMechanics`