### PR TITLE
Fix crash related to questgiver items

### DIFF
--- a/game/world/managers/objects/units/player/quest/QuestManager.py
+++ b/game/world/managers/objects/units/player/quest/QuestManager.py
@@ -297,6 +297,9 @@ class QuestManager:
         # Greeting - 'None'
         return QuestState.QUEST_GREETING
 
+    def get_quest_state_acceptable(self, quest_entry):
+        return self.get_quest_state(quest_entry) < QuestState.QUEST_ACCEPTED
+
     def get_active_quest_num_from_quest_giver(self, quest_giver):
         quest_num: int = 0
 
@@ -1268,8 +1271,8 @@ class QuestManager:
         if not item_template:
             return False
 
-        # Always allow items that are quest starters.
-        if item_template.start_quest > 0:
+        # Always allow items that are quest starters (if we are not on that quest and it's not done)
+        if item_template.start_quest > 0 and self.get_quest_state_acceptable(item_template.start_quest):
             return True
 
         for active_quest in list(self.active_quests.values()):

--- a/game/world/opcode_handling/handlers/quest/QuestGiverQueryQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverQueryQuestHandler.py
@@ -49,6 +49,8 @@ class QuestGiverQueryQuestHandler:
                     return 0
                 if not quest_giver.item_template.start_quest == quest_entry:
                     return 0
+                if not player_mgr.quest_manager.get_quest_state_acceptable(quest.quest_entry):
+                    return 0
             else:
                 Logger.error(f'Error in {reader.opcode_str()}, unknown quest giver type.')
                 return 0


### PR DESCRIPTION
Fix items that are quest givers can be looted multiple times, accepting such quest crashes the server (e.g. 1307 - Gold Pickup Schedule).

This is just an attempt and runs smoothly locally. Sadly this does introduce some more issues like:
- A masterlooter (guess not present here) could not give players items like Onyxias head (https://tbcdb.rising-gods.de/?item=18422)
- The mob is still marked as lootable but the loot is empty (but I couldn't find a good place to do so)
- Master of the arena (guess not present here) can only be looted as long as you do not accept the quest (https://tbcdb.rising-gods.de/?item=18706)

The QuestGiverQueryQuestHandler alone would suffice to prevent the crash and is required even when changing the QuestManager since you could give that item to another player (e.g. additem) and then the server would still crash on accept.

I have very limited knowledge of python and the codebase itself, so I hope this fine - feel free to adapt or decline :)