### PR TITLE
#1670

### DIFF
--- a/game/world/managers/objects/units/UnitManager.py
+++ b/game/world/managers/objects/units/UnitManager.py
@@ -546,7 +546,7 @@ class UnitManager(ObjectManager):
          for unit in [damage_info.attacker, damage_info.target]]
 
     def calculate_melee_damage(self, victim, attack_type):
-        dual_wield_penalty = 0.19 if self.has_offhand_weapon() and attack_type != AttackTypes.RANGED_ATTACK else 0
+        dual_wield_miss_penalty, dual_wield_miss_floor = self.stat_manager.get_dual_wield_miss_profile(attack_type)
 
         damage_info = DamageInfoHolder(attacker=self, target=victim,
                                        attack_type=attack_type,
@@ -554,7 +554,8 @@ class UnitManager(ObjectManager):
 
         roll_info = AttackRollInfo()
         damage_info.attack_round_hit_info = victim.stat_manager.get_attack_result_against_self(self, attack_type,
-                                                                                  dual_wield_penalty=dual_wield_penalty,
+                                                                                  dual_wield_miss_penalty=dual_wield_miss_penalty,
+                                                                                  dual_wield_miss_floor=dual_wield_miss_floor,
                                                                                   roll_info=roll_info)
         damage_info.advanced_logging = AttackRoundAdvancedLogging(roll_info=roll_info)
         if attack_type == AttackTypes.OFFHAND_ATTACK:

--- a/game/world/managers/objects/units/player/PlayerManager.py
+++ b/game/world/managers/objects/units/player/PlayerManager.py
@@ -1447,6 +1447,7 @@ class PlayerManager(UnitManager):
     def handle_combat_skill_gain(self, damage_info, spell_id=0):
         if damage_info.attacker == self:
             self.skill_manager.handle_weapon_skill_gain_chance(damage_info.attack_type)
+            self.skill_manager.handle_dual_wield_skill_gain_chance(damage_info)
         else:
             self.skill_manager.handle_defense_skill_gain_chance(damage_info)
 

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -871,6 +871,7 @@ class SkillManager:
         miss_chance = SkillManager.DUAL_WIELD_MAX_MISS_CHANCE - (
             (SkillManager.DUAL_WIELD_MAX_MISS_CHANCE - SkillManager.DUAL_WIELD_MIN_MISS_CHANCE) * skill_progress
         )
+        # Convert total miss chance into the extra dual-wield penalty added on top of the base 5% miss chance.
         miss_penalty = max(0.0, miss_chance - 0.05)
         # Keep the archived 19% miss floor once the skill is fully trained.
         return miss_penalty, SkillManager.DUAL_WIELD_MIN_MISS_CHANCE

--- a/game/world/managers/objects/units/player/SkillManager.py
+++ b/game/world/managers/objects/units/player/SkillManager.py
@@ -226,6 +226,8 @@ class Proficiency:
 class SkillManager:
     MAX_PROFESSION_SKILL = 225
     MAX_SKILLS = 64
+    DUAL_WIELD_MAX_MISS_CHANCE = 0.24
+    DUAL_WIELD_MIN_MISS_CHANCE = 0.19
 
     def __init__(self, player_mgr):
         self.player_mgr = player_mgr
@@ -421,6 +423,18 @@ class SkillManager:
             return
 
         self.handle_offense_skill_gain_chance(skill_id)
+
+    def handle_dual_wield_skill_gain_chance(self, damage_info):
+        if damage_info.attack_type not in (AttackTypes.BASE_ATTACK, AttackTypes.OFFHAND_ATTACK):
+            return False
+
+        if not self.can_dual_wield() or not self.player_mgr.has_offhand_weapon():
+            return False
+
+        if damage_info.total_damage <= 0:
+            return False
+
+        return self.handle_offense_skill_gain_chance(SkillTypes.DUALWIELD)
 
     def handle_spell_cast_skill_gain(self, casting_spell):
         if not casting_spell:
@@ -828,25 +842,38 @@ class SkillManager:
     def get_riding_speed_bonus_percent(self) -> float:
         best_bonus = 0.0
         for skill_id in RIDING_SKILLS:
-            skill = self.skills.get(skill_id)
-            if not skill:
-                continue
-
-            max_rank = skill.max if skill.max else self.get_max_rank(skill_id)
-            if max_rank <= 0:
-                continue
-
-            value = self.get_total_skill_value(skill_id)
-            if value <= 0:
-                continue
-            if value > max_rank:
-                value = max_rank
-
-            bonus = (value / max_rank) * 100.0
+            bonus = self.get_skill_progress(skill_id) * 100.0
             if bonus > best_bonus:
                 best_bonus = bonus
 
         return best_bonus
+
+    def get_skill_progress(self, skill_id, no_bonus=False) -> float:
+        skill = self.skills.get(skill_id)
+        if not skill:
+            return 0.0
+
+        max_rank = skill.max if skill.max else self.get_max_rank(skill_id)
+        if max_rank <= 0:
+            return 0.0
+
+        value = self.get_total_skill_value(skill_id, no_bonus=no_bonus)
+        if value <= 0:
+            return 0.0
+
+        return min(value, max_rank) / max_rank
+
+    def get_dual_wield_miss_profile(self):
+        if not self.can_dual_wield():
+            return 0.0, 0.0
+
+        skill_progress = self.get_skill_progress(SkillTypes.DUALWIELD, no_bonus=True)
+        miss_chance = SkillManager.DUAL_WIELD_MAX_MISS_CHANCE - (
+            (SkillManager.DUAL_WIELD_MAX_MISS_CHANCE - SkillManager.DUAL_WIELD_MIN_MISS_CHANCE) * skill_progress
+        )
+        miss_penalty = max(0.0, miss_chance - 0.05)
+        # Keep the archived 19% miss floor once the skill is fully trained.
+        return miss_penalty, SkillManager.DUAL_WIELD_MIN_MISS_CHANCE
 
     def get_skill_id_for_weapon(self, item_template: Optional[ItemTemplate]):
         if not item_template:

--- a/game/world/managers/objects/units/player/StatManager.py
+++ b/game/world/managers/objects/units/player/StatManager.py
@@ -830,7 +830,8 @@ class StatManager:
         return min(0.4, 0.2 - 0.002 * self._get_combat_rating_difference(attacker.level))
 
     def get_attack_result_against_self(self, attacker, attack_type,
-                                       dual_wield_penalty=0.0, invalid_result_mask: HitInfo = 0,
+                                       dual_wield_miss_penalty=0.0, dual_wield_miss_floor=0.0,
+                                       invalid_result_mask: HitInfo = 0,
                                        combat_rating=-1, roll_info: AttackRollInfo = None) -> HitInfo:
         # TODO Based on vanilla calculations.
         # Evading/Sanctuary.
@@ -846,7 +847,7 @@ class StatManager:
 
         rating_difference = self._get_combat_rating_difference(attacker.level, combat_rating)
 
-        base_miss = 0.05 + dual_wield_penalty
+        base_miss = 0.05 + dual_wield_miss_penalty
         miss_chance = base_miss
         if self.unit_mgr.is_player():
             # 0.04% Bonus against players when the defender has a higher combat rating,
@@ -865,7 +866,7 @@ class StatManager:
         # Prior to version 1.8, dual wield's miss chance had a hard cap of 19%,
         # meaning that all dual-wield auto-attacks had a minimum 19% miss chance
         # regardless of how much +hit% gear was equipped.
-        miss_chance = max(dual_wield_penalty, miss_chance)
+        miss_chance = max(dual_wield_miss_floor, miss_chance)
 
         hit_info = HitInfo.SUCCESS
 
@@ -968,8 +969,16 @@ class StatManager:
                 cumulative += crush_chance
                 if roll < cumulative:
                     return hit_info | HitInfo.CRUSHING
-        
         return hit_info
+
+    def get_dual_wield_miss_profile(self, attack_type):
+        if attack_type == AttackTypes.RANGED_ATTACK or not self.unit_mgr.is_player():
+            return 0.0, 0.0
+
+        if not self.unit_mgr.has_offhand_weapon():
+            return 0.0, 0.0
+
+        return self.unit_mgr.skill_manager.get_dual_wield_miss_profile()
 
     @staticmethod
     def _get_attack_weapon(attacker, attack_type):


### PR DESCRIPTION
Closes #1670

- Wire Dual Wield into the normal melee skill-gain path and scale the extra dual-wield miss penalty by current/max skill instead of leaving it static. This uses a first-pass 24% to 19% range based on the evidence, may need adjustment if stronger archive evidence surfaces later.

Archive evidence shows Dual Wield was a trainable combat skill, not just a passive unlock:
- OCR screenshots in the archive show Dual Wield skill-up messages.
- WoWVault guidebook describes poor off-hand hit rate at low Dual Wield skill, suggesting the miss penalty improved with skill.
- 2004 beta forum posts point to a built-in dual wield miss rate in the 19-24% range and to miss spikes when the related skill is not maxed after leveling.