### PR TITLE
Bug fixes!

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -1296,5 +1296,16 @@ begin not atomic
 
         INSERT INTO applied_updates VALUES ('080620251');
     end if;
+
+    -- 15/08/2025 1
+    if (select count(*) from applied_updates where id='150820251') = 0 then
+        -- Fix spell data and name for Minor Bloodstone
+        UPDATE `item_template` SET `name` = "Minor Bloodstone",
+           `spellid_1` = 6262, `spellcategory_1` = 30, `spellcategorycooldown_1` = 180000,
+           `spellid_2` = 0, `spellcategory_2` = 0, `spellcategorycooldown_2` = 0
+        WHERE entry = 5512;
+
+        INSERT INTO applied_updates VALUES ('150820251');
+    end if;
 end $
 delimiter ;

--- a/game/world/managers/objects/units/creature/utils/TrainerUtils.py
+++ b/game/world/managers/objects/units/creature/utils/TrainerUtils.py
@@ -5,7 +5,6 @@ from database.dbc.DbcDatabaseManager import DbcDatabaseManager
 from database.dbc.DbcModels import Spell
 from database.world.WorldDatabaseManager import WorldDatabaseManager
 from database.world.WorldModels import TrainerTemplate
-from game.world.managers.objects.item.ItemManager import ItemManager
 from network.packet.PacketWriter import PacketWriter
 from utils.Logger import Logger
 from utils.ObjectQueryUtils import ObjectQueryUtils
@@ -240,7 +239,12 @@ class TrainerUtils:
         if template_req_skill:
             # Check player race/class masks with skill race/class masks.
             skill_race_mask = template_req_skill.RaceMask
+            if template_req_skill.ExcludeRace:
+                skill_race_mask = ~skill_race_mask
+
             skill_class_mask = template_req_skill.ClassMask
+            if template_req_skill.ExcludeClass:
+                skill_class_mask = ~skill_class_mask
 
             if skill_race_mask and not race_mask & skill_race_mask:
                 return False

--- a/game/world/managers/objects/units/pet/PetData.py
+++ b/game/world/managers/objects/units/pet/PetData.py
@@ -204,10 +204,10 @@ class PetData:
         # Load spell info.
         line_spells = [DbcDatabaseManager.SpellHolder.spell_get_by_id(line.Spell) for line in skill_line_abilities]
 
-        # Filter spells by pet level.
+        # Filter spells by pet level,
+        # ignore spells with no level information (pet talents).
         level = level_override if level_override != -1 else self._level
-        # TODO This level isn't always correct. We should do a lookup on the teaching spell instead.
-        return [spell.ID for spell in line_spells if ignore_level or spell.SpellLevel <= level]
+        return [spell.ID for spell in line_spells if spell.SpellLevel and (ignore_level or spell.SpellLevel <= level)]
 
     def can_learn_spell(self, spell_id):
         return spell_id in self.get_available_spells()

--- a/game/world/managers/objects/units/pet/PetManager.py
+++ b/game/world/managers/objects/units/pet/PetManager.py
@@ -86,7 +86,14 @@ class PetManager:
         creature.leave_combat()
 
         self.send_pet_spell_info()
+
+        # Set level and initialize pet stats.
         active_pet.set_level(pet_level)
+
+        # Apply passive effects.
+        for spell in active_pet.get_pet_data().spells:
+            spell_template = DbcDatabaseManager.SpellHolder.spell_get_by_id(spell)
+            creature.spell_manager.apply_passive_spell_effects(spell_template)
 
         if pet_data.is_hunter_pet():
             creature.set_can_rename(pet_data.rename_time == 0)  # Only allow one rename.

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -233,7 +233,7 @@ class SkillManager(object):
         self.proficiencies = {}
 
         # Dictionary for all equipment proficiencies the player can learn.
-        # Used to determine which talents should be excluded from the player (ie. 2H talents from rogues).
+        # Used to determine which talents should be excluded from the player (e.g. 2H talents from rogues).
         self.full_proficiency_masks = {}
 
     def load_skills(self):


### PR DESCRIPTION
* Fix pet passive effects not being applied
* Fix max level hunters' pets not gaining experience
* Don't automatically learn hunter pet talents on tame
    * Fixes hunter pets learning all possible passive talents
    * These spells lack level data, and training level requirements would be tricky to load
* Fix race/class restriction check for talents
    * Fixes Bow Specialization not being available for hunters using bows
* Don't interrupt physical spells from crushing blows
    * 0.5.3: `Creatures dealing enough damage (crushing blow) will now fully interrupt casting`
    * Patch notes probably don't refer to abilities with "casting"
* Fix lower rank abilities persisting in spellbook (after relog) when a new rank is learned
* Fix `Minor Healthstone` spell data and rename to `Minor Bloodstone`
    * Closes #1523