### PR TITLE
Closes #1661

### DIFF
--- a/etc/databases/world/updates/updates.sql
+++ b/etc/databases/world/updates/updates.sql
@@ -23250,5 +23250,72 @@ begin not atomic
         insert into applied_updates values ('270320262');
     end if;
 
+    -- 19/04/2026 1
+    if (select count(*) from applied_updates where id='190420261') = 0 then
+        -- Closes https://github.com/The-Alpha-Project/alpha-core/issues/1661
+        -- Captain Placeholder should offer and complete both Menethil -> Auberdine/Theramore boat placeholder quests.
+        INSERT INTO `creature_quest_starter` (`entry`, `quest`) VALUES (3896, 1126)
+            ON DUPLICATE KEY UPDATE `quest` = VALUES(`quest`);
+
+        INSERT INTO `creature_quest_finisher` (`entry`, `quest`) VALUES (3896, 1126)
+            ON DUPLICATE KEY UPDATE `quest` = VALUES(`quest`);
+
+        -- Sniffed quest list levels for boat placeholder teleport menus.
+        UPDATE `quest_template` SET `QuestLevel` = 1 WHERE `entry` IN (796, 797, 798, 799, 801, 802, 803, 1018, 1019, 1124, 1126);
+
+        -- Prevent boat placeholder NPCs from offering another teleport while their 2 second teleport cast is active.
+        DELETE FROM `quest_end_scripts`
+        WHERE `id` IN (796, 797, 798, 799, 801, 802, 803, 1018, 1019, 1124, 1126)
+            AND `comments` LIKE 'Boat placeholder teleport - % QuestGiver Flag';
+        INSERT INTO `quest_end_scripts` (
+            `id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `datalong4`,
+            `target_param1`, `target_param2`, `target_type`, `data_flags`,
+            `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`
+        ) VALUES
+        (796, 0, 0, 4, 147, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Remove QuestGiver Flag'),
+        (796, 3, 0, 4, 147, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Restore QuestGiver Flag'),
+        (797, 0, 0, 4, 147, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Remove QuestGiver Flag'),
+        (797, 3, 0, 4, 147, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Restore QuestGiver Flag'),
+        (798, 0, 0, 4, 147, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Remove QuestGiver Flag'),
+        (798, 3, 0, 4, 147, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Restore QuestGiver Flag'),
+        (799, 0, 0, 4, 147, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Remove QuestGiver Flag'),
+        (799, 3, 0, 4, 147, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Restore QuestGiver Flag'),
+        (801, 0, 0, 4, 147, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Remove QuestGiver Flag'),
+        (801, 3, 0, 4, 147, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Restore QuestGiver Flag'),
+        (802, 0, 0, 4, 147, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Remove QuestGiver Flag'),
+        (802, 3, 0, 4, 147, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Restore QuestGiver Flag'),
+        (803, 0, 0, 4, 147, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Remove QuestGiver Flag'),
+        (803, 3, 0, 4, 147, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Restore QuestGiver Flag'),
+        (1018, 0, 0, 4, 147, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Remove QuestGiver Flag'),
+        (1018, 3, 0, 4, 147, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Restore QuestGiver Flag'),
+        (1019, 0, 0, 4, 147, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Remove QuestGiver Flag'),
+        (1019, 3, 0, 4, 147, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Restore QuestGiver Flag'),
+        (1124, 0, 0, 4, 147, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Remove QuestGiver Flag'),
+        (1124, 3, 0, 4, 147, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Restore QuestGiver Flag'),
+        (1126, 0, 0, 4, 147, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Remove QuestGiver Flag'),
+        (1126, 3, 0, 4, 147, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Boat placeholder teleport - Restore QuestGiver Flag');
+
+        -- Sniffed boat placeholder greetings.
+        DELETE FROM `quest_greeting` WHERE `entry` IN (3895, 3896) AND `type` = 0;
+        INSERT INTO `quest_greeting` (`entry`, `type`, `content_default`, `emote_id`, `emote_delay`) VALUES
+        (3895, 0, 'You look like a smooth criminal. Looking for a boat ride?', 10, 0),
+        (3896, 0, 'Ahoy! Welcome to Captain Placeholder''s Placeholder Boat Ride!', 0, 0);
+
+        -- Sniffed teleport destination positions.
+        UPDATE `spell_target_position`
+        SET `target_position_x` = -3761.13, `target_position_y` = -705.091, `target_position_z` = 8.34659
+        WHERE `id` = 6348 AND `target_map` = 0;
+
+        UPDATE `spell_target_position`
+        SET `target_position_x` = 6476.85, `target_position_y` = 614.586, `target_position_z` = 7
+        WHERE `id` = 6349 AND `target_map` = 1;
+
+        UPDATE `spell_target_position`
+        SET `target_position_x` = -3974.05, `target_position_y` = -4744.09, `target_position_z` = 20
+        WHERE `id` = 6719 AND `target_map` = 1;
+
+        insert into applied_updates values ('190420261');
+    end if;
+
 end $
 delimiter ;

--- a/game/world/managers/objects/units/player/quest/QuestManager.py
+++ b/game/world/managers/objects/units/player/quest/QuestManager.py
@@ -58,6 +58,10 @@ class QuestManager:
     def is_quest_log_full(self):
         return len(self.active_quests) >= MAX_QUEST_LOG
 
+    @staticmethod
+    def can_interact_with_quest_giver(quest_giver):
+        return bool(quest_giver) and (not quest_giver.is_unit() or quest_giver.is_quest_giver())
+
     def should_interact_with_go(self, game_object):
         if game_object.gobject_template.type == GameObjectTypes.TYPE_CHEST:
             if game_object.gobject_template.data1 != 0:
@@ -128,6 +132,9 @@ class QuestManager:
     def get_dialog_status(self, quest_giver):
         dialog_status = QuestGiverStatus.QUEST_GIVER_NONE
         new_dialog_status = QuestGiverStatus.QUEST_GIVER_NONE
+
+        if not QuestManager.can_interact_with_quest_giver(quest_giver):
+            return dialog_status
 
         if self.player_mgr.is_hostile_to(quest_giver):
             return dialog_status
@@ -299,6 +306,9 @@ class QuestManager:
         return QuestState.QUEST_GREETING
 
     def get_active_quest_num_from_quest_giver(self, quest_giver):
+        if not QuestManager.can_interact_with_quest_giver(quest_giver):
+            return 0
+
         quest_num: int = 0
 
         relations_list = QuestManager.get_quest_giver_relations(quest_giver)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverAcceptQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverAcceptQuestHandler.py
@@ -45,6 +45,8 @@ class QuestGiverAcceptQuestHandler:
         elif not is_item and player_mgr.is_hostile_to(quest_giver):
             Logger.warning(f'{reader.opcode_str()}, quest giver with guid: {guid} is hostile.')
             return 0
+        elif not is_item and not player_mgr.quest_manager.can_interact_with_quest_giver(quest_giver):
+            return 0
         elif player_mgr.quest_manager.is_quest_log_full():
             player_mgr.enqueue_packet(PacketWriter.get_packet(OpCode.SMSG_QUESTLOG_FULL))
         elif is_item or quest_giver.is_within_interactable_distance(player_mgr):

--- a/game/world/opcode_handling/handlers/quest/QuestGiverChooseRewardHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverChooseRewardHandler.py
@@ -43,6 +43,8 @@ class QuestGiverChooseRewardHandler:
         if not is_item and player_mgr.is_hostile_to(quest_giver):
             Logger.warning(f'{reader.opcode_str()}, quest giver with guid: {guid} is hostile.')
             return 0
+        if not is_item and not player_mgr.quest_manager.can_interact_with_quest_giver(quest_giver):
+            return 0
 
         if is_item or quest_giver.is_within_interactable_distance(player_mgr):
             player_mgr.quest_manager.handle_choose_reward(quest_giver, quest_id, item_choice)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverCompleteQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverCompleteQuestHandler.py
@@ -43,6 +43,8 @@ class QuestGiverCompleteQuestHandler:
         if not is_item and player_mgr.is_hostile_to(quest_giver):
             Logger.warning(f'{reader.opcode_str()}, quest giver with guid: {guid} is hostile.')
             return 0
+        if not is_item and not player_mgr.quest_manager.can_interact_with_quest_giver(quest_giver):
+            return 0
 
         if is_item or quest_giver.is_within_interactable_distance(player_mgr):
             player_mgr.quest_manager.handle_complete_quest(quest_id, guid)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverHelloHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverHelloHandler.py
@@ -43,6 +43,8 @@ class QuestGiverHelloHandler:
         if not is_item and player_mgr.is_hostile_to(quest_giver):
             Logger.warning(f'{reader.opcode_str()}, quest giver with guid: {guid} is hostile.')
             return 0
+        if not is_item and not player_mgr.quest_manager.can_interact_with_quest_giver(quest_giver):
+            return 0
 
         # TODO: Remove feign death from player
         # TODO: If the gossip menu is already open, do nothing

--- a/game/world/opcode_handling/handlers/quest/QuestGiverQueryQuestHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverQueryQuestHandler.py
@@ -39,6 +39,8 @@ class QuestGiverQueryQuestHandler:
             quest_giver = quest_giver if quest_giver else player_mgr.get_map().get_surrounding_unit_by_guid(player_mgr, guid)
             if not quest_giver:
                 return 0
+            elif not player_mgr.quest_manager.can_interact_with_quest_giver(quest_giver):
+                return 0
             elif not player_mgr.quest_manager.check_quest_giver_npc_is_related(quest_giver, quest_entry):
                 return 0
         elif high_guid == HighGuid.HIGHGUID_GAMEOBJECT:

--- a/game/world/opcode_handling/handlers/quest/QuestGiverRequestReward.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverRequestReward.py
@@ -43,6 +43,8 @@ class QuestGiverRequestReward:
         if not is_item and player_mgr.is_hostile_to(quest_giver):
             Logger.warning(f'{reader.opcode_str()}, quest giver with guid: {guid} is hostile.')
             return 0
+        if not is_item and not player_mgr.quest_manager.can_interact_with_quest_giver(quest_giver):
+            return 0
 
         if is_item or quest_giver.is_within_interactable_distance(player_mgr):
             player_mgr.quest_manager.handle_request_reward(guid, quest_id)

--- a/game/world/opcode_handling/handlers/quest/QuestGiverStatusHandler.py
+++ b/game/world/opcode_handling/handlers/quest/QuestGiverStatusHandler.py
@@ -2,7 +2,7 @@ from struct import unpack
 from game.world.opcode_handling.HandlerValidator import HandlerValidator
 from utils.GuidUtils import GuidUtils
 from utils.Logger import Logger
-from utils.constants.MiscCodes import HighGuid
+from utils.constants.MiscCodes import HighGuid, QuestGiverStatus
 
 
 class QuestGiverStatusHandler:
@@ -41,6 +41,9 @@ class QuestGiverStatusHandler:
 
         # Only units are able to provide quest status.
         if player_mgr and quest_giver.is_unit():
+            if not player_mgr.quest_manager.can_interact_with_quest_giver(quest_giver):
+                player_mgr.quest_manager.send_quest_giver_status(guid, QuestGiverStatus.QUEST_GIVER_NONE)
+                return 0
             quest_giver_status = player_mgr.quest_manager.get_dialog_status(quest_giver)
             player_mgr.quest_manager.send_quest_giver_status(guid, quest_giver_status)
 


### PR DESCRIPTION
Closes #1661
- Remove quest giver flag from boat placeholders while casting in order to prevent multiple triggers.